### PR TITLE
Benchmarks

### DIFF
--- a/src/Paprika.Benchmarks/FixedMapBenchmarks.cs
+++ b/src/Paprika.Benchmarks/FixedMapBenchmarks.cs
@@ -1,0 +1,51 @@
+﻿using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Disassemblers;
+using Paprika.Pages;
+
+namespace Paprika.Benchmarks;
+
+public class FixedMapBenchmarks
+{
+    private readonly byte[] _data = new byte[Page.PageSize];
+    private readonly int _to;
+
+    public FixedMapBenchmarks()
+    {
+        var map = new FixedMap(_data);
+
+        Span<byte> key = stackalloc byte[4];
+
+        // fill 
+        while (true)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(key, _to);
+            var path = NibblePath.FromKey(key);
+            if (map.TrySet(FixedMap.Key.Account(path), key) == false)
+            {
+                // filled
+                break;
+            }
+
+            _to++;
+        }
+    }
+
+    [Benchmark]
+    public int Read_all_keys()
+    {
+        var map = new FixedMap(_data);
+        Span<byte> key = stackalloc byte[4];
+        for (var i = 0; i < _to; i++)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(key, i);
+            var path = NibblePath.FromKey(key);
+            if (map.TryGet(FixedMap.Key.Account(path), out var data) == false)
+            {
+                return i;
+            }
+        }
+
+        return _to;
+    }
+}

--- a/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
+++ b/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Paprika\Paprika.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Paprika.Benchmarks/Program.cs
+++ b/src/Paprika.Benchmarks/Program.cs
@@ -1,0 +1,11 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using BenchmarkDotNet.Running;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var summary = BenchmarkRunner.Run(typeof(Program).Assembly);
+    }
+}

--- a/src/Paprika.sln
+++ b/src/Paprika.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Tests", "Paprika.Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Runner", "Paprika.Runner\Paprika.Runner.csproj", "{BFF87BF1-D687-4EBF-B60C-3B67184A8A7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Benchmarks", "Paprika.Benchmarks\Paprika.Benchmarks.csproj", "{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{BFF87BF1-D687-4EBF-B60C-3B67184A8A7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BFF87BF1-D687-4EBF-B60C-3B67184A8A7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BFF87BF1-D687-4EBF-B60C-3B67184A8A7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR introduces `BenchmarkDotNet` and uses it as an excuse to provide a `FixedMap` benchmark. Then, it optimizes the search over the map.

```
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1555/22H2/2022Update/SunValley2)
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.105
  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2


|        Method |     Mean |     Error |    StdDev |
|-------------- |---------:|----------:|----------:|
| Read_all_keys (before) | 45.83 us | 3.887 us | 11.46 us | 50.91 us |
| Read_all_keys (after) | 8.075 us | 0.0591 us | 0.0524 us |
```


Resolves #24 