### PR TITLE
Written pages tracking

### DIFF
--- a/src/Paprika.Tests/BasePageTests.cs
+++ b/src/Paprika.Tests/BasePageTests.cs
@@ -45,6 +45,9 @@ public abstract class BasePageTests
             return page;
         }
 
+        // for now
+        public override bool WasWritten(DbAddress addr) => true;
+
         protected override void RegisterForFutureReuse(Page page)
         {
             // NOOP

--- a/src/Paprika/Data/IBatchContext.cs
+++ b/src/Paprika/Data/IBatchContext.cs
@@ -21,6 +21,11 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// <param name="page"></param>
     /// <returns></returns>
     Page GetWritableCopy(Page page);
+
+    /// <summary>
+    /// Checks whether the page was written during this batch.
+    /// </summary>
+    bool WasWritten(DbAddress addr);
 }
 
 public interface IReadOnlyBatchContext : IPageResolver

--- a/src/Paprika/Db/BatchContextBase.cs
+++ b/src/Paprika/Db/BatchContextBase.cs
@@ -40,6 +40,8 @@ abstract class BatchContextBase : IBatchContext
         return @new;
     }
 
+    public abstract bool WasWritten(DbAddress addr);
+
     /// <summary>
     /// Registers the given page for future GC.
     /// </summary>


### PR DESCRIPTION
This PR introduces tracking for the pages written within the given batch. Additionally a check whether the page `WasWritten` is added to the context so that a page can be checked without fetching it.