### PR TITLE
Root fanout

### DIFF
--- a/src/Paprika.Tests/DbTests.cs
+++ b/src/Paprika.Tests/DbTests.cs
@@ -155,7 +155,7 @@ public class DbTests
     public void Readonly_transaction_block_till_they_are_released()
     {
         const int size = MB16;
-        const int blocksDuringReadAcquired = 1_000;
+        const int blocksDuringReadAcquired = 500; // the number should be smaller than the number of buckets in the root
         const int blocksPostRead = 10_000;
         UInt256 start = 13;
 

--- a/src/Paprika/Db/BatchMetrics.cs
+++ b/src/Paprika/Db/BatchMetrics.cs
@@ -5,16 +5,19 @@ class BatchMetrics : IBatchMetrics
     public int PagesReused { get; private set; }
     public int PagesAllocated { get; private set; }
     public int UnusedPoolFetch { get; private set; }
-
-    public BatchMetrics()
-    {
-    }
+    public int AbandonedPagesSlotsCount { get; private set; }
 
     public void ReportPageReused() => PagesReused++;
 
     public void ReportNewPageAllocation() => PagesAllocated++;
 
     public void ReportUnusedPoolFetch() => UnusedPoolFetch++;
+
+
+    public void ReportAbandonedPagesSlotsCount(int abandonedPagesSlotsCount)
+    {
+        AbandonedPagesSlotsCount = abandonedPagesSlotsCount;
+    }
 }
 
 public interface IBatchMetrics
@@ -33,6 +36,11 @@ public interface IBatchMetrics
     /// The count of unused pool fetches.
     /// </summary>
     int UnusedPoolFetch { get; }
+
+    /// <summary>
+    /// How many abandoned pages slots are used in the root page.
+    /// </summary>
+    int AbandonedPagesSlotsCount { get; }
 
     /// <summary>
     /// Total pages written during this batch.

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -475,6 +475,18 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
                 // write the abandoned in the youngestAddr
                 youngestAddr = _db.GetAddress(first.AsPage());
             }
+
+            if (_db._reporter != null)
+            {
+                var occupied = 0;
+                foreach (var abandoned in abandonedPages)
+                {
+                    if (abandoned != DbAddress.Null)
+                        occupied++;
+                }
+
+                _metrics.ReportAbandonedPagesSlotsCount(occupied);
+            }
         }
 
         private bool TryGetNoLongerUsedPage(out DbAddress found, out DbAddress registerForGC)

--- a/src/Paprika/Pages/Printer.cs
+++ b/src/Paprika/Pages/Printer.cs
@@ -76,7 +76,7 @@ public class Printer : IPageVisitor
                 ("BatchId", page.Header.BatchId.ToString()),
                 ("BlockNumber", page.Data.BlockNumber.ToString()),
                 ("StateRootHash", Abbr(page.Data.StateRootHash)),
-                ("DataPage", page.Data.DataPage.ToString()),
+                ("DataPages", ListPages(page.Data.DataPages)),
                 ("NextFreePage", page.Data.NextFreePage.ToString()),
                 ("Abandoned", ListPages(page.Data.AbandonedPages))
             };


### PR DESCRIPTION
This PR introduces a fan out of `256` at the root level. It saves 17 pages for each root atm. With the max reorg depth equal to 64 it gives 64 * 17 * 4kb = ~4MB only but reduces the depth of the tree by 2.

Resolves #52 