### PR TITLE
Context uses NibblePath

### DIFF
--- a/src/Paprika.Tests/DataPageTests.cs
+++ b/src/Paprika.Tests/DataPageTests.cs
@@ -8,8 +8,6 @@ namespace Paprika.Tests;
 
 public class DataPageTests : BasePageTests
 {
-    private const byte RootLevel = 0;
-
     const uint BatchId = 1;
 
     [Test]
@@ -20,11 +18,11 @@ public class DataPageTests : BasePageTests
 
         var batch = NewBatch(BatchId);
         var dataPage = new DataPage(page);
-        var ctx = new SetContext(Key0, Balance0, Nonce0, batch);
+        var ctx = new SetContext(NibblePath.FromKey(Key0), Balance0, Nonce0, batch);
 
-        var updated = dataPage.Set(ctx, RootLevel);
+        var updated = dataPage.Set(ctx);
 
-        new DataPage(updated).GetAccount(Key0, batch, out var account, RootLevel);
+        new DataPage(updated).GetAccount(NibblePath.FromKey(Key0), batch, out var account);
 
         Assert.AreEqual(Nonce0, account.Nonce);
         Assert.AreEqual(Balance0, account.Balance);
@@ -38,14 +36,16 @@ public class DataPageTests : BasePageTests
 
         var batch = NewBatch(BatchId);
 
+        var path0 = NibblePath.FromKey(Key0);
+
         var dataPage = new DataPage(page);
-        var ctx1 = new SetContext(Key0, Balance0, Nonce0, batch);
-        var ctx2 = new SetContext(Key0, Balance1, Nonce1, batch);
+        var ctx1 = new SetContext(path0, Balance0, Nonce0, batch);
+        var ctx2 = new SetContext(path0, Balance1, Nonce1, batch);
 
-        var updated = dataPage.Set(ctx1, RootLevel);
-        updated = new DataPage(updated).Set(ctx2, RootLevel);
+        var updated = dataPage.Set(ctx1);
+        updated = new DataPage(updated).Set(ctx2);
 
-        new DataPage(updated).GetAccount(Key0, batch, out var account, RootLevel);
+        new DataPage(updated).GetAccount(path0, batch, out var account);
         Assert.AreEqual(Nonce1, account.Nonce);
         Assert.AreEqual(Balance1, account.Balance);
     }
@@ -59,17 +59,19 @@ public class DataPageTests : BasePageTests
         var batch = NewBatch(BatchId);
 
         var dataPage = new DataPage(page);
-        var ctx1 = new SetContext(Key1a, Balance0, Nonce0, batch);
-        var ctx2 = new SetContext(Key1b, Balance1, Nonce1, batch);
+        var path1A = NibblePath.FromKey(Key1a);
+        var path1B = NibblePath.FromKey(Key1b);
+        var ctx1 = new SetContext(path1A, Balance0, Nonce0, batch);
+        var ctx2 = new SetContext(path1B, Balance1, Nonce1, batch);
 
-        var updated = dataPage.Set(ctx1, RootLevel);
-        updated = new DataPage(updated).Set(ctx2, RootLevel);
+        var updated = dataPage.Set(ctx1);
+        updated = new DataPage(updated).Set(ctx2);
 
-        new DataPage(updated).GetAccount(Key1a, batch, out var account, RootLevel);
+        new DataPage(updated).GetAccount(path1A, batch, out var account);
         Assert.AreEqual(Nonce0, account.Nonce);
         Assert.AreEqual(Balance0, account.Balance);
 
-        new DataPage(updated).GetAccount(Key1b, batch, out account, RootLevel);
+        new DataPage(updated).GetAccount(path1B, batch, out account);
         Assert.AreEqual(Nonce1, account.Nonce);
         Assert.AreEqual(Balance1, account.Balance);
     }
@@ -90,8 +92,8 @@ public class DataPageTests : BasePageTests
             var key = Key1a;
             BinaryPrimitives.WriteUInt32LittleEndian(key.BytesAsSpan, i);
 
-            var ctx = new SetContext(key, i, i, batch);
-            dataPage = new DataPage(dataPage.Set(ctx, RootLevel));
+            var ctx = new SetContext(NibblePath.FromKey(key), i, i, batch);
+            dataPage = new DataPage(dataPage.Set(ctx));
         }
 
         for (uint i = 0; i < count; i++)
@@ -99,7 +101,7 @@ public class DataPageTests : BasePageTests
             var key = Key1a;
             BinaryPrimitives.WriteUInt32LittleEndian(key.BytesAsSpan, i);
 
-            dataPage.GetAccount(key, batch, out var account, RootLevel);
+            dataPage.GetAccount(NibblePath.FromKey(key), batch, out var account);
             account.Should().Be(new Account(i, i));
         }
     }
@@ -126,9 +128,9 @@ public class DataPageTests : BasePageTests
                 batch = batch.Next();
             }
 
-            var ctx = new SetContext(key, i, i, batch);
+            var ctx = new SetContext(NibblePath.FromKey(key), i, i, batch);
 
-            dataPage = new DataPage(dataPage.Set(ctx, RootLevel));
+            dataPage = new DataPage(dataPage.Set(ctx));
         }
 
         for (uint i = 0; i < count; i++)
@@ -136,7 +138,7 @@ public class DataPageTests : BasePageTests
             var key = Key1a;
             BinaryPrimitives.WriteUInt32LittleEndian(key.BytesAsSpan, i);
 
-            dataPage.GetAccount(key, batch, out var account, RootLevel);
+            dataPage.GetAccount(NibblePath.FromKey(key), batch, out var account);
             account.Should().Be(new Account(i, i));
         }
     }

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -247,7 +247,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             if (_disposed)
                 throw new ObjectDisposedException("The readonly batch has already been disposed");
 
-            var addr = RootPage.FindDataPage(_rootDataPages, key);
+            var addr = RootPage.FindAccountPage(_rootDataPages, key);
             if (addr.IsNull)
                 return default;
 
@@ -300,7 +300,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
         {
             CheckDisposed();
 
-            var addr = RootPage.FindDataPage(_root.Data.AccountPages, key);
+            var addr = RootPage.FindAccountPage(_root.Data.AccountPages, key);
 
             if (addr.IsNull)
             {
@@ -318,7 +318,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
         {
             CheckDisposed();
 
-            ref var addr = ref RootPage.FindDataPage(_root.Data.AccountPages, key);
+            ref var addr = ref RootPage.FindAccountPage(_root.Data.AccountPages, key);
             var page = addr.IsNull ? GetNewPage(out addr, true) : GetAt(addr);
 
             // treat as fanout page
@@ -618,7 +618,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
     // ReSharper disable once UnusedParameter.Global
     protected abstract void FlushRootPage(in Page rootPage);
 
-    private static NibblePath GetPath(Keccak key)
+    private static NibblePath GetPath(in Keccak key)
     {
         return NibblePath.FromKey(key).SliceFrom(RootPage.Payload.RootNibbleLevel);
     }

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -252,7 +252,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
                 return default;
 
             var dataPage = new FanOut256Page(GetAt(addr));
-            dataPage.GetAccount(key, this, out var account, RootPage.Payload.RootNibbleLevel);
+            dataPage.GetAccount(GetPath(key), this, out var account);
             return account;
         }
 
@@ -310,7 +310,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             // treat as data page
             var data = new FanOut256Page(_db.GetAt(addr));
 
-            data.GetAccount(key, this, out var account, RootPage.Payload.RootNibbleLevel);
+            data.GetAccount(GetPath(key), this, out var account);
             return account;
         }
 
@@ -321,12 +321,12 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             ref var addr = ref RootPage.FindDataPage(_root.Data.AccountPages, key);
             var page = addr.IsNull ? GetNewPage(out addr, true) : GetAt(addr);
 
-            // treat as data page
+            // treat as fanout page
             var data = new FanOut256Page(page);
 
-            var ctx = new SetContext(in key, account.Balance, account.Nonce, this);
+            var ctx = new SetContext(GetPath(key), account.Balance, account.Nonce, this);
 
-            var updated = data.Set(ctx, RootPage.Payload.RootNibbleLevel);
+            var updated = data.Set(ctx);
 
             addr = _db.GetAddress(updated);
         }
@@ -617,4 +617,9 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
 
     // ReSharper disable once UnusedParameter.Global
     protected abstract void FlushRootPage(in Page rootPage);
+
+    private static NibblePath GetPath(Keccak key)
+    {
+        return NibblePath.FromKey(key).SliceFrom(RootPage.Payload.RootNibbleLevel);
+    }
 }

--- a/src/Paprika/NibblePath.cs
+++ b/src/Paprika/NibblePath.cs
@@ -34,7 +34,15 @@ public readonly ref struct NibblePath
         return new NibblePath(key, nibbleFrom, count - nibbleFrom);
     }
 
-    public static NibblePath FromKey(Keccak key, int nibbleFrom = 0)
+    /// <summary>
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="nibbleFrom"></param>
+    /// <returns>
+    /// The Keccak needs to be "in" here, as otherwise a copy would be create and the ref
+    /// would point to a garbage memory.
+    /// </returns>
+    public static NibblePath FromKey(in Keccak key, int nibbleFrom = 0)
     {
         var count = Keccak.Size * NibblePerByte;
         return new NibblePath(key.BytesAsSpan, nibbleFrom, count - nibbleFrom);

--- a/src/Paprika/Pages/DataPage.cs
+++ b/src/Paprika/Pages/DataPage.cs
@@ -25,6 +25,8 @@ public readonly unsafe struct DataPage : IAccountPage
 
     public ref Payload Data => ref Unsafe.AsRef<Payload>(_page.Payload);
 
+    public const int NibbleCount = 1;
+
     /// <summary>
     /// Represents the data of this data page. This type of payload stores data in 16 nibble-addressable buckets.
     /// These buckets is used to store up to <see cref="FixedMapSize"/> entries before flushing them down as other pages
@@ -89,7 +91,7 @@ public readonly unsafe struct DataPage : IAccountPage
         if (address.IsNull == false && address.IsValidPageAddress)
         {
             var page = ctx.Batch.GetAt(address);
-            var updated = new DataPage(page).Set(ctx.TrimPath(1));
+            var updated = new DataPage(page).Set(ctx.TrimPath(NibbleCount));
 
             // remember the updated
             Data.Buckets[nibble] = ctx.Batch.GetAddress(updated);
@@ -125,7 +127,7 @@ public readonly unsafe struct DataPage : IAccountPage
         // non-null page jump, follow it!
         if (bucket.IsNull == false && bucket.IsValidPageAddress)
         {
-            new DataPage(batch.GetAt(bucket)).GetAccount(path, batch, out result);
+            new DataPage(batch.GetAt(bucket)).GetAccount(path.SliceFrom(NibbleCount), batch, out result);
             return;
         }
 

--- a/src/Paprika/Pages/FanOut256Page.cs
+++ b/src/Paprika/Pages/FanOut256Page.cs
@@ -37,17 +37,16 @@ public readonly unsafe struct FanOut256Page : IAccountPage
         public Span<DbAddress> Buckets => MemoryMarshal.CreateSpan(ref Bucket, BucketCount);
     }
 
-    public Page Set(in SetContext ctx, int level)
+    public Page Set(in SetContext ctx)
     {
         if (Header.BatchId != ctx.Batch.BatchId)
         {
             // the page is from another batch, meaning, it's readonly. Copy
             var writable = ctx.Batch.GetWritableCopy(_page);
-            return new FanOut256Page(writable).Set(ctx, level);
+            return new FanOut256Page(writable).Set(ctx);
         }
 
-        var path = NibblePath.FromKey(ctx.Key.BytesAsSpan, level);
-        var prefix = FirstTwoNibbles(path);
+        var prefix = FirstTwoNibbles(ctx.Path);
 
         var address = Data.Buckets[prefix];
 
@@ -55,13 +54,13 @@ public readonly unsafe struct FanOut256Page : IAccountPage
         {
             // no data page, allocate and set
             var page = ctx.Batch.GetNewPage(out address, true);
-            new DataPage(page).Set(ctx, level + NibbleCount);
+            new DataPage(page).Set(ctx.TrimPath(NibbleCount));
             Data.Buckets[prefix] = address;
         }
         else
         {
             var page = ctx.Batch.GetAt(address);
-            var updated = new DataPage(page).Set(ctx, level + NibbleCount);
+            var updated = new DataPage(page).Set(ctx.TrimPath(NibbleCount));
             Data.Buckets[prefix] = ctx.Batch.GetAddress(updated);
         }
 
@@ -76,9 +75,8 @@ public readonly unsafe struct FanOut256Page : IAccountPage
 
     private const int NibbleCount = 2;
 
-    public void GetAccount(in Keccak key, IReadOnlyBatchContext batch, out Account result, int level)
+    public void GetAccount(in NibblePath path, IReadOnlyBatchContext batch, out Account result)
     {
-        var path = NibblePath.FromKey(key.BytesAsSpan, level);
         var prefix = FirstTwoNibbles(path);
 
         var address = Data.Buckets[prefix];
@@ -90,7 +88,7 @@ public readonly unsafe struct FanOut256Page : IAccountPage
         else
         {
             var page = batch.GetAt(address);
-            new DataPage(page).GetAccount(key, batch, out result, level + NibbleCount);
+            new DataPage(page).GetAccount(path.SliceFrom(NibbleCount), batch, out result);
         }
     }
 }

--- a/src/Paprika/Pages/FanOut256Page.cs
+++ b/src/Paprika/Pages/FanOut256Page.cs
@@ -67,7 +67,7 @@ public readonly unsafe struct FanOut256Page : IAccountPage
         return _page;
     }
 
-    private static ushort FirstTwoNibbles(NibblePath path)
+    public static ushort FirstTwoNibbles(NibblePath path)
     {
         return (ushort)((path.GetAt(0) << NibblePath.NibbleShift * 0) +
                         (path.GetAt(1) << NibblePath.NibbleShift * 1));

--- a/src/Paprika/Pages/FixedMap.cs
+++ b/src/Paprika/Pages/FixedMap.cs
@@ -140,7 +140,7 @@ public readonly ref struct FixedMap
                 var data = NibblePath.ReadFrom(payload, out var key);
 
                 // copy with slice one
-                if (oneLevelDeeper.TrySet(key.SliceFrom(1), data) == false)
+                if (oneLevelDeeper.TrySet(key.SliceFrom(DataPage.NibbleCount), data) == false)
                 {
                     throw new Exception("There should always be space for in the nested map");
                 }

--- a/src/Paprika/Pages/Page.cs
+++ b/src/Paprika/Pages/Page.cs
@@ -18,9 +18,9 @@ public interface IPage
 
 public interface IAccountPage : IPage
 {
-    void GetAccount(in Keccak key, IReadOnlyBatchContext batch, out Account result, int level);
+    void GetAccount(in NibblePath key, IReadOnlyBatchContext batch, out Account result);
 
-    Page Set(in SetContext ctx, int level);
+    Page Set(in SetContext ctx);
 }
 
 /// <summary>

--- a/src/Paprika/Pages/RootPage.cs
+++ b/src/Paprika/Pages/RootPage.cs
@@ -94,7 +94,7 @@ public readonly unsafe struct RootPage : IPage
         }
     }
 
-    public static ref DbAddress FindDataPage(Span<DbAddress> dataPages, in Keccak key)
+    public static ref DbAddress FindAccountPage(Span<DbAddress> dataPages, in Keccak key)
     {
         var b = key.Span[0];
         return ref dataPages[b];

--- a/src/Paprika/Pages/SetContext.cs
+++ b/src/Paprika/Pages/SetContext.cs
@@ -13,7 +13,7 @@ public readonly ref struct SetContext
     public readonly UInt256 Balance;
     public readonly UInt256 Nonce;
 
-    public SetContext(in NibblePath path, in UInt256 balance, in UInt256 nonce, IBatchContext batch)
+    public SetContext(NibblePath path, UInt256 balance, UInt256 nonce, IBatchContext batch)
     {
         Path = path;
         Batch = batch;

--- a/src/Paprika/Pages/SetContext.cs
+++ b/src/Paprika/Pages/SetContext.cs
@@ -8,16 +8,18 @@ namespace Paprika.Pages;
 /// </summary>
 public readonly ref struct SetContext
 {
-    public readonly Keccak Key;
+    public readonly NibblePath Path;
     public readonly IBatchContext Batch;
     public readonly UInt256 Balance;
     public readonly UInt256 Nonce;
 
-    public SetContext(in Keccak keccak, in UInt256 balance, in UInt256 nonce, IBatchContext batch)
+    public SetContext(in NibblePath path, in UInt256 balance, in UInt256 nonce, IBatchContext batch)
     {
-        Key = keccak;
+        Path = path;
         Batch = batch;
         Balance = balance;
         Nonce = nonce;
     }
+
+    public SetContext TrimPath(int nibbleCount) => new(Path.SliceFrom(nibbleCount), Balance, Nonce, Batch);
 }


### PR DESCRIPTION
This PR simplifies the semantics of set and get operations. It does it by passing the `NibblePath` instead of the `Keccak` + `level` of the tree. It makes it simpler, more elegant and easier to work with.