### PR TITLE
Page metadata added

### DIFF
--- a/src/Paprika/Data/DataPage.cs
+++ b/src/Paprika/Data/DataPage.cs
@@ -134,6 +134,10 @@ public readonly unsafe struct DataPage : IDataPage
 
         // standard nibble extraction followed by the child creation
         var child = ctx.Batch.GetNewPage(out var childAddr, true);
+
+        child.Header.TreeLevel = (byte)(Header.TreeLevel + 1);
+        child.Header.PageType = Header.PageType;
+
         var dataPage = new DataPage(child);
 
         foreach (var item in map.EnumerateNibble(biggestNibble))
@@ -242,6 +246,11 @@ public readonly unsafe struct DataPage : IDataPage
         NibblePath.ReadFrom(accountPathBytes, out var accountPath);
 
         var storage = ctx.Batch.GetNewPage(out _, true);
+
+        // this is the top page of the massive storage tree
+        storage.Header.TreeLevel = 0;
+        storage.Header.PageType = PageType.MassiveStorageTree;
+
         var dataPage = new DataPage(storage);
 
         foreach (var item in map.EnumerateNibble(nibble))

--- a/src/Paprika/Data/FanOut256Page.cs
+++ b/src/Paprika/Data/FanOut256Page.cs
@@ -55,6 +55,11 @@ public readonly unsafe struct FanOut256Page : IDataPage
         {
             // no data page, allocate and set
             var page = ctx.Batch.GetNewPage(out address, true);
+
+            page.Header.PageType = PageType.Standard;
+            page.Header.PaprikaVersion = PageHeader.CurrentVersion;
+            page.Header.TreeLevel = (byte)(Header.TreeLevel + 1);
+
             new DataPage(page).Set(ctx.SliceFrom(NibbleCount));
             Data.Buckets[prefix] = address;
         }

--- a/src/Paprika/Data/Page.cs
+++ b/src/Paprika/Data/Page.cs
@@ -40,6 +40,8 @@ public static class PageExtensions
 [StructLayout(LayoutKind.Explicit, Pack = 1, Size = Size)]
 public struct PageHeader
 {
+    public const byte CurrentVersion = 1;
+
     public const int Size = sizeof(ulong);
 
     /// <summary>
@@ -47,7 +49,34 @@ public struct PageHeader
     /// </summary>
     [FieldOffset(0)] public uint BatchId;
 
-    [FieldOffset(4)] public uint Reserved; // for not it's just alignment
+    /// <summary>
+    /// The version of the Paprika the page was written by.
+    /// </summary>
+    [FieldOffset(4)] public byte PaprikaVersion;
+
+    /// <summary>
+    /// The level of the tree the page represents.
+    /// </summary>
+    [FieldOffset(5)] public byte TreeLevel;
+
+    /// <summary>
+    /// The type of the page.
+    /// </summary>
+    [FieldOffset(6)] public PageType PageType;
+}
+
+public enum PageType : byte
+{
+    None = 0,
+
+    Standard = 1,
+
+    /// <summary>
+    /// The page is a part of the tree use for massive storage accounts.
+    /// </summary>
+    MassiveStorageTree = 2,
+
+    Abandoned = 3
 }
 
 /// <summary>

--- a/src/Paprika/Db/AbandonedPage.cs
+++ b/src/Paprika/Db/AbandonedPage.cs
@@ -41,7 +41,13 @@ public readonly struct AbandonedPage : IPage
         }
 
         // no more space, needs another next AbandonedPage
-        var next = new AbandonedPage(batch.GetNewPage(out var nextAddr, true))
+        var newPage = batch.GetNewPage(out var nextAddr, true);
+
+        newPage.Header.TreeLevel = 0;
+        newPage.Header.PageType = PageType.Abandoned;
+        newPage.Header.PaprikaVersion = PageHeader.CurrentVersion;
+
+        var next = new AbandonedPage(newPage)
         {
             AbandonedAtBatch = AbandonedAtBatch
         };

--- a/src/Paprika/Db/BatchContextBase.cs
+++ b/src/Paprika/Db/BatchContextBase.cs
@@ -52,5 +52,9 @@ abstract class BatchContextBase : IBatchContext
     /// <summary>
     /// Assigns the batch identifier to a given page, marking it writable by this batch.
     /// </summary>
-    protected void AssignBatchId(Page page) => page.Header.BatchId = BatchId;
+    protected void AssignBatchId(Page page)
+    {
+        page.Header.BatchId = BatchId;
+        page.Header.PaprikaVersion = PageHeader.CurrentVersion;
+    }
 }


### PR DESCRIPTION
This PR sprinkles metadata on top of header pages. They are not actively used now, just assigned, but they can be used to assert some properties of pages. Additionally, as the version of Paprika is embedded in them, this should allow much easier, per-page versioning.