### PR TITLE
Parallel tests

### DIFF
--- a/src/Paprika.Tests/Global.cs
+++ b/src/Paprika.Tests/Global.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Children)]


### PR DESCRIPTION
This PR makes all the tests parallel by default by applying `[assembly: Parallelizable(ParallelScope.Children)]`