### PR TITLE
Massive fanout improvement

### DIFF
--- a/src/Paprika/Pages/DataPage.cs
+++ b/src/Paprika/Pages/DataPage.cs
@@ -131,8 +131,8 @@ public readonly unsafe struct DataPage : IDataPage
 
             dataPage = new DataPage(dataPage.Set(set));
 
-            // delete the item, it's possible due to the internal construction of the map
-            map.Delete(item.Key);
+            // use the special delete for the item that is much faster than map.Delete(item.Key);
+            map.Delete(item);
         }
 
         Data.Buckets[biggestNibble] = childAddr;

--- a/src/Paprika/Pages/FixedMap.cs
+++ b/src/Paprika/Pages/FixedMap.cs
@@ -225,7 +225,7 @@ public readonly ref struct FixedMap
 
     private int To => _header.Low / Slot.Size;
 
-    public NibbleEnumerator EnumerateNibble(byte nibble) => new(in this, nibble);
+    public NibbleEnumerator EnumerateNibble(byte nibble) => new(this, nibble);
 
     public ref struct NibbleEnumerator
     {
@@ -242,7 +242,7 @@ public readonly ref struct FixedMap
 
         private readonly byte[] _bytes;
 
-        internal NibbleEnumerator(in FixedMap map, byte nibble)
+        internal NibbleEnumerator(FixedMap map, byte nibble)
         {
             _map = map;
             _nibble = nibble;


### PR DESCRIPTION
This PR introduces a massive performance improvements of **10% or more**, for payloads that require a `DataPage` to fanout one of the nibbles as a child page. It does it by deleting migrated items not by the usual `FixedMap.Delete(key)` that performs a lookup, but by the newly introduced `FixedMap.Delete(NibbleEnumerator.Item)`. The `NibbleEnumerator.Item` is modified so that it memoizes the index if the delete is needed.

```
Using in-memory DB for greater speed.
Initializing db of size 18GB
Starting benchmark with commit level FlushDataOnly
Preparing random accounts addresses...
Accounts prepared

(P) - 90th percentile of the value

At Block        | Avg. speed      | Space used      | New pages(P)    | Pages reused(P) | Total pages(P)
           5000 |  817.1 blocks/s |          2.30GB |            1593 |             185 |            1720
          10000 |  706.6 blocks/s |          3.55GB |            1909 |             169 |            1954
          15000 |  652.9 blocks/s |          4.03GB |            2036 |             154 |            2057
          20000 |  627.0 blocks/s |          4.28GB |            2103 |             141 |            2115
          25000 |  632.7 blocks/s |          4.51GB |            2143 |             128 |            2155
          30000 |  622.6 blocks/s |          5.01GB |            2175 |             115 |            2199
          35000 |  590.8 blocks/s |          6.42GB |            2195 |             110 |            2257
          40000 |  541.7 blocks/s |          8.98GB |            2223 |             140 |            2341
          45000 |  510.7 blocks/s |         12.18GB |            2273 |             165 |            2433
          49999 |  494.4 blocks/s |         15.48GB |            2337 |             175 |            2509
```