### PR TITLE
Reorganization handling

### DIFF
--- a/src/Paprika.Tests/DataPageTests.cs
+++ b/src/Paprika.Tests/DataPageTests.cs
@@ -1,9 +1,7 @@
 ﻿using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using FluentAssertions;
-using Nethermind.Int256;
 using NUnit.Framework;
-using Paprika.Crypto;
 using Paprika.Pages;
 using static Paprika.Tests.Values;
 

--- a/src/Paprika.Tests/DataPageTests.cs
+++ b/src/Paprika.Tests/DataPageTests.cs
@@ -5,28 +5,12 @@ using Nethermind.Int256;
 using NUnit.Framework;
 using Paprika.Crypto;
 using Paprika.Pages;
+using static Paprika.Tests.Values;
 
 namespace Paprika.Tests;
 
 public unsafe class DataPageTests
 {
-    private static readonly Keccak Key0 = new(new byte[]
-        { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, });
-
-    private static readonly Keccak Key1a = new(new byte[]
-        { 1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, });
-
-    private static readonly Keccak Key1b = new(new byte[]
-        { 1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 8 });
-
-    private static readonly UInt256 Balance0 = 13;
-    private static readonly UInt256 Balance1 = 17;
-    private static readonly UInt256 Balance3 = 19;
-
-    private static readonly UInt256 Nonce0 = 23;
-    private static readonly UInt256 Nonce1 = 29;
-    private static readonly UInt256 Nonce2 = 31;
-
     private const byte RootLevel = 0;
 
     const uint BatchId = 1;
@@ -164,7 +148,6 @@ public unsafe class DataPageTests
     class BatchContext : IBatchContext
     {
         private readonly Dictionary<DbAddress, Page> _address2Page = new();
-        private readonly Dictionary<UIntPtr, DbAddress> _page2Address = new();
 
         // data pages should start at non-null addresses
         // 0-N is take by metadata pages
@@ -183,7 +166,6 @@ public unsafe class DataPageTests
             addr = DbAddress.Page(_pageCount++);
 
             _address2Page[addr] = page;
-            _page2Address[page.Raw] = addr;
 
             return page;
         }

--- a/src/Paprika.Tests/DbTests.cs
+++ b/src/Paprika.Tests/DbTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Paprika.Crypto;
 using Paprika.Db;
+using static Paprika.Tests.Values;
 
 namespace Paprika.Tests;
 
@@ -51,7 +52,12 @@ public class DbTests
     {
         using var db = new NativeMemoryPagedDb(1024 * 1024UL, 2);
 
-        Span<byte> span = stackalloc byte[Keccak.Size];
+        using (var batch = db.BeginNextBlock())
+        {
+            batch.Set(Key0, new Account(Balance0, Nonce0));
+            batch.Commit(CommitOptions.FlushDataOnly);    
+        }
+        
     }
 
     // [Test]

--- a/src/Paprika.Tests/DbTests.cs
+++ b/src/Paprika.Tests/DbTests.cs
@@ -1,13 +1,17 @@
-﻿using Nethermind.Int256;
+﻿using FluentAssertions;
+using Nethermind.Int256;
 using NUnit.Framework;
 using Paprika.Crypto;
 using Paprika.Db;
+using Paprika.Pages;
 using static Paprika.Tests.Values;
 
 namespace Paprika.Tests;
 
 public class DbTests
 {
+    private const int SmallDb = 256 * Page.PageSize;
+
     [Test]
     public void Simple()
     {
@@ -48,16 +52,71 @@ public class DbTests
     }
 
     [Test]
-    public void Reorganization()
+    public void Reorganization_jump_to_given_block_hash()
     {
-        using var db = new NativeMemoryPagedDb(1024 * 1024UL, 2);
+        using var db = new NativeMemoryPagedDb(SmallDb, 2);
 
-        using (var batch = db.BeginNextBlock())
+        var account0 = new Account(Balance0, Nonce0);
+        var account1 = new Account(Balance1, Nonce1);
+        var account2 = new Account(Balance2, Nonce2);
+
+        Keccak block0Commit;
+
+        using (var block0 = db.BeginNextBlock())
         {
-            batch.Set(Key0, new Account(Balance0, Nonce0));
-            batch.Commit(CommitOptions.FlushDataOnly);    
+            block0.Set(Key0, account0);
+
+            block0Commit = block0.Commit(CommitOptions.FlushDataOnly);
         }
-        
+
+        using (var block1A = db.BeginNextBlock())
+        {
+            block1A.Set(Key0, account1);
+            block1A.Set(Key1a, account2);
+
+            block1A.Commit(CommitOptions.FlushDataOnly);
+
+            // assert
+            block1A.GetAccount(Key0).Should().Be(account1);
+            block1A.GetAccount(Key1a).Should().Be(account2);
+        }
+
+        using (var block1B = db.ReorganizeBackToAndStartNew(block0Commit))
+        {
+            block1B.GetAccount(Key0).Should().Be(account0);
+            block1B.GetAccount(Key1a).Should().Be(Account.Empty);
+
+            block1B.Set(Key0, account2);
+
+            block1B.Commit(CommitOptions.FlushDataOnly);
+
+            // assert
+            block1B.GetAccount(Key0).Should().Be(account2);
+            block1B.GetAccount(Key1a).Should().Be(Account.Empty);
+        }
+    }
+
+    [Test]
+    public void Reorganization_block_not_found()
+    {
+        using var db = new NativeMemoryPagedDb(SmallDb, 2);
+
+        var account0 = new Account(Balance0, Nonce0);
+
+        using (var block0 = db.BeginNextBlock())
+        {
+            block0.Set(Key0, account0);
+            block0.Commit(CommitOptions.FlushDataOnly);
+        }
+
+        using (var block1A = db.BeginNextBlock())
+        {
+            block1A.Commit(CommitOptions.FlushDataOnly);
+        }
+
+        var invalidBlock = Keccak.EmptyTreeHash;
+
+        Assert.Throws<ArgumentException>(() => db.ReorganizeBackToAndStartNew(invalidBlock).Should());
     }
 
     // [Test]

--- a/src/Paprika.Tests/DbTests.cs
+++ b/src/Paprika.Tests/DbTests.cs
@@ -46,6 +46,14 @@ public class DbTests
         Console.WriteLine($"Used memory {db.TotalUsedPages:P}");
     }
 
+    [Test]
+    public void Reorganization()
+    {
+        using var db = new NativeMemoryPagedDb(1024 * 1024UL, 2);
+
+        Span<byte> span = stackalloc byte[Keccak.Size];
+    }
+
     // [Test]
     // public void Random_big()
     // {

--- a/src/Paprika.Tests/Values.cs
+++ b/src/Paprika.Tests/Values.cs
@@ -1,0 +1,24 @@
+﻿using Nethermind.Int256;
+using Paprika.Crypto;
+
+namespace Paprika.Tests;
+
+public static class Values
+{
+    public static readonly Keccak Key0 = new(new byte[]
+        { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, });
+
+    public static readonly Keccak Key1a = new(new byte[]
+        { 1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, });
+
+    public static readonly Keccak Key1b = new(new byte[]
+        { 1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 8 });
+
+    public static readonly UInt256 Balance0 = 13;
+    public static readonly UInt256 Balance1 = 17;
+    public static readonly UInt256 Balance3 = 19;
+
+    public static readonly UInt256 Nonce0 = 23;
+    public static readonly UInt256 Nonce1 = 29;
+    public static readonly UInt256 Nonce2 = 31;
+}

--- a/src/Paprika.Tests/Values.cs
+++ b/src/Paprika.Tests/Values.cs
@@ -16,7 +16,7 @@ public static class Values
 
     public static readonly UInt256 Balance0 = 13;
     public static readonly UInt256 Balance1 = 17;
-    public static readonly UInt256 Balance3 = 19;
+    public static readonly UInt256 Balance2 = 19;
 
     public static readonly UInt256 Nonce0 = 23;
     public static readonly UInt256 Nonce1 = 29;

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -8,13 +8,19 @@ namespace Paprika;
 /// </summary>
 public readonly struct Account : IEquatable<Account>
 {
-    private readonly UInt128 _balance;
-    private readonly uint _nonce;
+    private readonly UInt256 _balance;
+    private readonly UInt256 _nonce;
     public UInt256 Nonce => _nonce;
 
-    public UInt256 Balance => Convert(_balance);
+    public UInt256 Balance => _balance;
 
     public Account(in UInt128 balance, uint nonce)
+    {
+        _balance = Convert(balance);
+        _nonce = nonce;
+    }
+    
+    public Account(in UInt256 balance, UInt256 nonce)
     {
         _balance = balance;
         _nonce = nonce;

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -8,6 +8,8 @@ namespace Paprika;
 /// </summary>
 public readonly struct Account : IEquatable<Account>
 {
+    public static readonly Account Empty = default;
+
     private readonly UInt256 _balance;
     private readonly UInt256 _nonce;
     public UInt256 Nonce => _nonce;
@@ -19,7 +21,7 @@ public readonly struct Account : IEquatable<Account>
         _balance = Convert(balance);
         _nonce = nonce;
     }
-    
+
     public Account(in UInt256 balance, UInt256 nonce)
     {
         _balance = balance;

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -8,6 +8,12 @@ using Paprika.Pages;
 
 namespace Paprika.Db;
 
+/// <summary>
+/// The base class for page db implementations.
+/// </summary>
+/// <remarks>
+/// Assumes a continuous memory allocation as it provides addressing based on the pointers.
+/// </remarks>
 public abstract unsafe class PagedDb : IDb, IDisposable
 {
     /// <summary>


### PR DESCRIPTION
This PR implements the logic for reorganization handling. As new methods can be easily added later it paves the way with the API of

```csharp 
using var batch = db.ReorganizeBackToAndStartNew(Keccak blockHash)
```

which allows to jump to an arbitrary block in the history that is within the defined history depth.

Resolves #8 