### PR TITLE
Var lengths NibblePath storage

### DIFF
--- a/src/Paprika/Data/FixedMap.cs
+++ b/src/Paprika/Data/FixedMap.cs
@@ -87,7 +87,7 @@ public readonly ref struct FixedMap
         /// [pathToNode, 6]-> the node hash. Please, mind the fact that storage trie can use this internally as well,
         /// with no need of the path.
         /// </summary>
-        // Keccak = 6,
+        KeccakOrRlp = 6,
 
         Deleted = 7,
         // one bit more is possible as delete is now a data type
@@ -149,17 +149,25 @@ public readonly ref struct FixedMap
         public static Key StorageCell(NibblePath path, ReadOnlySpan<byte> keccak) =>
             new(path, DataType.StorageCell, keccak);
 
+        /// <summary>
+        /// Builds the key identifying the value of the <see cref="DbAddress"/> for the root of the storage tree.
+        /// </summary>
         public static Key StorageTreeRootPageAddress(NibblePath path) =>
             new(path, DataType.StorageTreeRootPageAddress, ReadOnlySpan<byte>.Empty);
 
         /// <summary>
         /// Treat the additional key as the key and drop the additional notion.
         /// </summary>
-        /// <param name="originalKey"></param>
-        /// <returns></returns>
         public static Key StorageTreeStorageCell(Key originalKey) =>
             new(NibblePath.FromKey(originalKey.AdditionalKey), DataType.StorageTreeStorageCell,
                 ReadOnlySpan<byte>.Empty);
+
+        /// <summary>
+        /// Builds the key responsible for storing the encoded RLP or Keccak (if len(RLP) >= 32) for
+        /// a node with the given <see cref="NibblePath"/>.
+        /// </summary>
+        public static Key KeccakOrRlp(NibblePath path) =>
+            new(path, DataType.KeccakOrRlp, ReadOnlySpan<byte>.Empty);
 
         public Key SliceFrom(int nibbles) => new(Path.SliceFrom(nibbles), Type, AdditionalKey);
 

--- a/src/Paprika/Data/FixedMap.cs
+++ b/src/Paprika/Data/FixedMap.cs
@@ -289,6 +289,7 @@ public readonly ref struct FixedMap
 
             while (index < to &&
                    (_map._slots[index].Type == DataType.Deleted ||
+                    _map._slots[index].NibbleCount == 0 ||
                     _map._slots[index].FirstNibbleOfPrefix != _nibble))
             {
                 index += 1;
@@ -402,7 +403,9 @@ public readonly ref struct FixedMap
         for (var i = 0; i < to; i++)
         {
             ref readonly var slot = ref _slots[i];
-            if (slot.Type != DataType.Deleted)
+
+            // extract only not deleted and these which have at least one nibble
+            if (slot.Type != DataType.Deleted && slot.NibbleCount > 0)
             {
                 slotCount++;
 
@@ -736,7 +739,12 @@ public readonly ref struct FixedMap
             }
         }
 
-        public byte FirstNibbleOfPrefix => (byte)(Prefix & 0x0F);
+        public byte FirstNibbleOfPrefix => (byte)(Prefix & Mask0);
+
+        /// <summary>
+        /// Gets the nibble count encoded in the prefix
+        /// </summary>
+        public int NibbleCount => Prefix >> NibbleCountShift;
 
         public override string ToString()
         {


### PR DESCRIPTION
A preliminary work required for storing `Keccak` hashes of the intermediate nodes. This PR ensures that `FixedMap.Key` that have a `NibblePath` of zero length, will be stored in-page and not 💥 the extraction of the most frequent nibble. Effectively, for future `Keccak` storage, it means that `Keccaks` can be stored in an agnostic manner in the tree. They should also not create much overhead on the tree as well. The toggling in the future might be needed to pull the Keccak a bit higher if pages are too full.