### PR TITLE
Massive storage trees

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -1,5 +1,4 @@
 ﻿// #define PERSISTENT_DB
-#define STORAGE
 
 using System.Buffers.Binary;
 using System.Diagnostics;
@@ -29,8 +28,11 @@ public static class Program
     private const CommitOptions Commit = CommitOptions.FlushDataOnly;
     private const int LogEvery = BlockCount / NumberOfLogs;
 
+    private const bool UseStorage = true;
+
     public static void Main(String[] args)
     {
+
 #if PERSISTENT_DB
         var dir = Directory.GetCurrentDirectory();
         var dataPath = Path.Combine(dir, "db");
@@ -96,11 +98,14 @@ public static class Program
                 var key = GetAccountKey(random, counter);
 
                 batch.Set(key, GetAccountValue(counter));
-#if STORAGE               
-                var storage = GetStorageAddress(counter);
-                var storageValue = GetStorageValue(counter);
-                batch.SetStorage(key, storage, storageValue);
-#endif
+
+                if (UseStorage)
+                {
+                    var storage = GetStorageAddress(counter);
+                    var storageValue = GetStorageValue(counter);
+                    batch.SetStorage(key, storage, storageValue);
+                }
+
                 counter++;
             }
 
@@ -116,9 +121,15 @@ public static class Program
         ReportProgress(BlockCount - 1, writing);
 
         Console.WriteLine();
-        Console.WriteLine(
-            "Writing state of {0} accounts per block, each with 1 storage, through {1} blocks, generated {2} accounts, used {3:F2}GB",
-            AccountsPerBlock, BlockCount, counter, db.ActualMegabytesOnDisk / 1024);
+        Console.WriteLine("Writing in numbers:");
+        Console.WriteLine("- {0} accounts per block", AccountsPerBlock);
+        if (UseStorage)
+        {
+            Console.WriteLine("- each with 1 storage slot");
+        }
+        Console.WriteLine("- through {0} blocks ", BlockCount);
+        Console.WriteLine("- generated accounts total number: {0} ", counter);
+        Console.WriteLine("- space used: {0:F2}GB ", db.ActualMegabytesOnDisk / 1024);
 
         // reading
         Console.WriteLine();

--- a/src/Paprika.Tests/DbTests.cs
+++ b/src/Paprika.Tests/DbTests.cs
@@ -221,7 +221,7 @@ public class DbTests
     }
 
     [Test]
-    [Ignore("Will be fixed in a separate PR")]
+    //[Ignore("Will be fixed in a separate PR")]
     public void State_and_storage()
     {
         const int size = MB16;

--- a/src/Paprika.Tests/DbTests.cs
+++ b/src/Paprika.Tests/DbTests.cs
@@ -221,7 +221,6 @@ public class DbTests
     }
 
     [Test]
-    //[Ignore("Will be fixed in a separate PR")]
     public void State_and_storage()
     {
         const int size = MB16;

--- a/src/Paprika/NibblePath.cs
+++ b/src/Paprika/NibblePath.cs
@@ -28,6 +28,8 @@ public readonly ref struct NibblePath
     private readonly ref byte _span;
     private readonly byte _odd;
 
+    public static NibblePath Empty => default;
+
     public static NibblePath FromKey(ReadOnlySpan<byte> key, int nibbleFrom = 0)
     {
         var count = key.Length * NibblePerByte;

--- a/src/Paprika/Pages/DbAddress.cs
+++ b/src/Paprika/Pages/DbAddress.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Buffers.Binary;
+using System.Diagnostics;
 
 namespace Paprika.Pages;
 
@@ -85,4 +86,8 @@ public readonly struct DbAddress : IEquatable<DbAddress>
     public override bool Equals(object? obj) => obj is DbAddress other && Equals(other);
 
     public override int GetHashCode() => (int)_value;
+
+    public static DbAddress Read(ReadOnlySpan<byte> data) => new(BinaryPrimitives.ReadUInt32LittleEndian(data));
+
+    public void Write(Span<byte> destination) => BinaryPrimitives.WriteUInt32LittleEndian(destination, _value);
 }

--- a/src/Paprika/Pages/FixedMap.cs
+++ b/src/Paprika/Pages/FixedMap.cs
@@ -223,7 +223,10 @@ public readonly ref struct FixedMap
         return true;
     }
 
-    private int To => _header.Low / Slot.Size;
+    /// <summary>
+    /// Gets how many slots are used in the map.
+    /// </summary>
+    public int Count => _header.Low / Slot.Size;
 
     public NibbleEnumerator EnumerateNibble(byte nibble) => new(this, nibble);
 
@@ -255,7 +258,7 @@ public readonly ref struct FixedMap
         public bool MoveNext()
         {
             int index = _index + 1;
-            var to = _map.To;
+            var to = _map.Count;
 
             while (index < to &&
                    (_map._slots[index].IsDeleted ||
@@ -471,7 +474,7 @@ public readonly ref struct FixedMap
     private void CollectTombstones()
     {
         // start with the last written and perform checks and cleanup till all the deleted are gone
-        var index = To - 1;
+        var index = Count - 1;
 
         while (index >= 0 && _slots[index].IsDeleted)
         {


### PR DESCRIPTION
This PR introduces a notion of a massive storage tree. Usually, for accounts that have a small number of storage slots occupied, the entries are kept in `FixedMap` in the page, just beside the account data. When a page is mostly filled with storage slots of the given account though, Paprika optimizes it by planting a new tree responsible for storing information only about the storage slots for the given account. This, for accounts with millions of slots occupied is a game changer.