### PR TITLE
Proper management of witten pages and batch id preservation

### DIFF
--- a/src/Paprika/Crypto/Keccak.cs
+++ b/src/Paprika/Crypto/Keccak.cs
@@ -1,42 +1,71 @@
 ﻿using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using static System.Runtime.CompilerServices.Unsafe;
 
 namespace Paprika.Crypto;
 
-/// <summary>
-/// Represents the value of a keccak.
-/// </summary>
-[StructLayout(LayoutKind.Explicit, Size = Size)]
+[DebuggerStepThrough]
+[DebuggerDisplay("{ToString()}")]
 public readonly struct Keccak : IEquatable<Keccak>
 {
+    private readonly Vector256<byte> Bytes;
+
     public const int Size = 32;
 
-    [FieldOffset(0)]
-    private readonly ulong u1;
-    [FieldOffset(8)]
-    private readonly ulong u2;
-    [FieldOffset(16)]
-    private readonly ulong u3;
-    [FieldOffset(24)]
-    private readonly ulong u4;
+    public Span<byte> BytesAsSpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref AsRef(in Bytes), 1));
 
-    public Span<byte> BytesAsSpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in u1), 4));
-
-    public bool Equals(Keccak other) => u1 == other.u1 && u2 == other.u2 && u3 == other.u3 && u4 == other.u4;
-
-    public override bool Equals(object? obj) => obj is Keccak other && Equals(other);
-
-    public override int GetHashCode() => (int)(u1 ^ u2 ^ u3 ^ u4);
-
-    public static bool operator ==(Keccak left, Keccak right) => left.Equals(right);
-
-    public static bool operator !=(Keccak left, Keccak right) => !left.Equals(right);
+    public ReadOnlySpan<byte> Span =>
+        MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref AsRef(in Bytes), 1));
 
     /// <returns>
     ///     <string>0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470</string>
     /// </returns>
-    public static readonly Keccak OfAnEmptyString = Compute(Span<byte>.Empty);
+    public static readonly Keccak OfAnEmptyString = InternalCompute(new byte[] { });
+
+    /// <returns>
+    ///     <string>0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347</string>
+    /// </returns>
+    public static readonly Keccak OfAnEmptySequenceRlp = InternalCompute(new byte[] { 192 });
+
+    /// <summary>
+    ///     0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+    /// </summary>
+    public static readonly Keccak EmptyTreeHash = InternalCompute(new byte[] { 128 });
+
+    /// <returns>
+    ///     <string>0x0000000000000000000000000000000000000000000000000000000000000000</string>
+    /// </returns>
+    public static Keccak Zero { get; } = default;
+
+    public Keccak(byte[]? bytes)
+    {
+        if (bytes is null || bytes.Length == 0)
+        {
+            Bytes = OfAnEmptyString.Bytes;
+            return;
+        }
+
+        Debug.Assert(bytes.Length == Size);
+        Bytes = As<byte, Vector256<byte>>(ref MemoryMarshal.GetArrayDataReference(bytes));
+    }
+
+    public Keccak(Span<byte> bytes)
+        : this((ReadOnlySpan<byte>)bytes)
+    {
+    }
+
+    public Keccak(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length == 0)
+        {
+            Bytes = OfAnEmptyString.Bytes;
+            return;
+        }
+
+        Debug.Assert(bytes.Length == Size);
+        Bytes = As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(bytes));
+    }
 
     [DebuggerStepThrough]
     public static Keccak Compute(ReadOnlySpan<byte> input)
@@ -46,8 +75,40 @@ public readonly struct Keccak : IEquatable<Keccak>
             return OfAnEmptyString;
         }
 
-        Keccak result = new();
+        Keccak result = default;
         KeccakHash.ComputeHashBytesToSpan(input, result.BytesAsSpan);
         return result;
     }
+
+    private static Keccak InternalCompute(byte[] input)
+    {
+        Keccak result = default;
+        KeccakHash.ComputeHashBytesToSpan(input, result.BytesAsSpan);
+        return result;
+    }
+
+    public override bool Equals(object? obj) => obj is Keccak keccak && Equals(keccak);
+
+    public bool Equals(Keccak other) => Bytes.Equals(other.Bytes);
+
+    public override int GetHashCode()
+    {
+        var v0 = As<Vector256<byte>, long>(ref AsRef(in Bytes));
+        var v1 = Add(ref As<Vector256<byte>, long>(ref AsRef(in Bytes)), 1);
+        var v2 = Add(ref As<Vector256<byte>, long>(ref AsRef(in Bytes)), 2);
+        var v3 = Add(ref As<Vector256<byte>, long>(ref AsRef(in Bytes)), 3);
+        v0 ^= v1;
+        v2 ^= v3;
+        v0 ^= v2;
+
+        return (int)v0 ^ (int)(v0 >> 32);
+    }
+
+    public override string ToString() => ToString(true);
+
+    public string ToString(bool withZeroX) => BytesAsSpan.ToHexString(withZeroX);
+
+    public static bool operator ==(Keccak left, Keccak right) => left.Equals(right);
+
+    public static bool operator !=(Keccak left, Keccak right) => !(left == right);
 }

--- a/src/Paprika/Pages/IBatchContext.cs
+++ b/src/Paprika/Pages/IBatchContext.cs
@@ -17,4 +17,8 @@ public interface IBatchContext
     /// </summary>
     /// <returns></returns>
     Page GetNewDirtyPage(out DbAddress addr);
+
+    long BatchId { get; }
+
+    Page GetWritableCopy(Page page);
 }

--- a/src/Paprika/Pages/Page.cs
+++ b/src/Paprika/Pages/Page.cs
@@ -27,7 +27,7 @@ public struct PageHeader
     /// The id of the last transaction that wrote to this page.
     /// </summary>
     [FieldOffset(0)]
-    public long TransactionId;
+    public long BatchId;
 }
 
 


### PR DESCRIPTION
Pages properly capture the batch id that they were written with. Also, they properly propagate up the writable page address if COW happens due to write.

Resolves #14