### PR TITLE
Pooling for queues in batches

### DIFF
--- a/src/Paprika/Pages/IBatchContext.cs
+++ b/src/Paprika/Pages/IBatchContext.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-
-namespace Paprika.Pages;
+﻿namespace Paprika.Pages;
 
 public interface IBatchContext : IReadOnlyBatchContext
 {


### PR DESCRIPTION
This PR addresses the last 2 items for pooling in batches. It makes both the queues of `_abandoned` and `_unused` pooled in the database. They are not `resettable` like in https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Core/Resettables/ResettableList.cs as they should not get terribly big and should not be allocate frequently (only for a write batch that happens once at the time).

Resolves #41 