### PR TITLE
File system amendments and Paprika.Runner

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -7,24 +7,26 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = 1000;
-    private const int AccountCount = 1000;
+    private const int BlockCount = 10000;
+    private const int AccountCount = 10000;
     private const long DbFileSize = 4 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
+    private const CommitOptions Commit = CommitOptions.FlushDataOnly;
 
     public static void Main(String[] args)
     {
         var dir = Directory.GetCurrentDirectory();
         var dataPath = Path.Combine(dir, "db");
 
-        if (Directory.Exists(dataPath) == false)
+        if (Directory.Exists(dataPath))
         {
             Directory.Delete(dataPath, true);
         }
 
         Directory.CreateDirectory(dataPath);
 
-        Console.WriteLine("Creating accounts data");
+        Console.WriteLine("Initializing db of size {0}GB", DbFileSize / Gb);
+        Console.WriteLine("Starting benchmark with commit level {0}", Commit);
 
         var db = new MemoryMappedPagedDb(DbFileSize, 64, dataPath);
 
@@ -43,7 +45,7 @@ public static class Program
                 batch.Set(key, new Account(block, block));
             }
 
-            batch.Commit(CommitOptions.FlushDataOnly);
+            batch.Commit(Commit);
         }
 
         Console.WriteLine("Writing state of {0} accounts through {1} blocks took {2} and used {3:F2}GB",

--- a/src/Paprika/Db/MemoryMappedPagedDb.cs
+++ b/src/Paprika/Db/MemoryMappedPagedDb.cs
@@ -1,48 +1,90 @@
 ﻿using System.IO.MemoryMappedFiles;
+using Paprika.Pages;
 
 namespace Paprika.Db;
 
 public unsafe class MemoryMappedPagedDb : PagedDb
 {
-    private readonly string _path;
+    /// <summary>
+    /// The only option is random access. As Paprika jumps over the file, any prefetching is futile.
+    /// Also, the file cannot be async to use some of the mmap features. So here it is, random access file. 
+    /// </summary>
+    private const FileOptions PaprikaFileOptions = FileOptions.RandomAccess;
 
     private readonly FileStream _file;
     private readonly MemoryMappedFile _mapped;
-    private readonly MemoryMappedViewAccessor _accessor;
+    private readonly MemoryMappedViewAccessor _whole;
+    private readonly MemoryMappedViewAccessor _rootsOnly;
     private readonly byte* _ptr;
 
-    public MemoryMappedPagedDb(ulong size, byte historyDepth, string path, bool deleteOnStart = false) : base(size, historyDepth)
+    public MemoryMappedPagedDb(ulong size, byte historyDepth, string dir) : base(size, historyDepth)
     {
-        _path = path;
+        Path = System.IO.Path.Combine(dir, "paprika.db");
 
-        var name = Path.Combine(_path, "memory-mapped.db");
+        if (!File.Exists(Path))
+        {
+            _file = new FileStream(Path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, 4096,
+                PaprikaFileOptions);
 
-        if (deleteOnStart && File.Exists(name))
-            File.Delete(name);
+            // set length
+            _file.SetLength((long)size);
 
-        _file = new FileStream(name, FileMode.CreateNew, FileAccess.ReadWrite);
-        _file.SetLength((long)size);
+            // clear first pages to make it clean
+            var page = new byte[Page.PageSize];
+            for (var i = 0; i < historyDepth; i++)
+            {
+                _file.Write(page);
+            }
+
+            _file.Flush(true);
+        }
+        else
+        {
+            _file = new FileStream(Path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite, 4096,
+                PaprikaFileOptions);
+        }
+
         _mapped = MemoryMappedFile.CreateFromFile(_file, null, (long)size, MemoryMappedFileAccess.ReadWrite,
             HandleInheritability.None, false);
-        _accessor = _mapped.CreateViewAccessor();
-        _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref _ptr);
+
+        _whole = _mapped.CreateViewAccessor();
+        _whole.SafeMemoryMappedViewHandle.AcquirePointer(ref _ptr);
+
+        _rootsOnly = _mapped.CreateViewAccessor(0, historyDepth * Page.PageSize);
 
         RootInit();
     }
+
+    public string Path { get; }
 
     protected override void* Ptr => _ptr;
 
     public override void Dispose()
     {
-        _accessor.Flush();
-        _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
-        _accessor.Dispose();
+        _whole.Flush();
+        _whole.SafeMemoryMappedViewHandle.ReleasePointer();
+        _whole.Dispose();
         _mapped.Dispose();
     }
 
-    protected override void Flush()
+    protected override void FlushAllPages()
     {
-        _accessor.Flush();
+        // On Windows LMDB does not use FlushViewOfFile + FlushFileBuffers due to some performance gains.
+        // At the moment, simplicity of using it wins over a much more complicated than scheduling writes with WriteFile.
+        // see: https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/mdb.c#L3715-L3716
+        // see: https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/mdb.c#L3775-L3784
+
+        _whole.Flush();
+        _file.Flush(true);
+    }
+
+    protected override void FlushRootPage(in Page rootPage)
+    {
+        // for now, flush all root pages.
+        // Adding LMDB-like flush that works with one page would require a lot of interop
+        // https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/mdb.c#L4136
+
+        _rootsOnly.Flush();
         _file.Flush(true);
     }
 }

--- a/src/Paprika/Db/MemoryMappedPagedDb.cs
+++ b/src/Paprika/Db/MemoryMappedPagedDb.cs
@@ -59,14 +59,6 @@ public unsafe class MemoryMappedPagedDb : PagedDb
 
     protected override void* Ptr => _ptr;
 
-    public override void Dispose()
-    {
-        _whole.Flush();
-        _whole.SafeMemoryMappedViewHandle.ReleasePointer();
-        _whole.Dispose();
-        _mapped.Dispose();
-    }
-
     protected override void FlushAllPages()
     {
         // On Windows LMDB does not use FlushViewOfFile + FlushFileBuffers due to some performance gains.
@@ -86,5 +78,13 @@ public unsafe class MemoryMappedPagedDb : PagedDb
 
         _rootsOnly.Flush();
         _file.Flush(true);
+    }
+
+    public override void Dispose()
+    {
+        _whole.Flush();
+        _whole.SafeMemoryMappedViewHandle.ReleasePointer();
+        _whole.Dispose();
+        _mapped.Dispose();
     }
 }

--- a/src/Paprika/Db/NativeMemoryPagedDb.cs
+++ b/src/Paprika/Db/NativeMemoryPagedDb.cs
@@ -18,7 +18,12 @@ public unsafe class NativeMemoryPagedDb : PagedDb
     protected override void* Ptr => _ptr;
     public override void Dispose() => NativeMemory.AlignedFree(_ptr);
 
-    protected override void Flush()
+    protected override void FlushAllPages()
+    {
+        // no op
+    }
+
+    protected override void FlushRootPage(in Page rootPage)
     {
         // no op
     }

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -54,7 +54,7 @@ public abstract unsafe class PagedDb : IDb, IDisposable
 
         _historyDepth = historyDepth;
         _maxPage = (int)(size / Page.PageSize);
-        _roots = new RootPage[MinHistoryDepth];
+        _roots = new RootPage[historyDepth];
         _batchCurrent = null;
         _ctx = new Context();
     }

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -1,5 +1,4 @@
 ﻿using System.Buffers.Binary;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -110,7 +109,11 @@ public abstract unsafe class PagedDb : IDb, IDisposable
     }
 
     public abstract void Dispose();
-    protected abstract void Flush();
+
+    /// <summary>
+    /// Flushes all the mapped pages.
+    /// </summary>
+    protected abstract void FlushAllPages();
 
     /// <summary>
     /// Begins a batch representing the next block.
@@ -199,10 +202,12 @@ public abstract unsafe class PagedDb : IDb, IDisposable
         }
     }
 
-    private void SetNewRoot(RootPage root)
+    private DbAddress SetNewRoot(RootPage root)
     {
         _lastRoot += 1;
-        root.CopyTo(_roots[_lastRoot % _historyDepth]);
+        var pageAddress = _lastRoot % _historyDepth;
+        root.CopyTo(_roots[pageAddress]);
+        return DbAddress.Page((uint)pageAddress);
     }
 
     class ReadOnlyBatch : IReadOnlyBatch, IReadOnlyBatchContext
@@ -319,22 +324,19 @@ public abstract unsafe class PagedDb : IDb, IDisposable
             // memoize the abandoned so that it's preserved for future uses 
             MemoizeAbandoned();
 
-            // flush data first
-            _db.Flush();
-
             lock (_db._batchLock)
             {
                 Debug.Assert(ReferenceEquals(this, _db._batchCurrent));
+                _db._batchCurrent = null;
 
-                _db.SetNewRoot(_root);
+                _db.FlushAllPages();
+
+                var newRootPage = _db.SetNewRoot(_root);
 
                 if (options == CommitOptions.FlushDataAndRoot)
                 {
-                    // TODO: make it flush only the root page, not the whole file
-                    _db.Flush();
+                    _db.FlushRootPage(GetAt(newRootPage));
                 }
-
-                _db._batchCurrent = null;
 
                 return _root.Data.StateRootHash;
             }
@@ -556,4 +558,7 @@ public abstract unsafe class PagedDb : IDb, IDisposable
             //Page.Clear();
         }
     }
+
+    // ReSharper disable once UnusedParameter.Global
+    protected abstract void FlushRootPage(in Page rootPage);
 }


### PR DESCRIPTION
This PR amends the flushing mechanism, by separating the flush for the root pages from the whole file. This should make it a bit more efficient. It also makes the file opened with `Random` and updates the `Paprika.Runner` so that it can be used for initial testing.

Resolves #35 
Resolves #36 
Resolves #31 