### PR TITLE
In page buffer

### DIFF
--- a/src/Paprika.Tests/BasePageTests.cs
+++ b/src/Paprika.Tests/BasePageTests.cs
@@ -17,13 +17,13 @@ public abstract class BasePageTests
     {
         private readonly Dictionary<DbAddress, Page> _address2Page = new();
         private readonly Dictionary<UIntPtr, DbAddress> _page2Address = new();
+        private readonly HashSet<DbAddress> _written = new();
 
         // data pages should start at non-null addresses
         // 0-N is take by metadata pages
         private uint _pageCount = 1U;
 
         public TestBatchContext(uint batchId) : base(batchId) { }
-
 
         public override Page GetAt(DbAddress address) => _address2Page[address];
 
@@ -42,8 +42,12 @@ public abstract class BasePageTests
             _address2Page[addr] = page;
             _page2Address[page.Raw] = addr;
 
+            _written.Add(addr);
+
             return page;
         }
+
+        public override bool WrittenThisBatch(DbAddress address) => _written.Contains(address);
 
         protected override void RegisterForFutureReuse(Page page)
         {

--- a/src/Paprika/Db/BatchContextBase.cs
+++ b/src/Paprika/Db/BatchContextBase.cs
@@ -20,6 +20,8 @@ abstract class BatchContextBase : IBatchContext
 
     public abstract Page GetNewPage(out DbAddress addr, bool clear);
 
+    public abstract bool WrittenThisBatch(DbAddress address);
+
     /// <summary>
     /// If <paramref name="page"/> is already writable in this batch,
     /// returns the same page. If it's not, it will copy the page and return a new one.

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -283,7 +283,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
         private readonly Queue<DbAddress> _abandoned;
 
         private readonly HashSet<DbAddress> _written;
-        
+
         private readonly BatchMetrics _metrics;
 
         public Batch(PagedDb db, RootPage root, uint reusePagesOlderThanBatchId, Context ctx) : base(root.Header.BatchId)
@@ -409,9 +409,9 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
                 page.Clear();
 
             AssignBatchId(page);
-            
+
             _written.Add(addr);
-            
+
             return page;
         }
 

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -251,7 +251,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             if (addr.IsNull)
                 return default;
 
-            var dataPage = new FanOut256Page(GetAt(addr));
+            var dataPage = new DataPage(GetAt(addr));
             dataPage.GetAccount(GetPath(key), this, out var account);
             return account;
         }
@@ -311,7 +311,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             }
 
             // treat as data page
-            var data = new FanOut256Page(_db.GetAt(addr));
+            var data = new DataPage(_db.GetAt(addr));
 
             data.GetAccount(GetPath(key), this, out var account);
             return account;
@@ -324,8 +324,8 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             ref var addr = ref RootPage.FindAccountPage(_root.Data.AccountPages, key);
             var page = addr.IsNull ? GetNewPage(out addr, true) : GetAt(addr);
 
-            // treat as fanout page
-            var data = new FanOut256Page(page);
+            // treat as data page
+            var data = new DataPage(page);
 
             var ctx = new SetContext(GetPath(key), account.Balance, account.Nonce, this);
 

--- a/src/Paprika/Pages/DataPage.cs
+++ b/src/Paprika/Pages/DataPage.cs
@@ -76,7 +76,7 @@ public readonly unsafe struct DataPage : IAccountPage
     public Page Set(in SetContext ctx)
     {
         var batch = ctx.Batch;
-        
+
         if (Header.BatchId != batch.BatchId)
         {
             // the page is from another batch, meaning, it's readonly. Copy
@@ -115,16 +115,16 @@ public readonly unsafe struct DataPage : IAccountPage
         // First find the biggest bucket
         var biggestNibble = map.GetBiggestNibbleBucket();
 
-        ref var biggestBucket = ref Data.Buckets[biggestNibble]; 
-        
+        ref var biggestBucket = ref Data.Buckets[biggestNibble];
+
         // If address null, create new. If it exists, use as is.
         if (biggestBucket.IsNull)
         {
             batch.GetNewPage(out biggestBucket, true);
         }
-        
+
         var dataPage = new DataPage(batch.GetAt(biggestBucket));
-        
+
         foreach (var item in map.EnumerateNibble(biggestNibble))
         {
             // TODO: consider writing data once, so that they don't need to be serialized and deserialized

--- a/src/Paprika/Pages/IBatchContext.cs
+++ b/src/Paprika/Pages/IBatchContext.cs
@@ -19,6 +19,13 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// <param name="page"></param>
     /// <returns></returns>
     Page GetWritableCopy(Page page);
+
+    /// <summary>
+    /// Checks whether the given page was written in this batch.
+    /// </summary>
+    /// <param name="address"></param>
+    /// <returns></returns>
+    bool WrittenThisBatch(DbAddress address);
 }
 
 public interface IReadOnlyBatchContext : IPageResolver

--- a/src/Paprika/Pages/RootPage.cs
+++ b/src/Paprika/Pages/RootPage.cs
@@ -35,7 +35,7 @@ public readonly unsafe struct RootPage : IPage
         /// <summary>
         /// The number of nibbles that are "consumed" on the root level.
         /// </summary>
-        public const byte RootNibbleLevel = 2;
+        public const byte RootNibbleLevel = 1;
 
         private const int AbandonedPagesStart = sizeof(uint) + Keccak.Size + DbAddress.Size + DbAddress.Size * AccountPageFanOut;
 

--- a/src/Paprika/Pages/RootPage.cs
+++ b/src/Paprika/Pages/RootPage.cs
@@ -30,7 +30,7 @@ public readonly unsafe struct RootPage : IPage
         /// <summary>
         /// How big is the fan out for the root.
         /// </summary>
-        private const int AccountPageFanOut = 256;
+        private const int AccountPageFanOut = 16;
 
         /// <summary>
         /// The number of nibbles that are "consumed" on the root level.
@@ -96,7 +96,7 @@ public readonly unsafe struct RootPage : IPage
 
     public static ref DbAddress FindAccountPage(Span<DbAddress> accountPages, in Keccak key)
     {
-        var index = FanOut256Page.FirstTwoNibbles(NibblePath.FromKey(key));
+        var index = NibblePath.FromKey(key).FirstNibble;
         return ref accountPages[index];
     }
 


### PR DESCRIPTION
This is a speculative experimental PR that uses in-page buffer to amortize the cost of IO. Previously a `DataPage` flushed one of its buckets, it was no longer storing keys with the given nibble. With this PR it does and flushes occasionally, whenever the in-page `FixedMap` is full. 

### Drawbacks

The drawback is that it will probably make the Merkle part terribly hard. Do not merge now.

### Benchmarks

Results:
- number of pages used by block: ~300 
    - 75% drop from previous 1857
    - this means effectively only ~1.2MB of writes per block
    - the number of pages per block does not change with the number of accounts getting bigger! remains constant. This is a big win as it's a good indicator for bigger data sets!
    - SSDs will last longer (1/4 of writes)
    - flushes are faster
- flush to disk: 0.11 s
    - ~50% drop from previous 0.2 s
- disk size: 4.17GB
    - 20% increase from previous 3.33GB
    - it's the least measurable as no assertion over how pages are filled, requires clarifying