### PR TITLE
File-based flusher

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -13,7 +13,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 5_000 : 20_000;
+    private const int BlockCount = PersistentDb ? 10_000 : 20_000;
     private const int RandomSampleSize = 260_000_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;
@@ -25,7 +25,7 @@ public static class Program
     private const long DbFileSize = PersistentDb ? 64 * Gb : 10 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
 
-    private const CommitOptions Commit = CommitOptions.FlushDataOnly;
+    private const CommitOptions Commit = CommitOptions.DangerNoFlush;
 
     private const int LogEvery = BlockCount / NumberOfLogs;
 

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -13,7 +13,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 20_000 : 20_000;
+    private const int BlockCount = PersistentDb ? 5_000 : 20_000;
     private const int RandomSampleSize = 260_000_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;
@@ -25,7 +25,7 @@ public static class Program
     private const long DbFileSize = PersistentDb ? 64 * Gb : 10 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
 
-    private const CommitOptions Commit = CommitOptions.DangerNoFlush;
+    private const CommitOptions Commit = CommitOptions.FlushDataOnly;
 
     private const int LogEvery = BlockCount / NumberOfLogs;
 
@@ -35,7 +35,7 @@ public static class Program
     private const int BigStorageAccountSlotCount = 1_000_000;
     private static readonly UInt256[] BigStorageAccountValues = new UInt256[BigStorageAccountSlotCount];
 
-    public static void Main(String[] args)
+    public static async Task Main(String[] args)
     {
         var dir = Directory.GetCurrentDirectory();
         var dataPath = Path.Combine(dir, "db");
@@ -136,7 +136,7 @@ public static class Program
                 counter++;
             }
 
-            batch.Commit(Commit);
+            await batch.Commit(Commit);
 
             if (block > 0 & block % LogEvery == 0)
             {
@@ -288,10 +288,10 @@ public static class Program
         return key;
     }
 
-    private static unsafe Span<byte> PrepareStableRandomSource()
+    private static byte[] PrepareStableRandomSource()
     {
         Console.WriteLine("Preparing random accounts addresses...");
-        var accounts = new Span<byte>(NativeMemory.Alloc((UIntPtr)RandomSampleSize), RandomSampleSize);
+        var accounts = GC.AllocateArray<byte>(RandomSampleSize);
         new Random(RandomSeed).NextBytes(accounts);
         Console.WriteLine("Accounts prepared");
         return accounts;

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -13,7 +13,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 50_000 : 20_000;
+    private const int BlockCount = PersistentDb ? 20_000 : 20_000;
     private const int RandomSampleSize = 260_000_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using HdrHistogram;
 using Nethermind.Int256;
 using Paprika.Crypto;
@@ -13,19 +12,19 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 10_000 : 20_000;
+    private const int BlockCount = PersistentDb ? 100_000 : 20_000;
     private const int RandomSampleSize = 260_000_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;
 
     private const int RandomSeed = 17;
 
-    private const int NumberOfLogs = PersistentDb ? 20 : 10;
+    private const int NumberOfLogs = PersistentDb ? 100 : 10;
 
-    private const long DbFileSize = PersistentDb ? 64 * Gb : 10 * Gb;
+    private const long DbFileSize = PersistentDb ? 128 * Gb : 10 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
 
-    private const CommitOptions Commit = CommitOptions.DangerNoFlush;
+    private const CommitOptions Commit = CommitOptions.FlushDataOnly;
 
     private const int LogEvery = BlockCount / NumberOfLogs;
 

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -101,7 +101,7 @@ public static class Program
 
         for (uint block = 0; block < BlockCount; block++)
         {
-            using var batch = db.BeginNextBlock();
+            using var batch = db.BeginNextBatch();
 
             for (var account = 0; account < AccountsPerBlock; account++)
             {

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -28,7 +28,7 @@ public static class Program
 
     private const int LogEvery = BlockCount / NumberOfLogs;
 
-    private const bool PersistentDb = true;
+    private const bool PersistentDb = false;
     private const bool UseStorage = true;
     private const bool UseBigStorageAccount = true;
     private const int BigStorageAccountSlotCount = 1_000_000;

--- a/src/Paprika.Tests/PrinterTests.cs
+++ b/src/Paprika.Tests/PrinterTests.cs
@@ -21,7 +21,7 @@ public class PrinterTests : BasePageTests
         {
             Printer.Print(db, Console.Out);
 
-            using (var block = db.BeginNextBlock())
+            using (var block = db.BeginNextBatch())
             {
                 block.Set(Key0, new Account(Balance0, (UInt256)i++));
                 block.Commit(CommitOptions.FlushDataOnly);

--- a/src/Paprika/Data/FixedMap.cs
+++ b/src/Paprika/Data/FixedMap.cs
@@ -452,6 +452,12 @@ public readonly ref struct FixedMap
                 }
             }
 
+            if (span.IsEmpty)
+            {
+                // the span is empty and there's not place to move forward
+                break;
+            }
+
             // move next: ushorts sliced to the next
             // offset moved by 1 to align
             span = span.Slice(index + 1);

--- a/src/Paprika/Data/FixedMap.cs
+++ b/src/Paprika/Data/FixedMap.cs
@@ -103,6 +103,8 @@ public readonly ref struct FixedMap
     /// </summary>
     public int Count => _header.Low / Slot.Size;
 
+    public int CapacityLeft => _data.Length - _header.Taken;
+
     public NibbleEnumerator EnumerateNibble(byte nibble) => new(this, nibble);
 
     public ref struct NibbleEnumerator
@@ -452,7 +454,7 @@ public readonly ref struct FixedMap
                 }
             }
 
-            if (span.IsEmpty)
+            if (index + 1 >= span.Length)
             {
                 // the span is empty and there's not place to move forward
                 break;

--- a/src/Paprika/IBatch.cs
+++ b/src/Paprika/IBatch.cs
@@ -22,7 +22,7 @@ public interface IBatch : IReadOnlyBatch
     /// </summary>
     /// <param name="options">How to commit.</param>
     /// <returns>The state root hash.</returns>
-    ValueTask<Keccak> Commit(CommitOptions options);
+    ValueTask Commit(CommitOptions options);
 }
 
 public enum CommitOptions

--- a/src/Paprika/IBatch.cs
+++ b/src/Paprika/IBatch.cs
@@ -22,7 +22,7 @@ public interface IBatch : IReadOnlyBatch
     /// </summary>
     /// <param name="options">How to commit.</param>
     /// <returns>The state root hash.</returns>
-    Keccak Commit(CommitOptions options);
+    ValueTask<Keccak> Commit(CommitOptions options);
 }
 
 public enum CommitOptions

--- a/src/Paprika/IDb.cs
+++ b/src/Paprika/IDb.cs
@@ -1,6 +1,4 @@
-﻿using Paprika.Crypto;
-
-namespace Paprika;
+﻿namespace Paprika;
 
 public interface IDb
 {
@@ -8,14 +6,7 @@ public interface IDb
     /// Starts a db transaction that is for the next block.
     /// </summary>
     /// <returns>The transaction that handles block operations.</returns>
-    IBatch BeginNextBlock();
-
-    /// <summary>
-    /// Reorganizes chain back to the given block hash and starts building on top of it.
-    /// </summary>
-    /// <param name="stateRootHash">The block hash to reorganize to.</param>
-    /// <returns>The new batch.</returns>
-    IBatch ReorganizeBackToAndStartNew(Keccak stateRootHash);
+    IBatch BeginNextBatch();
 
     /// <summary>
     /// Starts a readonly batch that preserves a snapshot of the database as in the moment of its creation.

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -135,7 +135,7 @@ public readonly unsafe struct DataPage : IDataPage
         // and check above passed through. In this case, retrieve the child as is and it'll COW itself later
         var childAddr = Data.Buckets[biggestNibble];
         var child = childAddr.IsNull ? ctx.Batch.GetNewPage(out childAddr, true) : ctx.Batch.GetAt(childAddr);
-        
+
         child.Header.TreeLevel = (byte)(Header.TreeLevel + 1);
         child.Header.PageType = Header.PageType;
 
@@ -152,7 +152,7 @@ public readonly unsafe struct DataPage : IDataPage
             map.Delete(item);
         }
 
-        Data.Buckets[biggestNibble] = ctx.Batch.GetAddress(dataPage.AsPage());;
+        Data.Buckets[biggestNibble] = ctx.Batch.GetAddress(dataPage.AsPage()); ;
 
         // The page has some of the values flushed down, try to add again.
         return Set(ctx);

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -92,8 +92,8 @@ public readonly unsafe struct DataPage : IDataPage
             var nibble = path.FirstNibble;
             var address = Data.Buckets[nibble];
 
-            // the bucket is not null and represents a page jump, follow it
-            if (address.IsNull == false && address.IsValidPageAddress)
+            // the bucket is not null and represents a page jump, follow it but only if it was written this tx
+            if (address.IsNull == false && ctx.Batch.WasWritten(address))
             {
                 var page = ctx.Batch.GetAt(address);
                 var updated = new DataPage(page).Set(ctx.SliceFrom(NibbleCount));
@@ -131,9 +131,11 @@ public readonly unsafe struct DataPage : IDataPage
             return Set(ctx);
         }
 
-        // standard nibble extraction followed by the child creation
-        var child = ctx.Batch.GetNewPage(out var childAddr, true);
-
+        // check if the child page already exists. It's possible if it was not written in this batch,
+        // and check above passed through. In this case, retrieve the child as is and it'll COW itself later
+        var childAddr = Data.Buckets[biggestNibble];
+        var child = childAddr.IsNull ? ctx.Batch.GetNewPage(out childAddr, true) : ctx.Batch.GetAt(childAddr);
+        
         child.Header.TreeLevel = (byte)(Header.TreeLevel + 1);
         child.Header.PageType = Header.PageType;
 
@@ -150,7 +152,7 @@ public readonly unsafe struct DataPage : IDataPage
             map.Delete(item);
         }
 
-        Data.Buckets[biggestNibble] = childAddr;
+        Data.Buckets[biggestNibble] = ctx.Batch.GetAddress(dataPage.AsPage());;
 
         // The page has some of the values flushed down, try to add again.
         return Set(ctx);
@@ -158,19 +160,6 @@ public readonly unsafe struct DataPage : IDataPage
 
     public bool TryGet(Key key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
     {
-        if (key.Path.Length > 0)
-        {
-            // try to go deeper only if the path is long enough
-            var nibble = key.Path.FirstNibble;
-            var bucket = Data.Buckets[nibble];
-
-            // non-null page jump, follow it!
-            if (bucket.IsNull == false && bucket.IsValidPageAddress)
-            {
-                return new DataPage(batch.GetAt(bucket)).TryGet(key.SliceFrom(NibbleCount), batch, out result);
-            }
-        }
-
         // read in-page
         var map = new FixedMap(Data.FixedMapSpan);
 
@@ -187,6 +176,20 @@ public readonly unsafe struct DataPage : IDataPage
         if (map.TryGet(key, out result))
         {
             return true;
+        }
+
+        // not found here, follow
+        if (key.Path.Length > 0)
+        {
+            // try to go deeper only if the path is long enough
+            var nibble = key.Path.FirstNibble;
+            var bucket = Data.Buckets[nibble];
+
+            // non-null page jump, follow it!
+            if (bucket.IsNull == false)
+            {
+                return new DataPage(batch.GetAt(bucket)).TryGet(key.SliceFrom(NibbleCount), batch, out result);
+            }
         }
 
         result = default;

--- a/src/Paprika/Store/DbAddress.cs
+++ b/src/Paprika/Store/DbAddress.cs
@@ -18,18 +18,6 @@ public readonly struct DbAddress : IEquatable<DbAddress>
 
     public const int Size = sizeof(uint);
 
-    /// <summary>
-    /// This value is bigger <see cref="Store.Page.PageCount"/> so that regular pages don't overflow.
-    /// </summary>
-    private const uint SamePage = 0x8000_0000;
-
-    private const int ValueMask = 0x00FF_FFFF;
-
-    /// <summary>
-    /// The shift that is applied to the counter of the jumps captured by the address.
-    /// </summary>
-    private const int JumpCountShift = 24;
-
     // private const uint JumpCounter = byte.MaxValue - (SamePage >> JumpCountShift);
     private const int NullValue = 0;
 
@@ -51,26 +39,11 @@ public readonly struct DbAddress : IEquatable<DbAddress>
     /// <summary>
     /// Gets the next address.
     /// </summary>
-    public DbAddress Next
-    {
-        get
-        {
-            Debug.Assert(IsSamePage == false,
-                "The next operator should be used only of the page addresses, not same page addresses");
-            return new DbAddress(_value + 1);
-        }
-    }
+    public DbAddress Next => new(_value + 1);
 
     public DbAddress(uint value) => _value = value;
 
     public bool IsNull => _value == NullValue;
-
-    /// <summary>
-    /// Keeps the number of frames used in the same page by jumps to the same nibble.
-    /// </summary>
-    public uint SamePageJumpCount => (_value & ~SamePage) >> JumpCountShift;
-
-    public bool IsSamePage => (_value & SamePage) == SamePage;
 
     // ReSharper disable once MergeIntoPattern
     public bool IsValidPageAddress => _value < Store.Page.PageCount;
@@ -78,8 +51,7 @@ public readonly struct DbAddress : IEquatable<DbAddress>
     public static implicit operator uint(DbAddress address) => address._value;
     public static implicit operator int(DbAddress address) => (int)address._value;
 
-    public override string ToString() => IsNull ? "null" :
-        IsSamePage ? $"Jump within page to index: {ValueMask & _value}" : $"Page @{_value}";
+    public override string ToString() => IsNull ? "null" : $"Page @{_value}";
 
     public bool Equals(DbAddress other) => _value == other._value;
 

--- a/src/Paprika/Store/DbAddress.cs
+++ b/src/Paprika/Store/DbAddress.cs
@@ -61,7 +61,7 @@ public readonly struct DbAddress : IEquatable<DbAddress>
         }
     }
 
-    private DbAddress(uint value) => _value = value;
+    public DbAddress(uint value) => _value = value;
 
     public bool IsNull => _value == NullValue;
 

--- a/src/Paprika/Store/IPageManager.cs
+++ b/src/Paprika/Store/IPageManager.cs
@@ -7,7 +7,7 @@ public interface IPageManager : IDisposable, IPageResolver
     DbAddress GetAddress(in Page page);
 
     /// <summary>
-    /// Gets the page for writing purposes.
+    /// Gets the page for writing purposes, ensuring that the page that is requested is finalized on disk.
     /// </summary>
     Page GetAtForWriting(DbAddress address, bool reused);
 

--- a/src/Paprika/Store/IPageManager.cs
+++ b/src/Paprika/Store/IPageManager.cs
@@ -9,7 +9,7 @@ public interface IPageManager : IDisposable, IPageResolver
     /// <summary>
     /// Gets the page for writing purposes.
     /// </summary>
-    Page GetAtForWriting(DbAddress address);
+    Page GetAtForWriting(DbAddress address, bool reused);
 
     /// <summary>
     /// Flushes all the mapped pages.

--- a/src/Paprika/Store/IPageManager.cs
+++ b/src/Paprika/Store/IPageManager.cs
@@ -16,7 +16,7 @@ public interface IPageManager : IDisposable, IPageResolver
     /// </summary>
     /// <param name="addresses"></param>
     /// <param name="options"></param>
-    void FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options);
+    ValueTask FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options);
 
-    void FlushRootPage(DbAddress rootPage, CommitOptions options);
+    ValueTask FlushRootPage(DbAddress rootPage, CommitOptions options);
 }

--- a/src/Paprika/Store/IPageManager.cs
+++ b/src/Paprika/Store/IPageManager.cs
@@ -7,9 +7,16 @@ public interface IPageManager : IDisposable, IPageResolver
     DbAddress GetAddress(in Page page);
 
     /// <summary>
+    /// Gets the page for writing purposes.
+    /// </summary>
+    Page GetAtForWriting(DbAddress address);
+
+    /// <summary>
     /// Flushes all the mapped pages.
     /// </summary>
-    void FlushAllPages();
+    /// <param name="addresses"></param>
+    /// <param name="options"></param>
+    void FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options);
 
-    void FlushRootPage(in Page rootPage);
+    void FlushRootPage(DbAddress rootPage, CommitOptions options);
 }

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -109,11 +109,13 @@ public class MemoryMappedPageManager : PointerPageManager
                 else if (addr == EndOfBatch)
                 {
                     _lastFlushedBatchId = _currentlyFlushedBatchId;
-                    
+
                     // notify waiters
                     lock (_lastFlushedMonitor) Monitor.PulseAll(_lastFlushedMonitor);
 
-                } else {
+                }
+                else
+                {
                     // a regular address to write
                     var offset = addr.Raw * Page.PageSize;
                     var page = GetAt(addr);
@@ -129,7 +131,7 @@ public class MemoryMappedPageManager : PointerPageManager
                     }
                 }
             }
-            
+
             await AwaitWrites();
 
             if (_toFlush.IsEmpty)
@@ -150,16 +152,16 @@ public class MemoryMappedPageManager : PointerPageManager
     public override Page GetAtForWriting(DbAddress address, bool reused)
     {
         var page = GetAt(address);
-        
+
         if (reused == false)
         {
             return page;
         }
-        
+
         // the page was reused, need to check whether it was flushed already
         var writtenAt = page.Header.BatchId;
 
-        while (writtenAt > _lastFlushedBatchId )
+        while (writtenAt > _lastFlushedBatchId)
         {
             // not flushed, wait
             lock (_lastFlushedMonitor)
@@ -179,7 +181,7 @@ public class MemoryMappedPageManager : PointerPageManager
         {
             _toFlush.Enqueue(ForceFlushMarker);
         }
-        
+
         _toFlush.Enqueue(EndOfBatch);
     }
 

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -1,23 +1,37 @@
-﻿using System.IO.MemoryMappedFiles;
+﻿using System.Buffers;
+using System.Collections.Concurrent;
+using System.IO.MemoryMappedFiles;
 using Paprika.Data;
 
 namespace Paprika.Store.PageManagers;
 
-public unsafe class MemoryMappedPageManager : PointerPageManager
+public class MemoryMappedPageManager : PointerPageManager
 {
     /// <summary>
     /// The only option is random access. As Paprika jumps over the file, any prefetching is futile.
     /// Also, the file cannot be async to use some of the mmap features. So here it is, random access file. 
     /// </summary>
-    private const FileOptions PaprikaFileOptions = FileOptions.RandomAccess;
+    private const FileOptions PaprikaFileOptions = FileOptions.RandomAccess | FileOptions.Asynchronous;
 
     private readonly FileStream _file;
     private readonly MemoryMappedFile _mapped;
     private readonly MemoryMappedViewAccessor _whole;
-    private readonly MemoryMappedViewAccessor _rootsOnly;
-    private readonly byte* _ptr;
+    private readonly unsafe byte* _ptr;
 
-    public MemoryMappedPageManager(ulong size, byte historyDepth, string dir) : base(size)
+    // Flusher section
+    private readonly Stack<PageMemoryOwner> _owners = new();
+    private readonly List<PageMemoryOwner> _ownersUsed = new();
+    private readonly List<Task> _pendingWrites = new();
+    private readonly List<DbAddress> _pendingAddresses = new();
+
+    private static readonly DbAddress FlushMarker = new(uint.MaxValue - 1);
+
+    private readonly ConcurrentQueue<DbAddress> _toFlush = new();
+    private readonly HashSet<DbAddress> _beingFlushed = new();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task<Task> _flusher;
+
+    public unsafe MemoryMappedPageManager(ulong size, byte historyDepth, string dir) : base(size)
     {
         Path = System.IO.Path.Combine(dir, "paprika.db");
 
@@ -40,49 +54,187 @@ public unsafe class MemoryMappedPageManager : PointerPageManager
         }
         else
         {
-            _file = new FileStream(Path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite, 4096,
+            _file = new FileStream(Path, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096,
                 PaprikaFileOptions);
         }
 
         _mapped = MemoryMappedFile.CreateFromFile(_file, null, (long)size, MemoryMappedFileAccess.ReadWrite,
-            HandleInheritability.None, false);
+            HandleInheritability.None, true);
 
         _whole = _mapped.CreateViewAccessor();
         _whole.SafeMemoryMappedViewHandle.AcquirePointer(ref _ptr);
 
-        _rootsOnly = _mapped.CreateViewAccessor(0, historyDepth * Page.PageSize);
+        _flusher = Task.Factory.StartNew(() => RunFlusher(), _cts.Token, TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
     }
 
     public string Path { get; }
 
-    protected override void* Ptr => _ptr;
+    protected override unsafe void* Ptr => _ptr;
 
-    public override void FlushAllPages()
+    public override void FlushPages(IReadOnlyCollection<DbAddress> dbAddresses, CommitOptions options)
     {
-        // On Windows LMDB does not use FlushViewOfFile + FlushFileBuffers due to some performance gains.
-        // At the moment, simplicity of using it wins over a much more complicated than scheduling writes with WriteFile.
-        // see: https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/mdb.c#L3715-L3716
-        // see: https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/mdb.c#L3775-L3784
+        // TODO: remove alloc
+        var addresses = dbAddresses.ToArray();
+        Array.Sort(addresses, (a, b) => a.Raw.CompareTo(b.Raw));
 
-        _whole.Flush();
-        _file.Flush(true);
+        // report as being flushed first
+        lock (_beingFlushed)
+        {
+            foreach (var address in addresses)
+            {
+                _beingFlushed.Add(address);
+            }
+        }
+
+        foreach (var address in addresses)
+        {
+            _toFlush.Enqueue(address);
+        }
+
+        if (options != CommitOptions.DangerNoFlush)
+        {
+            _toFlush.Enqueue(FlushMarker);
+        }
     }
 
-    public override void FlushRootPage(in Page rootPage)
+    private async Task RunFlusher()
     {
-        // for now, flush all root pages.
-        // Adding LMDB-like flush that works with one page would require a lot of interop
-        // https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/mdb.c#L4136
+        var handle = _file.SafeFileHandle;
+        const int maxPendingWrites = 4096;
 
-        _rootsOnly.Flush();
-        _file.Flush(true);
+        while (_cts.IsCancellationRequested == false)
+        {
+            while (_toFlush.TryDequeue(out var addr))
+            {
+                if (addr == FlushMarker)
+                {
+                    await AwaitWrites();
+                    _file.Flush(true);
+                }
+                else
+                {
+                    // a regular address to write
+                    _pendingAddresses.Add(addr);
+                    var offset = addr.Raw * Page.PageSize;
+                    _pendingWrites.Add(RandomAccess.WriteAsync(handle, Own(GetAt(addr)).Memory, offset).AsTask());
+
+                    // TODO: this should be throttling
+                    if (_pendingWrites.Count > maxPendingWrites)
+                    {
+                        await AwaitWrites();
+                    }
+                }
+            }
+            
+            await AwaitWrites();
+
+            if (_toFlush.IsEmpty)
+            {
+                // still empty, wait
+                await Task.Delay(50);
+            }
+        }
+    }
+
+    private async Task AwaitWrites()
+    {
+        await Task.WhenAll(_pendingWrites);
+        ReleaseOwners();
+
+        lock (_beingFlushed)
+        {
+            foreach (var address in _pendingAddresses)
+            {
+                _beingFlushed.Remove(address);
+            }
+
+            // notify waiters
+            Monitor.PulseAll(_beingFlushed);
+        }
+
+        _pendingWrites.Clear();
+        _pendingAddresses.Clear();
+    }
+
+    public override Page GetAtForWriting(DbAddress address)
+    {
+        // ensure that the page is not being flushed atm.
+        lock (_beingFlushed)
+        {
+            while (_beingFlushed.Contains(address))
+            {
+                Monitor.Wait(_beingFlushed);
+            }
+        }
+
+        return GetAt(address);
+    }
+
+    public override void FlushRootPage(DbAddress root, CommitOptions options)
+    {
+        lock (_beingFlushed)
+        {
+            _beingFlushed.Add(root);
+        }
+
+        _toFlush.Enqueue(root);
+
+        if (options == CommitOptions.FlushDataAndRoot)
+        {
+            _toFlush.Enqueue(FlushMarker);
+        }
     }
 
     public override void Dispose()
     {
-        _whole.Flush();
+        _cts.Cancel();
+        _flusher.GetAwaiter().GetResult();
+
         _whole.SafeMemoryMappedViewHandle.ReleasePointer();
         _whole.Dispose();
         _mapped.Dispose();
+        _file.Dispose();
+    }
+
+    private PageMemoryOwner Own(Page page)
+    {
+        if (_owners.TryPop(out var owner) == false)
+        {
+            owner = new();
+        }
+
+        _ownersUsed.Add(owner);
+
+        owner.Page = page;
+        return owner;
+    }
+
+    private void ReleaseOwners()
+    {
+        foreach (var used in _ownersUsed)
+        {
+            _owners.Push(used);
+        }
+
+        _ownersUsed.Clear();
+    }
+
+    private class PageMemoryOwner : MemoryManager<byte>
+    {
+        public Page Page;
+
+        protected override void Dispose(bool disposing)
+        {
+        }
+
+        public override unsafe Span<byte> GetSpan() => new(Page.Raw.ToPointer(), Page.PageSize);
+
+        public override unsafe MemoryHandle Pin(int elementIndex = 0) =>
+            new((byte*)Page.Raw.ToPointer() + elementIndex);
+
+        public override void Unpin()
+        {
+        }
     }
 }

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -17,11 +17,7 @@ public unsafe class NativeMemoryPageManager : PointerPageManager
 
     public override void Dispose() => NativeMemory.AlignedFree(_ptr);
 
-    public override void FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options)
-    {
-    }
+    public override ValueTask FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options) => ValueTask.CompletedTask;
 
-    public override void FlushRootPage(DbAddress rootPage, CommitOptions options)
-    {
-    }
+    public override ValueTask FlushRootPage(DbAddress rootPage, CommitOptions options) => ValueTask.CompletedTask;
 }

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -17,13 +17,11 @@ public unsafe class NativeMemoryPageManager : PointerPageManager
 
     public override void Dispose() => NativeMemory.AlignedFree(_ptr);
 
-    public override void FlushAllPages()
+    public override void FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options)
     {
-        // no op
     }
 
-    public override void FlushRootPage(in Page rootPage)
+    public override void FlushRootPage(DbAddress rootPage, CommitOptions options)
     {
-        // no op
     }
 }

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -34,8 +34,11 @@ public abstract unsafe class PointerPageManager : IPageManager
             .ToInt64() / Page.PageSize));
     }
 
-    public abstract void FlushAllPages();
-    public abstract void FlushRootPage(in Page rootPage);
+    public virtual Page GetAtForWriting(DbAddress address) => GetAt(address);
+
+    public abstract void FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options);
+
+    public abstract void FlushRootPage(DbAddress rootPage, CommitOptions options);
 
     public abstract void Dispose();
 }

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -36,9 +36,9 @@ public abstract unsafe class PointerPageManager : IPageManager
 
     public virtual Page GetAtForWriting(DbAddress address, bool reused) => GetAt(address);
 
-    public abstract void FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options);
+    public abstract ValueTask FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options);
 
-    public abstract void FlushRootPage(DbAddress rootPage, CommitOptions options);
+    public abstract ValueTask FlushRootPage(DbAddress rootPage, CommitOptions options);
 
     public abstract void Dispose();
 }

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -34,7 +34,7 @@ public abstract unsafe class PointerPageManager : IPageManager
             .ToInt64() / Page.PageSize));
     }
 
-    public virtual Page GetAtForWriting(DbAddress address) => GetAt(address);
+    public virtual Page GetAtForWriting(DbAddress address, bool reused) => GetAt(address);
 
     public abstract void FlushPages(IReadOnlyCollection<DbAddress> addresses, CommitOptions options);
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -226,9 +226,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
         _lastRoot += 1;
         var pageAddress = _lastRoot % _historyDepth;
 
-        // The GetAtForWriting is used to ensure that the given page has already been flushed to disk
-        var destination = GetAtForWriting(GetAddress(_roots[pageAddress].AsPage()), true);
-        root.CopyTo(destination);
+        root.CopyTo(_roots[pageAddress]);
         return DbAddress.Page((uint)pageAddress);
     }
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -402,6 +402,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
 
             await _db._manager.FlushPages(_written, options);
 
+
             var newRootPage = _db.SetNewRoot(_root);
 
             await _db._manager.FlushRootPage(newRootPage, options);

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -393,7 +393,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             }
         }
 
-        public Keccak Commit(CommitOptions options)
+        public async ValueTask<Keccak> Commit(CommitOptions options)
         {
             CheckDisposed();
 
@@ -402,11 +402,11 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             // memoize the abandoned so that it's preserved for future uses 
             MemoizeAbandoned();
 
-            _db._manager.FlushPages(_written, options);
+            await _db._manager.FlushPages(_written, options);
 
             var newRootPage = _db.SetNewRoot(_root);
 
-            _db._manager.FlushRootPage(newRootPage, options);
+            await _db._manager.FlushRootPage(newRootPage, options);
 
             // if reporter passed
             _db._reporter?.Invoke(_metrics);

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -225,7 +225,10 @@ public class PagedDb : IPageResolver, IDb, IDisposable
     {
         _lastRoot += 1;
         var pageAddress = _lastRoot % _historyDepth;
-        root.CopyTo(_roots[pageAddress]);
+
+        // The GetAtForWriting is used to ensure that the given page has already been flushed to disk
+        var destination = GetAtForWriting(GetAddress(_roots[pageAddress].AsPage()), true);
+        root.CopyTo(destination);
         return DbAddress.Page((uint)pageAddress);
     }
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -262,7 +262,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             return TryGetPage(key, out var page) ? page.GetStorage(GetPath(key), address, this) : default;
         }
 
-        private bool TryGetPage(Keccak key, out FanOut256Page page)
+        private bool TryGetPage(Keccak key, out DataPage page)
         {
             if (_disposed)
                 throw new ObjectDisposedException("The readonly batch has already been disposed");
@@ -274,7 +274,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            page = new FanOut256Page(GetAt(addr));
+            page = new DataPage(GetAt(addr));
             return true;
         }
 
@@ -329,7 +329,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
         public Account GetAccount(in Keccak key) =>
             TryGetPageNoAlloc(key, out var page) ? page.GetAccount(GetPath(key), this) : default;
 
-        private bool TryGetPageNoAlloc(in Keccak key, out FanOut256Page page)
+        private bool TryGetPageNoAlloc(in Keccak key, out DataPage page)
         {
             CheckDisposed();
 
@@ -341,7 +341,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            page = new FanOut256Page(_db.GetAt(addr));
+            page = new DataPage(_db.GetAt(addr));
             return true;
         }
 
@@ -362,7 +362,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             addr = _db.GetAddress(updated);
         }
 
-        private ref DbAddress TryGetPageAlloc(in Keccak key, out FanOut256Page page)
+        private ref DbAddress TryGetPageAlloc(in Keccak key, out DataPage page)
         {
             CheckDisposed();
 
@@ -380,7 +380,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 p = GetAt(addr);
             }
 
-            page = new FanOut256Page(p);
+            page = new DataPage(p);
 
             return ref addr;
         }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -204,7 +204,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
 
             // select min batch across the one respecting history and the min of all the read-only batches
             var rootBatchId = root.Header.BatchId;
-            
+
             var minBatch = rootBatchId < _historyDepth ? 0 : rootBatchId - _historyDepth;
             foreach (var batch in _batchesReadOnly)
             {

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -38,7 +38,7 @@ public readonly unsafe struct RootPage : IPage
         /// </summary>
         public const byte RootNibbleLevel = 2;
 
-        private const int AbandonedPagesStart = sizeof(uint) + Keccak.Size + DbAddress.Size + DbAddress.Size * AccountPageFanOut;
+        private const int AbandonedPagesStart = DbAddress.Size + DbAddress.Size * AccountPageFanOut;
 
         /// <summary>
         /// This gives the upper boundary of the number of abandoned pages that can be kept in the list.
@@ -51,25 +51,15 @@ public readonly unsafe struct RootPage : IPage
         private const int AbandonedPagesCount = (Size - AbandonedPagesStart) / DbAddress.Size;
 
         /// <summary>
-        /// The block number that the given batch represents.
-        /// </summary>
-        [FieldOffset(0)] public uint BlockNumber;
-
-        /// <summary>
-        /// The hash of the state root of the given block identified by <see cref="BlockNumber"/>.
-        /// </summary>
-        [FieldOffset(sizeof(uint))] public Keccak StateRootHash;
-
-        /// <summary>
         /// The address of the next free page. This should be used rarely as pages should be reused
         /// with <see cref="AbandonedPage"/>.
         /// </summary>
-        [FieldOffset(sizeof(uint) + Keccak.Size)] public DbAddress NextFreePage;
+        [FieldOffset(0)] public DbAddress NextFreePage;
 
         /// <summary>
         /// The first of the data pages.
         /// </summary>
-        [FieldOffset(sizeof(uint) + Keccak.Size + DbAddress.Size)] private DbAddress AccountPage;
+        [FieldOffset(DbAddress.Size)] private DbAddress AccountPage;
 
         /// <summary>
         /// Gets the span of account pages of the root

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -31,7 +31,7 @@ public readonly unsafe struct RootPage : IPage
         /// <summary>
         /// How big is the fan out for the root.
         /// </summary>
-        private const int AccountPageFanOut = 256;
+        private const int AccountPageFanOut = 16;
 
         /// <summary>
         /// The number of nibbles that are "consumed" on the root level.
@@ -97,8 +97,8 @@ public readonly unsafe struct RootPage : IPage
 
     public static ref DbAddress FindAccountPage(Span<DbAddress> accountPages, in Keccak key)
     {
-        var index = FanOut256Page.FirstTwoNibbles(NibblePath.FromKey(key));
-        return ref accountPages[index];
+        var path = NibblePath.FromKey(key);
+        return ref accountPages[path.FirstNibble];
     }
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver)
@@ -107,7 +107,7 @@ public readonly unsafe struct RootPage : IPage
         {
             if (dataAddr.IsNull == false)
             {
-                var data = new FanOut256Page(resolver.GetAt(dataAddr));
+                var data = new DataPage(resolver.GetAt(dataAddr));
                 visitor.On(data, dataAddr);
             }
         }

--- a/src/Paprika/Utils/Printer.cs
+++ b/src/Paprika/Utils/Printer.cs
@@ -75,8 +75,6 @@ public class Printer : IPageVisitor
             {
                 (Type, "Root"),
                 ("BatchId", page.Header.BatchId.ToString()),
-                ("BlockNumber", page.Data.BlockNumber.ToString()),
-                ("StateRootHash", Abbr(page.Data.StateRootHash)),
                 ("DataPages", ListPages(page.Data.AccountPages)),
                 ("NextFreePage", page.Data.NextFreePage.ToString()),
                 ("Abandoned", ListPages(page.Data.AbandonedPages))


### PR DESCRIPTION
This PR alters Paprika flushing behavior in a preparation of handling `NewPayload` and `ForkChoiceUpdate`. It's premise is to separate the database as a storage component, that can have a list of `NewPayloads` squashed to it asynchronously, once the blocks breach finality provided by `FCU`. The changes introduced:

- db engine
  - `Commit` becomes async 
  - `Commit` uses `RandomAccess.WriteAsync` to flush dirty pages in a way similar to LMDB. No `FlushViewOfFile` is used
  - `Flush` on files used when needed.
- pages
  - page provides a in-page buffer that reduces the number of writes by 75%