### PR TITLE
Fanout of 256

### DIFF
--- a/src/Paprika.Tests/DbTests.cs
+++ b/src/Paprika.Tests/DbTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers.Binary;
+using System.Diagnostics;
 using FluentAssertions;
 using Nethermind.Int256;
 using NUnit.Framework;
@@ -14,6 +15,7 @@ public class DbTests
     private const int SmallDb = 256 * Page.PageSize;
     private const int MB = 1024 * 1024;
     private const int MB16 = 16 * MB;
+    private const int MB64 = 64 * MB;
 
     [Test]
     public void Simple()
@@ -126,9 +128,12 @@ public class DbTests
     [TestCase(500, 2_000, TestName = "Short history, many accounts")]
     public void Page_reuse(int blockCount, int accountsCount)
     {
-        const int size = MB16;
+        const int size = MB64;
 
-        using var db = new NativeMemoryPagedDb(size, 2);
+        using var db = new NativeMemoryPagedDb(size, 2, metrics =>
+        {
+            Debugger.Break();
+        });
 
         for (var i = 0; i < blockCount; i++)
         {

--- a/src/Paprika/Db/BatchMetrics.cs
+++ b/src/Paprika/Db/BatchMetrics.cs
@@ -6,6 +6,7 @@ class BatchMetrics : IBatchMetrics
     public int PagesAllocated { get; private set; }
     public int UnusedPoolFetch { get; private set; }
     public int AbandonedPagesSlotsCount { get; private set; }
+    public int AbandonedPagesCount { get; set; }
 
     public void ReportPageReused() => PagesReused++;
 
@@ -47,3 +48,4 @@ public interface IBatchMetrics
     /// </summary>
     int TotalPagesWritten => PagesAllocated + PagesReused;
 }
+

--- a/src/Paprika/Pages/DataPage.cs
+++ b/src/Paprika/Pages/DataPage.cs
@@ -15,7 +15,7 @@ namespace Paprika.Pages;
 /// The page preserves locality of the data though. It's either all the children with a given nibble stored
 /// in the parent page, or they are flushed underneath. 
 /// </remarks>
-public readonly unsafe struct DataPage : IPage
+public readonly unsafe struct DataPage : IAccountPage
 {
     private readonly Page _page;
 

--- a/src/Paprika/Pages/FanOut256Page.cs
+++ b/src/Paprika/Pages/FanOut256Page.cs
@@ -1,0 +1,96 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Paprika.Crypto;
+
+namespace Paprika.Pages;
+
+/// <summary>
+/// Represents the page with the fan out of 256 to maximally flatten the tree.
+/// </summary>
+public readonly unsafe struct FanOut256Page : IAccountPage
+{
+    private readonly Page _page;
+
+    [DebuggerStepThrough]
+    public FanOut256Page(Page page) => _page = page;
+
+    public ref PageHeader Header => ref _page.Header;
+    public ref Payload Data => ref Unsafe.AsRef<Payload>(_page.Payload);
+
+    /// <summary>
+    /// Represents the data of this data page. This type of payload stores data in 256 nibble-addressable buckets.
+    /// No data are stored inline.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    public struct Payload
+    {
+        private const int Size = Page.PageSize - PageHeader.Size;
+
+        public const int BucketCount = 256;
+
+        /// <summary>
+        /// The first field of buckets.
+        /// </summary>
+        [FieldOffset(0)] private DbAddress Bucket;
+
+        public Span<DbAddress> Buckets => MemoryMarshal.CreateSpan(ref Bucket, BucketCount);
+    }
+
+    public Page Set(in SetContext ctx, int level)
+    {
+        if (Header.BatchId != ctx.Batch.BatchId)
+        {
+            // the page is from another batch, meaning, it's readonly. Copy
+            var writable = ctx.Batch.GetWritableCopy(_page);
+            return new FanOut256Page(writable).Set(ctx, level);
+        }
+
+        var path = NibblePath.FromKey(ctx.Key.BytesAsSpan, level);
+        var prefix = FirstTwoNibbles(path);
+
+        var address = Data.Buckets[prefix];
+
+        if (address.IsNull)
+        {
+            // no data page, allocate and set
+            var page = ctx.Batch.GetNewPage(out address, true);
+            new DataPage(page).Set(ctx, level + NibbleCount);
+            Data.Buckets[prefix] = address;
+        }
+        else
+        {
+            var page = ctx.Batch.GetAt(address);
+            var updated = new DataPage(page).Set(ctx, level + NibbleCount);
+            Data.Buckets[prefix] = ctx.Batch.GetAddress(updated);
+        }
+
+        return _page;
+    }
+
+    private static ushort FirstTwoNibbles(NibblePath path)
+    {
+        return (ushort)((path.GetAt(0) << NibblePath.NibbleShift * 0) +
+                        (path.GetAt(1) << NibblePath.NibbleShift * 1));
+    }
+
+    private const int NibbleCount = 2;
+
+    public void GetAccount(in Keccak key, IReadOnlyBatchContext batch, out Account result, int level)
+    {
+        var path = NibblePath.FromKey(key.BytesAsSpan, level);
+        var prefix = FirstTwoNibbles(path);
+
+        var address = Data.Buckets[prefix];
+
+        if (address.IsNull)
+        {
+            result = default;
+        }
+        else
+        {
+            var page = batch.GetAt(address);
+            new DataPage(page).GetAccount(key, batch, out result, level + NibbleCount);
+        }
+    }
+}

--- a/src/Paprika/Pages/IPageVisitor.cs
+++ b/src/Paprika/Pages/IPageVisitor.cs
@@ -7,4 +7,6 @@ public interface IPageVisitor
     void On(AbandonedPage page, DbAddress addr);
 
     void On(DataPage page, DbAddress addr);
+
+    void On(FanOut256Page page, DbAddress addr);
 }

--- a/src/Paprika/Pages/Page.cs
+++ b/src/Paprika/Pages/Page.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Paprika.Crypto;
 
 namespace Paprika.Pages;
 
@@ -13,6 +14,13 @@ namespace Paprika.Pages;
 /// </remarks>
 public interface IPage
 {
+}
+
+public interface IAccountPage : IPage
+{
+    void GetAccount(in Keccak key, IReadOnlyBatchContext batch, out Account result, int level);
+
+    Page Set(in SetContext ctx, int level);
 }
 
 /// <summary>

--- a/src/Paprika/Pages/Printer.cs
+++ b/src/Paprika/Pages/Printer.cs
@@ -76,7 +76,7 @@ public class Printer : IPageVisitor
                 ("BatchId", page.Header.BatchId.ToString()),
                 ("BlockNumber", page.Data.BlockNumber.ToString()),
                 ("StateRootHash", Abbr(page.Data.StateRootHash)),
-                ("DataPages", ListPages(page.Data.DataPages)),
+                ("DataPages", ListPages(page.Data.AccountPages)),
                 ("NextFreePage", page.Data.NextFreePage.ToString()),
                 ("Abandoned", ListPages(page.Data.AbandonedPages))
             };
@@ -106,6 +106,19 @@ public class Printer : IPageVisitor
             (Type, "DataPage"),
             ("BatchId", page.Header.BatchId.ToString()),
             ("Points Down To Pages",ListPages(nextPages)),
+        };
+
+        _printable.Add(addr.Raw, p);
+    }
+
+    public void On(FanOut256Page page, DbAddress addr)
+    {
+        var nextPages = page.Data.Buckets.ToArray().Where(a => a.IsNull == false && a.IsValidPageAddress).ToArray();
+        var p = new[]
+        {
+            (Type, "FanOut256Page"),
+            ("BatchId", page.Header.BatchId.ToString()),
+            ("Points Down To Pages", ListPages(nextPages)),
         };
 
         _printable.Add(addr.Raw, p);

--- a/src/Paprika/Pages/RootPage.cs
+++ b/src/Paprika/Pages/RootPage.cs
@@ -30,20 +30,20 @@ public readonly unsafe struct RootPage : IPage
         /// <summary>
         /// How big is the fan out for the root.
         /// </summary>
-        private const int DataPageFanOut = 256;
+        private const int AccountPageFanOut = 256;
 
         /// <summary>
         /// The number of nibbles that are "consumed" on the root level.
         /// </summary>
         public const byte RootNibbleLevel = 2;
 
-        private const int AbandonedPagesStart = sizeof(uint) + Keccak.Size + DbAddress.Size + DbAddress.Size * DataPageFanOut;
+        private const int AbandonedPagesStart = sizeof(uint) + Keccak.Size + DbAddress.Size + DbAddress.Size * AccountPageFanOut;
 
         /// <summary>
         /// This gives the upper boundary of the number of abandoned pages that can be kept in the list.
         /// </summary>
         /// <remarks>
-        /// The value is dependent on <see cref="DataPageFanOut"/> as the more data pages addresses, the less space for
+        /// The value is dependent on <see cref="AccountPageFanOut"/> as the more data pages addresses, the less space for
         /// the abandoned. Still, the number of abandoned that is required is ~max reorg depth as later, pages are reused.
         /// Even with fan-out of data pages equal to 256, there's still a lot of room here.
         /// </remarks>
@@ -68,12 +68,12 @@ public readonly unsafe struct RootPage : IPage
         /// <summary>
         /// The first of the data pages.
         /// </summary>
-        [FieldOffset(sizeof(uint) + Keccak.Size + DbAddress.Size)] private DbAddress DataPage;
+        [FieldOffset(sizeof(uint) + Keccak.Size + DbAddress.Size)] private DbAddress AccountPage;
 
         /// <summary>
-        /// Gets the span of data pages of the root
+        /// Gets the span of account pages of the root
         /// </summary>
-        public Span<DbAddress> DataPages => MemoryMarshal.CreateSpan(ref DataPage, DataPageFanOut);
+        public Span<DbAddress> AccountPages => MemoryMarshal.CreateSpan(ref AccountPage, AccountPageFanOut);
 
         /// <summary>
         /// The start of the abandoned pages.
@@ -102,11 +102,11 @@ public readonly unsafe struct RootPage : IPage
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver)
     {
-        foreach (var dataAddr in Data.DataPages)
+        foreach (var dataAddr in Data.AccountPages)
         {
             if (dataAddr.IsNull == false)
             {
-                var data = new DataPage(resolver.GetAt(dataAddr));
+                var data = new FanOut256Page(resolver.GetAt(dataAddr));
                 visitor.On(data, dataAddr);
             }
         }


### PR DESCRIPTION
This PR introduces the top level of fanout of 256. It also fixes a page leak where if there was more than 1k pages abandoned during a batch, the abandoned pages over 1k were leaked and no longer used.

### Paprika.Runner

The run of `Paprika.Runner` shows a massive reduction of disk size and no leakage at all.

#### Before (main)
```
Writing state of 1000 accounts per block through 2000 blocks, generated 2000000 accounts, used 4.76GB
Reading state of all of 2000000 accounts from the last block took 00:00:00.3171895
90th percentiles:
   - new pages allocated per block: 868
   - pages reused allocated per block: 1019
   - total pages written per block: 1887
 ```

#### After (main)

```
Writing state of 1000 accounts per block through 2000 blocks, generated 2000000 accounts, used 0.56GB
Reading state of all of 2000000 accounts from the last block took 00:00:00.2291687
90th percentiles:
   - new pages allocated per block: 0
   - pages reused allocated per block: 1235
   - total pages written per block: 1235
```

Resolves #22 
