### PR TITLE
Fixedmap optimizations

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -16,7 +16,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = 30_000;
+    private const int BlockCount = 50_000;
     private const int RandomSampleSize = 260_000_000;
     private const int AccountsPerBlock = 1000;
 
@@ -24,7 +24,7 @@ public static class Program
 
     private const int NumberOfLogs = 10;
 
-    private const long DbFileSize = 8 * Gb;
+    private const long DbFileSize = 18 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
     private const CommitOptions Commit = CommitOptions.FlushDataOnly;
     private const int LogEvery = BlockCount / NumberOfLogs;

--- a/src/Paprika.Tests/DataPageTests.cs
+++ b/src/Paprika.Tests/DataPageTests.cs
@@ -86,10 +86,12 @@ public class DataPageTests : BasePageTests
 
         const int count = 1 * 1024 * 1024;
 
+        const int offset = 0x12345678;
+
         for (uint i = 0; i < count; i++)
         {
             var key = Key1a;
-            BinaryPrimitives.WriteUInt32LittleEndian(key.BytesAsSpan, i);
+            BinaryPrimitives.WriteUInt32LittleEndian(key.BytesAsSpan, i + offset);
 
             dataPage = new DataPage(dataPage.SetAccount(NibblePath.FromKey(key), new Account(i, i), batch));
         }
@@ -97,7 +99,7 @@ public class DataPageTests : BasePageTests
         for (uint i = 0; i < count; i++)
         {
             var key = Key1a;
-            BinaryPrimitives.WriteUInt32LittleEndian(key.BytesAsSpan, i);
+            BinaryPrimitives.WriteUInt32LittleEndian(key.BytesAsSpan, i + offset);
 
             var account = dataPage.GetAccount(NibblePath.FromKey(key), batch);
             account.Should().Be(new Account(i, i));

--- a/src/Paprika.Tests/FixedMapTests.cs
+++ b/src/Paprika.Tests/FixedMapTests.cs
@@ -65,9 +65,11 @@ public class FixedMapTests
 
         e.MoveNext().Should().BeTrue();
         e.Current.Key.Path.ToString().Should().Be(path0.ToString());
+        e.Current.RawData.SequenceEqual(Data0).Should().BeTrue();
 
         e.MoveNext().Should().BeTrue();
         e.Current.Key.Path.ToString().Should().Be(path1.ToString());
+        e.Current.RawData.SequenceEqual(Data1).Should().BeTrue();
 
         e.MoveNext().Should().BeFalse();
     }

--- a/src/Paprika.Tests/FixedMapTests.cs
+++ b/src/Paprika.Tests/FixedMapTests.cs
@@ -7,10 +7,10 @@ namespace Paprika.Tests;
 
 public class FixedMapTests
 {
-    private static NibblePath Key0 => NibblePath.FromKey(new byte[] { 1, 2, 3, 5, 6 });
+    private static NibblePath Key0 => NibblePath.FromKey(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x90 });
 
     private static ReadOnlySpan<byte> Data0 => new byte[] { 23 };
-    private static NibblePath Key1 => NibblePath.FromKey(new byte[] { 1, 2, 3, 5, 7 });
+    private static NibblePath Key1 => NibblePath.FromKey(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x99 });
     private static ReadOnlySpan<byte> Data1 => new byte[] { 29, 31 };
     private static NibblePath Key2 => NibblePath.FromKey(new byte[] { 19, 21, 23, 29, 23 });
     private static ReadOnlySpan<byte> Data2 => new byte[] { 37, 39 };
@@ -38,6 +38,27 @@ public class FixedMapTests
         map.TrySet(FixedMap.Key.Account(Key1), Data1).Should().BeTrue("Should have memory after previous delete");
 
         map.GetAssert(FixedMap.Key.Account(Key1), Data1);
+    }
+    
+    [Test]
+    public void Enumerate_nibble()
+    {
+        Span<byte> span = stackalloc byte[256];
+        var map = new FixedMap(span);
+
+        var key0 = FixedMap.Key.Account(Key0);
+        var key1 = FixedMap.Key.Account(Key1);
+        
+        map.SetAssert(key0, Data0);
+        map.SetAssert(key1, Data1);
+
+        Console.WriteLine($"Expected keys: {key0.Path.ToString()} and {key1.Path.ToString()}");
+        Console.WriteLine("Actual: ");
+        
+        foreach (var item in map.EnumerateNibble(key0.Path.FirstNibble))
+        {
+            Console.WriteLine(item.Key.Path.ToString());
+        }
     }
 
     [Test]
@@ -88,33 +109,6 @@ public class FixedMapTests
         map.SetAssert(FixedMap.Key.Account(Key0), Data2);
 
         map.GetAssert(FixedMap.Key.Account(Key0), Data2);
-    }
-
-    [Test]
-    public void Enumerator()
-    {
-        Span<byte> span = stackalloc byte[256];
-        var map = new FixedMap(span);
-
-        map.SetAssert(FixedMap.Key.Account(Key0), Data0);
-        map.SetAssert(FixedMap.Key.Account(Key1), Data1);
-        map.SetAssert(FixedMap.Key.Account(Key2), Data2);
-
-        map.Delete(FixedMap.Key.Account(Key1)); // delete K1 to not observe it during the iteration
-
-        var e = map.GetEnumerator();
-
-        Next(ref e, Key0, Data0);
-        Next(ref e, Key2, Data2);
-
-        e.MoveNext().Should().BeFalse();
-
-        static void Next(ref FixedMap.Enumerator e, NibblePath key, ReadOnlySpan<byte> data)
-        {
-            e.MoveNext().Should().BeTrue();
-            e.Current.Path.Equals(key).Should().BeTrue();
-            e.Current.Data.SequenceEqual(data).Should().BeTrue();
-        }
     }
 
     [Test]

--- a/src/Paprika.Tests/NibblePathTests.cs
+++ b/src/Paprika.Tests/NibblePathTests.cs
@@ -194,4 +194,27 @@ public class NibblePathTests
         var path = NibblePath.FromKey(stackalloc byte[] { 0x12, 0x34, 0x56 }, odd ? 1 : 0);
         Assert.AreEqual(result, path.GetAt(at));
     }
+
+    [TestCase(0, 4)]
+    [TestCase(0, 3)]
+    [TestCase(1, 3)]
+    [TestCase(1, 2)]
+    public void Write_and_read(int from, int length)
+    {
+        const byte data = 253;
+        var raw = new byte[] { 0x12, 0x34 };
+        var path = NibblePath.FromKey(raw).SliceFrom(from).SliceTo(length);
+
+        Span<byte> span = stackalloc byte[path.MaxByteLength + 1];
+        var written = path.WriteTo(span);
+        span[written.Length] = data;
+
+        var left = NibblePath.ReadFrom(span.Slice(0, written.Length + 1), out var actual);
+
+        // assert
+        actual.ToString().Should().Be(path.ToString());
+
+        left.Length.Should().Be(1);
+        left[0].Should().Be(data);
+    }
 }

--- a/src/Paprika/Crypto/KeccakHash.cs
+++ b/src/Paprika/Crypto/KeccakHash.cs
@@ -44,10 +44,6 @@ public sealed class KeccakHash
         0x8000000000008080UL, 0x0000000080000001UL, 0x8000000080008008UL
     };
 
-    private byte[]? _hash;
-    private int _remainderLength;
-    private int _roundSize;
-
     private static int GetRoundSize(int hashSize) => checked(STATE_SIZE - 2 * hashSize);
 
     // update the state with given number of rounds

--- a/src/Paprika/NibblePath.cs
+++ b/src/Paprika/NibblePath.cs
@@ -138,12 +138,10 @@ public readonly ref struct NibblePath
     /// <summary>
     /// Moves into arbitrary direction. 
     /// </summary>
-    /// <param name="nibble"></param>
-    /// <param name="value"></param>
-    public void UnsafeSetAt(int nibble, byte value)
+    public void UnsafeSetAt(int nibble, byte countOdd, byte value)
     {
         ref var b = ref Unsafe.Add(ref _span, (nibble + _odd) / 2);
-        var shift = GetShift(nibble);
+        var shift = GetShift(nibble + countOdd);
         var mask = NibbleMask << shift;
 
         b = (byte)((b & ~mask) | (value << shift));

--- a/src/Paprika/Pages/FixedMap.cs
+++ b/src/Paprika/Pages/FixedMap.cs
@@ -289,12 +289,13 @@ public readonly ref struct FixedMap
 
                 if (count == 0)
                 {
+                    // no nibbles stored in the slot, read as is.
                     data = NibblePath.ReadFrom(span, out path);
                 }
                 else
                 {
                     // there's at least one nibble extracted
-                    var raw = NibblePath.RawExtract(span, out var odd);
+                    var raw = NibblePath.RawExtract(span);
 
                     const int space = 2;
 
@@ -305,9 +306,6 @@ public readonly ref struct FixedMap
                     raw.CopyTo(pathDestination);
 
                     data = NibblePath.ReadFrom(pathDestination, out path);
-
-                    bytes[0] = 0xFE;
-                    bytes[1] = 0xFF;
 
                     var countOdd = (byte)(count & 1);
                     for (var i = 0; i < count; i++)

--- a/src/Paprika/Pages/FixedMap.cs
+++ b/src/Paprika/Pages/FixedMap.cs
@@ -305,7 +305,7 @@ public readonly ref struct FixedMap
                     var pathDestination = bytes.Slice(space);
                     raw.CopyTo(pathDestination);
 
-                    data = NibblePath.ReadFrom(pathDestination, out path);
+                    data = NibblePath.ReadFrom(span, out path);
 
                     var countOdd = (byte)(count & 1);
                     for (var i = 0; i < count; i++)

--- a/src/Paprika/Pages/FixedMap.cs
+++ b/src/Paprika/Pages/FixedMap.cs
@@ -309,9 +309,10 @@ public readonly ref struct FixedMap
                     bytes[0] = 0xFE;
                     bytes[1] = 0xFF;
 
+                    var countOdd = (byte)(count & 1);
                     for (var i = 0; i < count; i++)
                     {
-                        path.UnsafeSetAt(i - count - 1, nibbles[i]);
+                        path.UnsafeSetAt(i - count - 1, countOdd, nibbles[i]);
                     }
 
                     path = path.CopyWithUnsafePointerMoveBack(count);

--- a/src/Paprika/Pages/FixedMap.cs
+++ b/src/Paprika/Pages/FixedMap.cs
@@ -296,6 +296,7 @@ public readonly ref struct FixedMap
                 {
                     // there's at least one nibble extracted
                     var raw = NibblePath.RawExtract(span);
+                    data = span.Slice(raw.Length);
 
                     const int space = 2;
 
@@ -305,7 +306,9 @@ public readonly ref struct FixedMap
                     var pathDestination = bytes.Slice(space);
                     raw.CopyTo(pathDestination);
 
-                    data = NibblePath.ReadFrom(span, out path);
+                    // Terribly unsafe region!
+                    // Operate on the copy, pathDestination, as it will be overwritten with unsafe ref.
+                    NibblePath.ReadFrom(pathDestination, out path);
 
                     var countOdd = (byte)(count & 1);
                     for (var i = 0; i < count; i++)


### PR DESCRIPTION
This PR optimizes `FixedMap` component internal encoding of data, so that more entries can be packed into a single map. This PR **lowers the disk space by total 10%**.

Changes introduced:

1. The length of size reduced to one byte. The size of length reduced from 2 bytes to 1 byte as no entry will ever be more than 255 bytes long. This gives savings ~5%.
2. The prefix extraction and encoding. This removes 1 or 2 bytes per entry as well, but required crazy unsafe ref magic over enumerator.

#### Before

```
Using in-memory DB for greater speed.
Initializing db of size 18GB
Starting benchmark with commit level FlushDataOnly
Preparing random accounts addresses...
Accounts prepared

(P) - 90th percentile of the value

At Block        | Avg. speed      | Space used      | New pages(P)    | Pages reused(P) | Total pages(P)
           5000 |  892.0 blocks/s |          2.35GB |            1606 |             188 |            1733
          10000 |  713.3 blocks/s |          3.58GB |            1917 |             171 |            1962
          15000 |  684.2 blocks/s |          4.06GB |            2042 |             157 |            2063
          20000 |  661.6 blocks/s |          4.31GB |            2111 |             143 |            2121
          25000 |  639.4 blocks/s |          4.60GB |            2147 |             129 |            2163
          30000 |  620.2 blocks/s |          5.42GB |            2181 |             116 |            2219
          35000 |  564.8 blocks/s |          7.38GB |            2205 |             127 |            2293
          40000 |  523.8 blocks/s |         10.37GB |            2241 |             158 |            2385
          45000 |  499.8 blocks/s |         13.79GB |            2299 |             177 |            2475
          49999 |  489.7 blocks/s |         17.13GB |            2365 |             184 |            2545

Writing state of 1000 accounts per block, each with 1 storage, through 50000 blocks, generated 50000000 accounts, used 17.13GB

Reading and asserting values...
Reading state of all of 50000000 accounts from the last block took 00:00:35.0334893
90th percentiles:
   - new pages allocated per block: 0
   - pages reused allocated per block: 1239
   - total pages written per block: 1244
```

#### After one-byte length

```
Using in-memory DB for greater speed.
Initializing db of size 18GB
Starting benchmark with commit level FlushDataOnly
Preparing random accounts addresses...
Accounts prepared

(P) - 90th percentile of the value

At Block        | Avg. speed      | Space used      | New pages(P)    | Pages reused(P) | Total pages(P)
           5000 |  873.9 blocks/s |          2.34GB |            1605 |             187 |            1730
          10000 |  705.7 blocks/s |          3.58GB |            1915 |             170 |            1960
          15000 |  679.5 blocks/s |          4.05GB |            2041 |             156 |            2063
          20000 |  656.4 blocks/s |          4.29GB |            2107 |             142 |            2119
          25000 |  629.4 blocks/s |          4.54GB |            2143 |             129 |            2155
          30000 |  613.4 blocks/s |          5.19GB |            2177 |             116 |            2207
          35000 |  541.7 blocks/s |          6.88GB |            2199 |             118 |            2273
          40000 |  487.9 blocks/s |          9.70GB |            2231 |             151 |            2365
          45000 |  486.9 blocks/s |         13.11GB |            2287 |             174 |            2457
          49999 |  496.1 blocks/s |         16.56GB |            2353 |             184 |            2535

Writing state of 1000 accounts per block, each with 1 storage, through 50000 blocks, generated 50000000 accounts, used 16.56GB

Reading and asserting values...
Reading state of all of 50000000 accounts from the last block took 00:00:34.3674436
90th percentiles:
   - new pages allocated per block: 0
   - pages reused allocated per block: 1239
   - total pages written per block: 1244
```

### After prefix extraction


```
Using in-memory DB for greater speed.
Initializing db of size 18GB
Starting benchmark with commit level FlushDataOnly
Preparing random accounts addresses...
Accounts prepared

(P) - 90th percentile of the value

At Block        | Avg. speed      | Space used      | New pages(P)    | Pages reused(P) | Total pages(P)
           5000 |  771.9 blocks/s |          2.30GB |            1593 |             185 |            1720
          10000 |  672.3 blocks/s |          3.55GB |            1909 |             169 |            1954
          15000 |  634.6 blocks/s |          4.03GB |            2036 |             154 |            2057
          20000 |  581.8 blocks/s |          4.28GB |            2103 |             141 |            2115
          25000 |  610.8 blocks/s |          4.51GB |            2143 |             128 |            2155
          30000 |  595.9 blocks/s |          5.01GB |            2175 |             115 |            2199
          35000 |  535.0 blocks/s |          6.42GB |            2195 |             110 |            2257
          40000 |  503.5 blocks/s |          8.98GB |            2223 |             140 |            2341
          45000 |  471.7 blocks/s |         12.18GB |            2273 |             165 |            2433
          49999 |  464.2 blocks/s |         15.48GB |            2337 |             175 |            2509

Writing state of 1000 accounts per block, each with 1 storage, through 50000 blocks, generated 50000000 accounts, used 15.48GB

Reading and asserting values...
Reading state of all of 50000000 accounts from the last block took 00:00:33.6083939
90th percentiles:
   - new pages allocated per block: 0
   - pages reused allocated per block: 1239
   - total pages written per block: 1244
```