### PR TITLE
ReadOnly batches

### DIFF
--- a/src/Paprika.Tests/BasePageTests.cs
+++ b/src/Paprika.Tests/BasePageTests.cs
@@ -1,46 +1,14 @@
 ﻿using System.Runtime.InteropServices;
-using NUnit.Framework;
 using Paprika.Pages;
 
 namespace Paprika.Tests;
 
 public abstract class BasePageTests
 {
-    private static readonly Stack<Page> Pages = new();
-    private static readonly List<Page> All = new();
-
-    [Test]
-    public void SetUp()
-    {
-        Pages.Clear();
-
-        foreach (var page in All)
-        {
-            Pages.Push(page);
-        }
-
-        All.Clear();
-    }
-
     protected static unsafe Page AllocPage()
     {
-        if (Pages.TryPop(out var page))
-            return page;
-
-        const int slab = 16;
-
-        var memory = (byte*)NativeMemory.AlignedAlloc((UIntPtr)Page.PageSize * (nuint)slab, (UIntPtr)sizeof(long));
-
-        for (var i = 1; i < slab; i++)
-        {
-            var item = new Page(memory + Page.PageSize * i);
-            Pages.Push(item);
-            All.Add(item);
-        }
-
-        page = new Page(memory);
-        All.Add(page); // memo for reuse
-        return page;
+        var memory = (byte*)NativeMemory.AlignedAlloc((UIntPtr)Page.PageSize, (UIntPtr)sizeof(long));
+        return new Page(memory);
     }
 
     internal class TestBatchContext : BatchContextBase

--- a/src/Paprika/Db/NativeMemoryPagedDb.cs
+++ b/src/Paprika/Db/NativeMemoryPagedDb.cs
@@ -10,6 +10,7 @@ public unsafe class NativeMemoryPagedDb : PagedDb
     public NativeMemoryPagedDb(ulong size, byte historyDepth) : base(size, historyDepth)
     {
         _ptr = NativeMemory.AlignedAlloc((UIntPtr)size, (UIntPtr)Page.PageSize);
+        NativeMemory.Clear(_ptr, (UIntPtr)size);
 
         RootInit();
     }

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -27,10 +27,17 @@ public abstract unsafe class PagedDb : IDb, IDisposable
     /// </remarks>
     private const int MinHistoryDepth = 2;
 
+    private const byte RootLevel = 0;
+
     private readonly byte _historyDepth;
     private readonly int _maxPage;
     private long _lastRoot;
     private readonly RootPage[] _roots;
+
+    // batches
+    private readonly object _batchLock = new();
+    private readonly List<ReadOnlyBatch> _batchesReadOnly = new();
+    private Batch? _batchCurrent;
 
     // a simple pool of root pages
     private readonly ConcurrentStack<Page> _pool = new();
@@ -49,6 +56,7 @@ public abstract unsafe class PagedDb : IDb, IDisposable
         _historyDepth = historyDepth;
         _maxPage = (int)(size / Page.PageSize);
         _roots = new RootPage[MinHistoryDepth];
+        _batchCurrent = null;
     }
 
     protected void RootInit()
@@ -150,21 +158,45 @@ public abstract unsafe class PagedDb : IDb, IDisposable
         return BuildFromRoot(reorganizeTo.Value);
     }
 
+    public IReadOnlyBatch BeginReadOnlyBatch()
+    {
+        lock (_batchLock)
+        {
+            var data = new DataPage(GetAt(Root.Data.DataPage));
+            var batchId = Root.Header.BatchId;
+
+            return new ReadOnlyBatch(this, batchId, data);
+        }
+    }
+
     private IBatch BuildFromRoot(RootPage rootPage)
     {
-        // prepare root
-        var root = new RootPage(RentPage());
-        rootPage.CopyTo(root);
+        lock (_batchLock)
+        {
+            if (_batchCurrent != null)
+            {
+                throw new Exception("There is another batch active at the moment. Commit the other first");
+            }
 
-        // always inc the batchId
-        root.Header.BatchId++;
+            // prepare root
+            var root = new RootPage(RentPage());
+            rootPage.CopyTo(root);
 
-        // move to the next block
-        root.Data.BlockNumber++;
+            // always inc the batchId
+            root.Header.BatchId++;
 
-        // TODO: when read transactions enabled, provide second parameter as
-        // Math.Min(all reader transactions batches, root.Header.BatchId - db._historyDepth)
-        return new Batch(this, root, root.Header.BatchId - _historyDepth);
+            // move to the next block
+            root.Data.BlockNumber++;
+
+            // select min batch across the one respecting history and the min of all the read-only batches
+            var minBatch = root.Header.BatchId - _historyDepth;
+            foreach (var batch in _batchesReadOnly)
+            {
+                minBatch = Math.Min(batch.BatchId, minBatch);
+            }
+
+            return _batchCurrent = new Batch(this, root, minBatch);
+        }
     }
 
     private void SetNewRoot(RootPage root)
@@ -173,9 +205,49 @@ public abstract unsafe class PagedDb : IDb, IDisposable
         root.CopyTo(_roots[_lastRoot % _historyDepth]);
     }
 
+    class ReadOnlyBatch : IReadOnlyBatch, IReadOnlyBatchContext
+    {
+        private readonly PagedDb _db;
+        private bool _disposed;
+
+        private readonly DataPage _data;
+
+        public ReadOnlyBatch(PagedDb db, uint batchId, DataPage data)
+        {
+            _db = db;
+            _data = data;
+            BatchId = batchId;
+
+            lock (_db._batchLock)
+            {
+                _db._batchesReadOnly.Add(this);
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_db._batchLock)
+            {
+                _db._batchesReadOnly.Remove(this);
+                _disposed = true;
+            }
+        }
+
+        public Account GetAccount(in Keccak key)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("The readonly batch has already been disposed");
+
+            _data.GetAccount(key, this, out var account, RootLevel);
+            return account;
+        }
+
+        public uint BatchId { get; }
+        public Page GetAt(DbAddress address) => _db.GetAt(address);
+    }
+
     class Batch : BatchContextBase, IBatch
     {
-        private const byte RootLevel = 0;
         private readonly PagedDb _db;
         private readonly RootPage _root;
         private readonly uint _reusePagesOlderThanBatchId;
@@ -235,20 +307,27 @@ public abstract unsafe class PagedDb : IDb, IDisposable
         {
             CalculateStateRootHash();
 
-            // flush data first
-            _db.Flush();
-
             // memoize the abandoned so that it's preserved for future uses 
             MemoizeAbandoned();
 
-            _db.SetNewRoot(_root);
+            // flush data first
+            _db.Flush();
 
-            if (options == CommitOptions.FlushDataAndRoot)
+            lock (_db._batchLock)
             {
-                _db.Flush();
-            }
+                Debug.Assert(ReferenceEquals(this, _db._batchCurrent));
 
-            return _root.Data.StateRootHash;
+                _db.SetNewRoot(_root);
+
+                if (options == CommitOptions.FlushDataAndRoot)
+                {
+                    _db.Flush();
+                }
+
+                _db._batchCurrent = null;
+
+                return _root.Data.StateRootHash;
+            }
         }
 
         private void CalculateStateRootHash()

--- a/src/Paprika/IBatch.cs
+++ b/src/Paprika/IBatch.cs
@@ -2,15 +2,8 @@
 
 namespace Paprika;
 
-public interface IBatch : IDisposable
+public interface IBatch : IReadOnlyBatch
 {
-    /// <summary>
-    /// Gets the account information
-    /// </summary>
-    /// <param name="key"></param>
-    /// <returns></returns>
-    Account GetAccount(in Keccak key);
-
     /// <summary>
     /// Sets the given account.
     /// </summary>
@@ -24,4 +17,14 @@ public interface IBatch : IDisposable
     /// <param name="options">How to commit.</param>
     /// <returns>The state root hash.</returns>
     Keccak Commit(CommitOptions options);
+}
+
+public interface IReadOnlyBatch : IDisposable
+{
+    /// <summary>
+    /// Gets the account information
+    /// </summary>
+    /// <param name="key">The key to looked up.</param>
+    /// <returns>The account or default on non-existence.</returns>
+    Account GetAccount(in Keccak key);
 }

--- a/src/Paprika/IDb.cs
+++ b/src/Paprika/IDb.cs
@@ -1,4 +1,6 @@
-﻿namespace Paprika;
+﻿using Paprika.Crypto;
+
+namespace Paprika;
 
 public interface IDb
 {
@@ -7,4 +9,11 @@ public interface IDb
     /// </summary>
     /// <returns>The transaction that handles block operations.</returns>
     IBatch BeginNextBlock();
+
+    /// <summary>
+    /// Reorganizes chain back to the given block hash and starts building on top of it.
+    /// </summary>
+    /// <param name="stateRootHash">The block hash to reorganize to.</param>
+    /// <returns>The new batch.</returns>
+    IBatch ReorganizeBackToAndStartNew(Keccak stateRootHash);
 }

--- a/src/Paprika/Pages/DataPage.cs
+++ b/src/Paprika/Pages/DataPage.cs
@@ -205,7 +205,7 @@ public readonly unsafe struct DataPage : IPage
         // type of the page, and others
     }
 
-    public void GetAccount(in Keccak key, IBatchContext batch, out Account result, int level)
+    public void GetAccount(in Keccak key, IReadOnlyBatchContext batch, out Account result, int level)
     {
         var frames = Data.Frames;
         var nibble = NibblePath.FromKey(key.BytesAsSpan, level).FirstNibble;

--- a/src/Paprika/Pages/IBatchContext.cs
+++ b/src/Paprika/Pages/IBatchContext.cs
@@ -2,18 +2,8 @@
 
 namespace Paprika.Pages;
 
-public interface IBatchContext
+public interface IBatchContext : IReadOnlyBatchContext
 {
-    /// <summary>
-    /// Gets the current <see cref="IBatch"/> id.
-    /// </summary>
-    uint BatchId { get; }
-
-    /// <summary>
-    /// Gets the page at given address.
-    /// </summary>
-    Page GetAt(DbAddress address);
-
     /// <summary>
     /// Get the address of the given page.
     /// </summary>
@@ -31,6 +21,19 @@ public interface IBatchContext
     /// <param name="page"></param>
     /// <returns></returns>
     Page GetWritableCopy(Page page);
+}
+
+public interface IReadOnlyBatchContext
+{
+    /// <summary>
+    /// Gets the current <see cref="IBatch"/> id.
+    /// </summary>
+    uint BatchId { get; }
+
+    /// <summary>
+    /// Gets the page at given address.
+    /// </summary>
+    Page GetAt(DbAddress address);
 }
 
 /// <summary>


### PR DESCRIPTION
This PR introduces a notion of `IReadOnlyBatch` that should be used for read-only operations. It allows to capture a snapshot of Paprika at a given state (block) and keep it alive arbitrarily long. The pages used by this batch won't be touched by write batches until the readonly batch is alive (not disposed).

This PR also limits the number of writers to `1`. 

Resolves #5