### PR TITLE
In-page buffer

### DIFF
--- a/src/Paprika/Data/DataPage.cs
+++ b/src/Paprika/Data/DataPage.cs
@@ -92,8 +92,8 @@ public readonly unsafe struct DataPage : IDataPage
             var nibble = path.FirstNibble;
             var address = Data.Buckets[nibble];
 
-            // the bucket is not null and represents a page jump, follow it
-            if (address.IsNull == false && address.IsValidPageAddress)
+            // the bucket is not null and represents a page jump, follow it but only if it was written in this batch already
+            if (address.IsNull == false && address.IsValidPageAddress && ctx.Batch.WasWritten(address))
             {
                 var page = ctx.Batch.GetAt(address);
                 var updated = new DataPage(page).Set(ctx.SliceFrom(NibbleCount));
@@ -131,8 +131,10 @@ public readonly unsafe struct DataPage : IDataPage
             return Set(ctx);
         }
 
-        // standard nibble extraction followed by the child creation
-        var child = ctx.Batch.GetNewPage(out var childAddr, true);
+        // check if the child page already exists. It's possible if it was not written in this batch,
+        // and check above passed through. In this case, retrieve the child as is and it'll COW itself later
+        var childAddr = Data.Buckets[biggestNibble];
+        var child = childAddr.IsNull ? ctx.Batch.GetNewPage(out childAddr, true) : ctx.Batch.GetAt(childAddr);
         var dataPage = new DataPage(child);
 
         foreach (var item in map.EnumerateNibble(biggestNibble))
@@ -146,7 +148,7 @@ public readonly unsafe struct DataPage : IDataPage
             map.Delete(item);
         }
 
-        Data.Buckets[biggestNibble] = childAddr;
+        Data.Buckets[biggestNibble] = ctx.Batch.GetAddress(dataPage.AsPage());
 
         // The page has some of the values flushed down, try to add again.
         return Set(ctx);
@@ -154,20 +156,6 @@ public readonly unsafe struct DataPage : IDataPage
 
     public bool TryGet(FixedMap.Key key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
     {
-        if (key.Path.Length > 0)
-        {
-            // try to go deeper only if the path is long enough
-            var nibble = key.Path.FirstNibble;
-            var bucket = Data.Buckets[nibble];
-
-            // non-null page jump, follow it!
-            if (bucket.IsNull == false && bucket.IsValidPageAddress)
-            {
-                return new DataPage(batch.GetAt(bucket)).TryGet(key.SliceFrom(NibbleCount), batch, out result);
-            }
-        }
-
-        // read in-page
         var map = new FixedMap(Data.FixedMapSpan);
 
         // try first storage tree
@@ -183,6 +171,19 @@ public readonly unsafe struct DataPage : IDataPage
         if (map.TryGet(key, out result))
         {
             return true;
+        }
+
+        if (key.Path.Length > 0)
+        {
+            // try to go deeper only if the path is long enough
+            var nibble = key.Path.FirstNibble;
+            var bucket = Data.Buckets[nibble];
+
+            // non-null page jump, follow it!
+            if (bucket.IsNull == false && bucket.IsValidPageAddress)
+            {
+                return new DataPage(batch.GetAt(bucket)).TryGet(key.SliceFrom(NibbleCount), batch, out result);
+            }
         }
 
         result = default;

--- a/src/Paprika/Db/PagedDb.cs
+++ b/src/Paprika/Db/PagedDb.cs
@@ -253,7 +253,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             return TryGetPage(key, out var page) ? page.GetStorage(GetPath(key), address, this) : default;
         }
 
-        private bool TryGetPage(Keccak key, out FanOut256Page page)
+        private bool TryGetPage(Keccak key, out DataPage page)
         {
             if (_disposed)
                 throw new ObjectDisposedException("The readonly batch has already been disposed");
@@ -265,7 +265,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            page = new FanOut256Page(GetAt(addr));
+            page = new DataPage(GetAt(addr));
             return true;
         }
 
@@ -318,7 +318,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
         public Account GetAccount(in Keccak key) =>
             TryGetPageNoAlloc(key, out var page) ? page.GetAccount(GetPath(key), this) : default;
 
-        private bool TryGetPageNoAlloc(in Keccak key, out FanOut256Page page)
+        private bool TryGetPageNoAlloc(in Keccak key, out DataPage page)
         {
             CheckDisposed();
 
@@ -330,7 +330,7 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            page = new FanOut256Page(_db.GetAt(addr));
+            page = new DataPage(_db.GetAt(addr));
             return true;
         }
 
@@ -351,13 +351,13 @@ public abstract unsafe class PagedDb : IPageResolver, IDb, IDisposable
             addr = _db.GetAddress(updated);
         }
 
-        private ref DbAddress TryGetPageAlloc(in Keccak key, out FanOut256Page page)
+        private ref DbAddress TryGetPageAlloc(in Keccak key, out DataPage page)
         {
             CheckDisposed();
 
             ref var addr = ref RootPage.FindAccountPage(_root.Data.AccountPages, key);
             var p = addr.IsNull ? GetNewPage(out addr, true) : GetAt(addr);
-            page = new FanOut256Page(p);
+            page = new DataPage(p);
 
             return ref addr;
         }

--- a/src/Paprika/Db/RootPage.cs
+++ b/src/Paprika/Db/RootPage.cs
@@ -31,7 +31,7 @@ public readonly unsafe struct RootPage : IPage
         /// <summary>
         /// How big is the fan out for the root.
         /// </summary>
-        private const int AccountPageFanOut = 256;
+        private const int AccountPageFanOut = 16;
 
         /// <summary>
         /// The number of nibbles that are "consumed" on the root level.
@@ -97,8 +97,7 @@ public readonly unsafe struct RootPage : IPage
 
     public static ref DbAddress FindAccountPage(Span<DbAddress> accountPages, in Keccak key)
     {
-        var index = FanOut256Page.FirstTwoNibbles(NibblePath.FromKey(key));
-        return ref accountPages[index];
+        return ref accountPages[NibblePath.FromKey(key).FirstNibble];
     }
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver)
@@ -107,7 +106,7 @@ public readonly unsafe struct RootPage : IPage
         {
             if (dataAddr.IsNull == false)
             {
-                var data = new FanOut256Page(resolver.GetAt(dataAddr));
+                var data = new DataPage(resolver.GetAt(dataAddr));
                 visitor.On(data, dataAddr);
             }
         }


### PR DESCRIPTION
A speculative in-page buffer. 

### Benchmark

Store 100 million accounts + one storage slot for each + Big Storage contract updated for each account

```
Deleting previous db...
Using persistent DB on disk, located: C:\Git\Paprika\db
Initializing db of size 64GB
Starting benchmark with commit level DangerNoFlush
Preparing random accounts addresses...
Accounts prepared

(P) - 90th percentile of the value

At Block        | Avg. speed      | Space used      | New pages(P)    | Pages reused(P) | Total pages(P)
           5000 |  372.0 blocks/s |          2.70GB |             752 |             234 |             939
          10000 |  339.3 blocks/s |          4.57GB |             862 |             214 |             945
          15000 |  344.8 blocks/s |          4.76GB |             916 |             199 |             947
          20000 |  345.3 blocks/s |          4.78GB |             935 |             187 |             950
          25000 |  343.4 blocks/s |          4.79GB |             946 |             176 |             955
          30000 |  336.5 blocks/s |          5.02GB |             950 |             165 |             961
          35000 |  320.2 blocks/s |          5.98GB |             952 |             155 |             979
          40000 |  301.3 blocks/s |          8.09GB |             955 |             160 |            1021
          45000 |  219.6 blocks/s |         11.17GB |             956 |             179 |            1070
          50000 |  264.2 blocks/s |         14.74GB |             958 |             196 |            1104
          55000 |  274.1 blocks/s |         18.49GB |             959 |             210 |            1124
          60000 |  258.2 blocks/s |         22.27GB |             960 |             218 |            1136
          65000 |  220.6 blocks/s |         26.02GB |             961 |             223 |            1143
          70000 |   94.6 blocks/s |         29.69GB |             962 |             227 |            1148
          75000 |   60.2 blocks/s |         33.27GB |             964 |             229 |            1152
          80000 |   71.5 blocks/s |         36.73GB |             966 |             230 |            1154
          85000 |   53.7 blocks/s |         40.06GB |             969 |             230 |            1156
          90000 |   59.8 blocks/s |         43.22GB |             972 |             230 |            1158
          95000 |   55.2 blocks/s |         46.20GB |             976 |             230 |            1159
          99999 |   43.5 blocks/s |         48.98GB |             981 |             229 |            1161

Writing in numbers:
- 1000 accounts per block
- each account with 1 storage slot written
- each account amends 1 slot in Big Storage account
- through 100000 blocks
- generated accounts total number: 100000000
- space used: 48.98GB

Reading and asserting values...
Reading at   5000000 out of 100000000 accounts. Current speed: 14771.0 reads/s
Reading at  10000000 out of 100000000 accounts. Current speed: 7374.6 reads/s
Reading at  15000000 out of 100000000 accounts. Current speed: 4943.2 reads/s
Reading at  20000000 out of 100000000 accounts. Current speed: 3721.6 reads/s
Reading at  25000000 out of 100000000 accounts. Current speed: 2977.1 reads/s
Reading at  30000000 out of 100000000 accounts. Current speed: 2480.2 reads/s
Reading at  35000000 out of 100000000 accounts. Current speed: 2143.2 reads/s
Reading at  40000000 out of 100000000 accounts. Current speed: 1889.3 reads/s
Reading at  45000000 out of 100000000 accounts. Current speed: 1698.9 reads/s
Reading at  50000000 out of 100000000 accounts. Current speed: 1550.4 reads/s
Reading at  55000000 out of 100000000 accounts. Current speed: 1435.5 reads/s
Reading at  60000000 out of 100000000 accounts. Current speed: 1348.6 reads/s
Reading at  65000000 out of 100000000 accounts. Current speed: 1278.6 reads/s
Reading at  70000000 out of 100000000 accounts. Current speed: 1225.6 reads/s
Reading at  75000000 out of 100000000 accounts. Current speed: 1186.2 reads/s
Reading at  80000000 out of 100000000 accounts. Current speed: 1159.8 reads/s
Reading at  85000000 out of 100000000 accounts. Current speed: 1145.2 reads/s
Reading at  90000000 out of 100000000 accounts. Current speed: 1137.5 reads/s
Reading at  95000000 out of 100000000 accounts. Current speed: 1133.0 reads/s
Reading state of all of 100000000 accounts from the last block took 01:13:42.7631753
90th percentiles:
   - new pages allocated per block: 0
   - pages reused allocated per block: 633
   - total pages written per block: 710
```