### PR TITLE
New page buffer management

### DIFF
--- a/src/Paprika.Tests/FrameTests.cs
+++ b/src/Paprika.Tests/FrameTests.cs
@@ -7,22 +7,22 @@ namespace Paprika.Tests;
 public class FrameTests
 {
     private const int MaxFrames = 16;
-    private const int Next = 23;
+    private static readonly FrameIndex Next = FrameIndex.FromIndex(23);
 
-    [TestCase(new byte[0], 1, TestName = "Empty Span")]
-    [TestCase(new byte[] { 13 }, 1, TestName = "Single byte")]
-    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6 }, 1, TestName = "Full frame")]
-    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7 }, 2, TestName = "2 frames")]
-    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 2, TestName = "2 full frames")]
-    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, 3, TestName = "3 frames")]
-    public void Write_Read(byte[] bytes, byte expectedFrameCount)
+    [TestCase(new byte[0], TestName = "Empty Span")]
+    [TestCase(new byte[] { 13 }, TestName = "Single byte")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6 }, TestName = "Full frame")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7 }, TestName = "2 frames")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, TestName = "2 full frames")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, TestName = "3 frames")]
+    public void Write_Read(byte[] bytes)
     {
-        Span<Frame> pool = stackalloc Frame[MaxFrames];
-        ref var frame = ref pool[0];
+        Span<Frame> frames = stackalloc Frame[MaxFrames];
+        var pool = new Frame.Pool();
 
-        Frame.GetFrameCount(bytes).Should().Be(expectedFrameCount);
+        pool.TryWrite(bytes, Next, frames, out var writtenTo).Should().BeTrue();
 
-        Frame.Write(ref frame, bytes, Next);
+        ref var frame = ref frames[writtenTo.Value];
         var read = Frame.Read(ref frame, out var next);
 
         Assert.AreEqual(Next, next);
@@ -30,4 +30,17 @@ public class FrameTests
         read.StartsWith(bytes).Should()
             .BeTrue("There can be more bytes in the frame, but they should start with original");
     }
+
+    // [Test]
+    // public void Write_Release_Write()
+    // {
+    //     var bytes0 = new byte[] { 13 };
+    //     var bytes1 = new byte[] { 17 };
+    //     var bytes2 = new byte[] { 23 };
+    //     
+    //     Span<Frame> frames = stackalloc Frame[2];
+    //     var pool = new Frame.Pool();
+    //     
+    //     pool.
+    // }
 }

--- a/src/Paprika.Tests/FrameTests.cs
+++ b/src/Paprika.Tests/FrameTests.cs
@@ -1,0 +1,33 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Pages.Frames;
+
+namespace Paprika.Tests;
+
+public class FrameTests
+{
+    private const int MaxFrames = 16;
+    private const int Next = 23;
+
+    [TestCase(new byte[0], 1, TestName = "Empty Span")]
+    [TestCase(new byte[] { 13 }, 1, TestName = "Single byte")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6 }, 1, TestName = "Full frame")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7 }, 2, TestName = "2 frames")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }, 2, TestName = "2 full frames")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, 3, TestName = "3 frames")]
+    public void Write_Read(byte[] bytes, byte expectedFrameCount)
+    {
+        Span<Frame> pool = stackalloc Frame[MaxFrames];
+        ref var frame = ref pool[0];
+
+        Frame.GetFrameCount(bytes).Should().Be(expectedFrameCount);
+
+        Frame.Write(ref frame, bytes, Next);
+        var read = Frame.Read(ref frame, out var next);
+
+        Assert.AreEqual(Next, next);
+
+        read.StartsWith(bytes).Should()
+            .BeTrue("There can be more bytes in the frame, but they should start with original");
+    }
+}

--- a/src/Paprika.Tests/PageBufferTests.cs
+++ b/src/Paprika.Tests/PageBufferTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Pages;
+
+namespace Paprika.Tests;
+
+public class PageBufferTests
+{
+    [Test]
+    public void Minimal()
+    {
+        Span<byte> span = stackalloc byte[PageBuffer.MixSize];
+        var buffer = new PageBuffer(span);
+
+        Span<byte> key = stackalloc byte[4];
+        new Random(13).NextBytes(key);
+
+        Span<byte> data = stackalloc byte[1] { 23 };
+
+        Index<ushort> prev = Index<ushort>.Null;
+        buffer.TrySet(key, data, ref prev).Should().BeTrue();
+
+        buffer.TryGet(key, out var retrieved, prev).Should().BeTrue();
+
+        data.SequenceEqual(retrieved).Should().BeTrue();
+    }
+}

--- a/src/Paprika.Tests/PageBufferTests.cs
+++ b/src/Paprika.Tests/PageBufferTests.cs
@@ -12,18 +12,24 @@ public class PageBufferTests
         Span<byte> span = stackalloc byte[PageBuffer.MixSize];
         var buffer = new PageBuffer(span);
 
-        Span<byte> key = stackalloc byte[4];
-        new Random(13).NextBytes(key);
+        Span<byte> key0 = stackalloc byte[4] { 1, 2, 3, 5 };
+        Span<byte> data0 = stackalloc byte[1] { 23 };
 
-        Span<byte> data = stackalloc byte[1] { 23 };
+        buffer.TrySet(key0, data0).Should().BeTrue();
 
-        Index<ushort> prev = Index<ushort>.Null;
-        buffer.TrySet(key, data, ref prev).Should().BeTrue();
+        buffer.TryGet(key0, out var retrieved).Should().BeTrue();
+        data0.SequenceEqual(retrieved).Should().BeTrue();
 
-        buffer.TryGet(key, out var retrieved, prev).Should().BeTrue();
-        data.SequenceEqual(retrieved).Should().BeTrue();
+        buffer.Delete(key0).Should().BeTrue("Should find and delete entry");
+        buffer.TryGet(key0, out _).Should().BeFalse("The entry shall no longer exist");
 
-        buffer.Delete(key, prev).Should().BeTrue("Should find and delete entry");
-        buffer.TryGet(key, out _, prev).Should().BeFalse("The entry shall no longer exist");
+        // should be ready to accept some data again
+        Span<byte> key1 = stackalloc byte[4] { 7, 11, 13, 17 };
+        Span<byte> data1 = stackalloc byte[2] { 29, 31 };
+
+        buffer.TrySet(key1, data1).Should().BeTrue("Should have memory after previous delete");
+
+        buffer.TryGet(key1, out retrieved).Should().BeTrue();
+        data1.SequenceEqual(retrieved).Should().BeTrue();
     }
 }

--- a/src/Paprika.Tests/PageBufferTests.cs
+++ b/src/Paprika.Tests/PageBufferTests.cs
@@ -7,7 +7,7 @@ namespace Paprika.Tests;
 public class PageBufferTests
 {
     [Test]
-    public void Minimal()
+    public void Set_Get_Delete_Get_AnotherSet()
     {
         Span<byte> span = stackalloc byte[PageBuffer.MixSize];
         var buffer = new PageBuffer(span);
@@ -21,7 +21,9 @@ public class PageBufferTests
         buffer.TrySet(key, data, ref prev).Should().BeTrue();
 
         buffer.TryGet(key, out var retrieved, prev).Should().BeTrue();
-
         data.SequenceEqual(retrieved).Should().BeTrue();
+
+        buffer.Delete(key, prev).Should().BeTrue("Should find and delete entry");
+        buffer.TryGet(key, out _, prev).Should().BeFalse("The entry shall no longer exist");
     }
 }

--- a/src/Paprika.Tests/SerializerTests.cs
+++ b/src/Paprika.Tests/SerializerTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using Nethermind.Int256;
+using NUnit.Framework;
+using Paprika.Crypto;
+using Paprika.Pages.Frames;
+
+namespace Paprika.Tests;
+
+public class SerializerTests
+{
+    [Test]
+    public void EOA()
+    {
+        var path = NibblePath.FromKey(Keccak.Zero);
+        var balance = UInt256.One;
+        var nonce = UInt256.One;
+
+        Span<byte> destination = stackalloc byte[Serializer.Account.EOAMaxByteCount];
+
+        var leftover = Serializer.Account.WriteEOA(destination, path, balance, nonce);
+        var actual = destination.Slice(0, destination.Length - leftover.Length);
+
+        Serializer.Account.ReadAccount(actual, out var pathRead, out var balanceRead, out var nonceRead);
+
+        pathRead.Equals(path).Should().BeTrue();
+        balanceRead.Should().Be(balance);
+        nonceRead.Should().Be(nonce);
+    }
+}

--- a/src/Paprika.Tests/SerializerTests.cs
+++ b/src/Paprika.Tests/SerializerTests.cs
@@ -8,12 +8,15 @@ namespace Paprika.Tests;
 
 public class SerializerTests
 {
-    [Test]
-    public void EOA()
+    private static readonly UInt256 EthInWei = 1_000_000_000_000_000_000;
+    private static readonly UInt256 Eth1000 = 1000UL * EthInWei;
+    private static readonly UInt256 EthMax = 120_000_000UL * EthInWei;
+    private static readonly UInt256 TotalTxCount = 2_000_000_000;
+
+    [TestCaseSource(nameof(GetEOAData))]
+    public void EOA(UInt256 balance, UInt256 nonce)
     {
         var path = NibblePath.FromKey(Keccak.Zero);
-        var balance = UInt256.One;
-        var nonce = UInt256.One;
 
         Span<byte> destination = stackalloc byte[Serializer.Account.EOAMaxByteCount];
 
@@ -25,5 +28,12 @@ public class SerializerTests
         pathRead.Equals(path).Should().BeTrue();
         balanceRead.Should().Be(balance);
         nonceRead.Should().Be(nonce);
+    }
+
+    static IEnumerable<TestCaseData> GetEOAData()
+    {
+        yield return new TestCaseData(UInt256.Zero, UInt256.Zero).SetName("Zeros");
+        yield return new TestCaseData(Eth1000, (UInt256)10000).SetName("Reasonable");
+        yield return new TestCaseData(EthMax, TotalTxCount).SetName("Max");
     }
 }

--- a/src/Paprika/NibblePath.cs
+++ b/src/Paprika/NibblePath.cs
@@ -58,6 +58,11 @@ public readonly ref struct NibblePath
     /// </summary>
     public int MaxLength => Length / 2 + 2;
 
+    /// <summary>
+    /// Writes the nibble path into the destination.
+    /// </summary>
+    /// <param name="destination"></param>
+    /// <returns>The leftover.</returns>
     public Span<byte> WriteTo(Span<byte> destination)
     {
         var odd = _odd & OddBit;

--- a/src/Paprika/Pages/Frames/Frame.cs
+++ b/src/Paprika/Pages/Frames/Frame.cs
@@ -4,14 +4,18 @@ using System.Runtime.InteropServices;
 namespace Paprika.Pages.Frames;
 
 /// <summary>
-/// Provides a wrapping for a <see cref="byte"/> based index of a <see cref="IFrame"/> on the page,
-/// so that 0 can be used as a value and is different from the null value. 
+/// Provides a coarse grained primitive used for memory management on the page.
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = Size)]
 public readonly struct Frame
 {
-    public const int Size = 8;
+    public const int Size = 16;
 
+    /// <summary>
+    /// The pool used to manage free and released memory on page.
+    /// Depends on the external <see cref="Span{Frame}"/> provided by the caller
+    /// as this is usually created on the page and depends on the size available in there.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = Size)]
     public struct Pool
     {
@@ -73,7 +77,8 @@ public readonly struct Frame
                 return true;
             }
 
-            throw new NotImplementedException();
+            throw new NotImplementedException(
+                "Iteration through the frames releases is not yet implemented");
         }
 
         public Span<byte> Read(FrameIndex index, Span<Frame> frames, out FrameIndex next)

--- a/src/Paprika/Pages/Frames/Frame.cs
+++ b/src/Paprika/Pages/Frames/Frame.cs
@@ -1,0 +1,60 @@
+﻿using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Paprika.Pages.Frames;
+
+/// <summary>
+/// Provides a wrapping for a <see cref="byte"/> based index of a <see cref="IFrame"/> on the page,
+/// so that 0 can be used as a value and is different from the null value. 
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = Size)]
+public readonly struct Frame
+{
+    public const int Size = 8;
+
+    public static Span<byte> Read(ref Frame frame, out byte next)
+    {
+        var header = Unsafe.As<Frame, Header>(ref frame);
+        next = header.Next;
+
+        return CreateByteSpan(ref frame, header);
+    }
+
+    public static void Write(ref Frame frame, Span<byte> bytes, byte next)
+    {
+        var length = GetFrameCount(bytes);
+
+        ref var header = ref Unsafe.As<Frame, Header>(ref frame);
+
+        header.Length = length;
+        header.Next = next;
+
+        var dest = CreateByteSpan(ref frame, header);
+        bytes.CopyTo(dest);
+    }
+
+    private static Span<byte> CreateByteSpan(ref Frame frame, Header header)
+    {
+        ref var bytes = ref Unsafe.Add(ref Unsafe.As<Frame, byte>(ref frame), Header.Size);
+        return MemoryMarshal.CreateSpan(ref bytes, header.Length * Size - Header.Size);
+    }
+
+    /// <summary>
+    /// Gets the number of frames needed to store <see cref="bytes"/> payload.
+    /// </summary>
+    public static byte GetFrameCount(Span<byte> bytes) => (byte)AlignToFrames(bytes.Length + Header.Size);
+
+    private static int AlignToFrames(int length) => ((length + (Size - 1)) & -Size) / Size;
+
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    private struct Header
+    {
+        // ReSharper disable once MemberHidesStaticFromOuterClass
+        public const int Size = 2;
+
+        [FieldOffset(0)] public byte Length;
+
+        [FieldOffset(1)] public byte Next;
+    }
+}

--- a/src/Paprika/Pages/Frames/FrameIndex.cs
+++ b/src/Paprika/Pages/Frames/FrameIndex.cs
@@ -31,4 +31,6 @@ public readonly struct FrameIndex
     public byte Raw => _raw;
 
     public bool IsNull => _raw == 0;
+
+    public override string ToString() => IsNull ? "null" : $"@{Value}";
 }

--- a/src/Paprika/Pages/Frames/Serializer.cs
+++ b/src/Paprika/Pages/Frames/Serializer.cs
@@ -19,6 +19,13 @@ public static class Serializer
         value.ToBigEndian(uint256);
         var firstNonZero = uint256.IndexOfAnyExcept((byte)0);
 
+        if (firstNonZero == -1)
+        {
+            // only zeros, special case
+            destination[0] = 0;
+            return destination.Slice(1);
+        }
+
         var nonZeroBytes = (byte)(Uint256Size - firstNonZero);
         destination[0] = nonZeroBytes;
 
@@ -42,7 +49,9 @@ public static class Serializer
     public static class Account
     {
         // TODO: provide header differentiating type of the account and the codeHash and storage
-        public const int EOAMaxByteCount = MaxNibblePathLength + MaxUint256SizeWithPrefix + MaxUint256SizeWithPrefix;
+        public const int EOAMaxByteCount = MaxNibblePathLength + // path
+                                           MaxUint256SizeWithPrefix + // balance
+                                           MaxUint256SizeWithPrefix; // nonce
 
         public static Span<byte> WriteEOA(Span<byte> destination, NibblePath key, UInt256 balance, UInt256 nonce)
         {

--- a/src/Paprika/Pages/Index.cs
+++ b/src/Paprika/Pages/Index.cs
@@ -1,0 +1,40 @@
+using System.Numerics;
+
+namespace Paprika.Pages;
+
+/// <summary>
+/// Represents any index that wants to use 0, the default value as null and shift all the other values by one.
+/// </summary>
+/// <typeparam name="TPrimitive"></typeparam>
+public readonly struct Index<TPrimitive>
+    where TPrimitive : INumberBase<TPrimitive>
+{
+    // ReSharper disable once StaticMemberInGenericType
+    public static readonly Index<TPrimitive> Null = default;
+
+    private static readonly TPrimitive Shift = TPrimitive.One;
+    private readonly TPrimitive _raw;
+
+    private Index(TPrimitive raw)
+    {
+        _raw = raw;
+    }
+
+    public static Index<TPrimitive> FromIndex(TPrimitive index) => new(index + Shift);
+
+    public static Index<TPrimitive> FromRaw(TPrimitive index) => new(index);
+
+    /// <summary>
+    /// Gets the value of the index.
+    /// </summary>
+    public TPrimitive Value => _raw - Shift;
+
+    /// <summary>
+    /// Gets the raw value underneath.
+    /// </summary>
+    public TPrimitive Raw => _raw;
+
+    public bool IsNull => _raw == TPrimitive.Zero;
+
+    public override string ToString() => IsNull ? "null" : $"@{Value}";
+}

--- a/src/Paprika/Pages/PageBuffer.cs
+++ b/src/Paprika/Pages/PageBuffer.cs
@@ -1,0 +1,179 @@
+﻿using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Paprika.Pages;
+
+/// <summary>
+/// Represents an in-page buffer, responsible for storing items and information related to them.
+/// </summary>
+public readonly ref struct PageBuffer
+{
+    public const int AllocationGranularity = 8;
+    public const int MixSize = AllocationGranularity * 3;
+
+    private readonly ref Header _header;
+    private readonly Span<byte> _data;
+    private readonly Span<ItemId> _ids;
+
+    private const int Null = 0;
+
+    public PageBuffer(Span<byte> buffer)
+    {
+        _header = ref Unsafe.As<byte, Header>(ref buffer[0]);
+        _data = buffer.Slice(Header.Size);
+        _ids = MemoryMarshal.Cast<byte, ItemId>(_data);
+    }
+
+    public bool TrySet(Span<byte> key, Span<byte> data, ref Index<ushort> prev)
+    {
+        var prefix = ItemId.ExtractKeyBytes(key);
+
+        if (prev.IsNull)
+        {
+            // try search first and replace in situ. If possible,
+            // if the size is different, mark as deleted and default to the next
+        }
+
+        // does not exist yet, calculate
+        var dataRequiredWithNoLength =
+            (ushort)(key.Length + data.Length - ItemId.KeyExtractedBytes);
+        var dataRequired = (ushort)(dataRequiredWithNoLength + ItemId.ItemLengthLength);
+
+        if (_header.Taken + dataRequired + ItemId.Size > _data.Length)
+        {
+            return false;
+        }
+
+        var at = _header.Low;
+        ref var id = ref _ids[at / ItemId.Size];
+
+        // write ItemId
+        id.ItemPrefix = prefix;
+        id.NextAddress = prev.Raw;
+        id.ItemAddress = (ushort)(_data.Length - _header.Low - dataRequired);
+
+        // write item, first length, then key, then data
+        var dest = _data.Slice(id.ItemAddress, dataRequired);
+        WriteDataLength(dest, dataRequiredWithNoLength);
+
+        key.Slice(ItemId.KeyExtractedBytes).CopyTo(dest.Slice(ItemId.ItemLengthLength));
+        data.CopyTo(dest.Slice(ItemId.ItemLengthLength + key.Length - ItemId.KeyExtractedBytes));
+
+        // commit low and high
+        prev = Index<ushort>.FromIndex(_header.Low);
+        _header.Low += ItemId.Size;
+        _header.High += dataRequired;
+        return true;
+    }
+
+    private static void WriteDataLength(Span<byte> dest, ushort dataRequiredWithNoLength) =>
+        BinaryPrimitives.WriteUInt16LittleEndian(dest, dataRequiredWithNoLength);
+
+    private static ushort ReadDataLength(Span<byte> source) => BinaryPrimitives.ReadUInt16LittleEndian(source);
+
+    public bool TryGet(Span<byte> key, out Span<byte> data, Index<ushort> start)
+    {
+        var prefix = ItemId.ExtractKeyBytes(key);
+
+        var index = start;
+        while (index.IsNull == false)
+        {
+            ref readonly var id = ref _ids[index.Value];
+
+            // compare only not deleted and with the same prefix
+            if (id.IsDeleted == false && id.ItemPrefix == prefix)
+            {
+                var slice = _data.Slice(id.ItemAddress);
+                var dataLength = ReadDataLength(slice);
+                var actual = slice.Slice(2, dataLength);
+
+                // this check assumes that all the keys have the same length.
+                // Otherwise, prefix length would be required
+                var keyLeftover = key.Slice(ItemId.KeyExtractedBytes);
+                if (actual.StartsWith(keyLeftover))
+                {
+                    data = actual.Slice(keyLeftover.Length);
+                    return true;
+                }
+            }
+
+            index = Index<ushort>.FromRaw(id.NextAddress);
+        }
+
+        data = default;
+        return false;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    private struct ItemId
+    {
+        public const int Size = 8;
+        public const int KeyExtractedBytes = 4;
+        public const int ItemLengthLength = 2;
+
+        private const int BitsForPageAddress = 12;
+        private const uint InPageAddressMask = Page.PageSize - 1;
+        private const uint Bit = 1;
+
+        private const int NextShift = BitsForPageAddress * 0;
+        private const int ItemShift = BitsForPageAddress * 1;
+        private const int DeletedShift = BitsForPageAddress * 2; // 24
+
+        /// <summary>
+        /// The next chained item.
+        /// </summary>
+        public ushort NextAddress
+        {
+            get => (ushort)((Raw >> NextShift) & InPageAddressMask);
+            set => Raw = Raw & ~(uint)(InPageAddressMask << NextShift) | ((uint)value << NextShift);
+        }
+
+        /// <summary>
+        /// The address of this item.
+        /// </summary>
+        public ushort ItemAddress
+        {
+            get => (ushort)((Raw >> ItemShift) & InPageAddressMask);
+            set => Raw = Raw & ~(InPageAddressMask << ItemShift) | ((uint)value << ItemShift);
+        }
+
+        public bool IsDeleted
+        {
+            get => ((Raw >> DeletedShift) & Bit) == Bit;
+            set => Raw = Raw & ~(Bit << DeletedShift) | ((value ? Bit : 0) << ItemShift);
+        }
+
+        [FieldOffset(0)] private uint Raw;
+
+        /// <summary>
+        /// First 4 bytes extracted from the item for fast comparisons.
+        /// </summary>
+        [FieldOffset(4)] public uint ItemPrefix;
+
+        public static uint ExtractKeyBytes(Span<byte> key) => BinaryPrimitives.ReadUInt32LittleEndian(key);
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    private struct Header
+    {
+        public const int Size = 8;
+
+        /// <summary>
+        /// Represents the distance from the start.t
+        /// </summary>
+        [FieldOffset(0)] public ushort Low;
+
+        /// <summary>
+        /// Represents the distance from the end
+        /// </summary>
+        [FieldOffset(2)] public ushort High;
+
+        /// <summary>
+        /// How much was deleted in this page
+        /// </summary>
+        [FieldOffset(4)] public ushort Deleted;
+
+        public ushort Taken => (ushort)(Low + High);
+    }
+}


### PR DESCRIPTION
This PR changes the way data are stored in-page from frame based to a modified slot array. A slot array uses a slice of memory to store two growing sets of data, one from the beginning, one from the end. The one growing from the beginning is responsible for storing metadata entries called `Slots`. The one growing from the end, the data. 

In case of Paprika a modified version is used, called `PageBuffer`, that with some overhead, is self-sufficient in handling keys and no external indexing is required.

Resolves #23 