### PR TITLE
Bucket map

### DIFF
--- a/src/Paprika.Tests/Data/BucketMapTests.cs
+++ b/src/Paprika.Tests/Data/BucketMapTests.cs
@@ -8,19 +8,8 @@ namespace Paprika.Tests.Data;
 public class BucketMapTests
 {
     private static NibblePath Key0 => NibblePath.FromKey(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x90 });
-    private static ReadOnlySpan<byte> Data0 => new byte[] { 23 };
-
     private static NibblePath Key1 => NibblePath.FromKey(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x99 });
-    private static ReadOnlySpan<byte> Data1 => new byte[] { 29, 31 };
-
-    private static NibblePath Key2 => NibblePath.FromKey(new byte[] { 19, 21, 23, 29, 23 });
-    private static ReadOnlySpan<byte> Data2 => new byte[] { 37, 39 };
-
-    private static ReadOnlySpan<byte> Data3 => new byte[] { 39, 41, 43 };
-
     private static readonly Keccak StorageCell0 = Keccak.Compute(new byte[] { 2, 43, 4, 5, 34 });
-    private static readonly Keccak StorageCell1 = Keccak.Compute(new byte[] { 2, 43, 4, });
-    private static readonly Keccak StorageCell2 = Keccak.Compute(new byte[] { 2, 43, });
 
     [Test]
     public void Clear()

--- a/src/Paprika.Tests/Data/BucketMapTests.cs
+++ b/src/Paprika.Tests/Data/BucketMapTests.cs
@@ -1,0 +1,99 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Crypto;
+using Paprika.Data;
+
+namespace Paprika.Tests.Data;
+
+public class BucketMapTests
+{
+    private static NibblePath Key0 => NibblePath.FromKey(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x90 });
+    private static ReadOnlySpan<byte> Data0 => new byte[] { 23 };
+
+    private static NibblePath Key1 => NibblePath.FromKey(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x99 });
+    private static ReadOnlySpan<byte> Data1 => new byte[] { 29, 31 };
+
+    private static NibblePath Key2 => NibblePath.FromKey(new byte[] { 19, 21, 23, 29, 23 });
+    private static ReadOnlySpan<byte> Data2 => new byte[] { 37, 39 };
+
+    private static ReadOnlySpan<byte> Data3 => new byte[] { 39, 41, 43 };
+
+    private static readonly Keccak StorageCell0 = Keccak.Compute(new byte[] { 2, 43, 4, 5, 34 });
+    private static readonly Keccak StorageCell1 = Keccak.Compute(new byte[] { 2, 43, 4, });
+    private static readonly Keccak StorageCell2 = Keccak.Compute(new byte[] { 2, 43, });
+
+    [Test]
+    public void Clear()
+    {
+        Span<byte> span = stackalloc byte[BucketMap.TotalSize];
+        Random.Shared.NextBytes(span);
+
+        var map = new BucketMap(span);
+
+        map.Clear();
+
+        for (byte nibble = 0; nibble < BucketMap.BucketCount; nibble++)
+        {
+            map.TryGetByNibble(nibble, out _, out _).Should().BeFalse();
+        }
+    }
+    
+    [Test]
+    public void Set()
+    {
+        var data = new byte[51];
+        
+        Span<byte> span = stackalloc byte[BucketMap.TotalSize];
+        var map = new BucketMap(span);
+
+        var key = Key.Account(Key0);
+        map.Set(key, data);
+
+        var set = Key0.FirstNibble;
+
+        for (byte nibble = 0; nibble < BucketMap.BucketCount; nibble++)
+        {
+            if (nibble != set)
+            {
+                map.TryGetByNibble(nibble, out _, out _).Should().BeFalse();
+            }
+            else
+            {
+                map.TryGetByNibble(nibble, out var actualKey, out var actualData);
+
+                key.Equals(actualKey).Should().BeTrue();
+                data.AsSpan().SequenceEqual(actualData).Should().BeTrue();
+            }
+        }
+    }
+    
+    [Test]
+    public void Set_overwrites()
+    {
+        var data = new byte[51];
+        
+        Span<byte> span = stackalloc byte[BucketMap.TotalSize];
+        var map = new BucketMap(span);
+
+        var key = Key.StorageCell(Key1, StorageCell0);
+        map.Set(Key.Account(Key0), new byte[] { 13, 17, 21 });
+        map.Set(key, data);
+
+        var set = key.Path.FirstNibble;
+
+        for (byte nibble = 0; nibble < BucketMap.BucketCount; nibble++)
+        {
+            if (nibble != set)
+            {
+                map.TryGetByNibble(nibble, out _, out _).Should().BeFalse();
+            }
+            else
+            {
+                map.TryGetByNibble(nibble, out var actualKey, out var actualData);
+
+                key.Equals(actualKey).Should().BeTrue();
+                data.AsSpan().SequenceEqual(actualData).Should().BeTrue();
+            }
+        }
+    }
+}

--- a/src/Paprika.Tests/Data/FixedMapTests.cs
+++ b/src/Paprika.Tests/Data/FixedMapTests.cs
@@ -2,9 +2,8 @@
 using NUnit.Framework;
 using Paprika.Crypto;
 using Paprika.Data;
-using Paprika.Store;
 
-namespace Paprika.Tests;
+namespace Paprika.Tests.Data;
 
 public class FixedMapTests
 {

--- a/src/Paprika.Tests/Data/NibblePathTests.PrefixTests.cs
+++ b/src/Paprika.Tests/Data/NibblePathTests.PrefixTests.cs
@@ -1,8 +1,7 @@
 ﻿using NUnit.Framework;
 using Paprika.Data;
-using Paprika.Store;
 
-namespace Paprika.Tests;
+namespace Paprika.Tests.Data;
 
 [TestFixture(true)]
 [TestFixture(false)]

--- a/src/Paprika.Tests/Data/NibblePathTests.cs
+++ b/src/Paprika.Tests/Data/NibblePathTests.cs
@@ -2,11 +2,10 @@
 using FluentAssertions;
 using NUnit.Framework;
 using Paprika.Data;
-using Paprika.Store;
 
 // ReSharper disable HeapView.BoxingAllocation
 
-namespace Paprika.Tests;
+namespace Paprika.Tests.Data;
 
 public class NibblePathTests
 {

--- a/src/Paprika.Tests/Data/SerializerTests.cs
+++ b/src/Paprika.Tests/Data/SerializerTests.cs
@@ -1,10 +1,9 @@
 ﻿using FluentAssertions;
 using Nethermind.Int256;
 using NUnit.Framework;
-using Paprika.Crypto;
 using Paprika.Data;
 
-namespace Paprika.Tests;
+namespace Paprika.Tests.Data;
 
 public class SerializerTests
 {

--- a/src/Paprika/Data/BucketMap.cs
+++ b/src/Paprika/Data/BucketMap.cs
@@ -1,0 +1,81 @@
+﻿namespace Paprika.Data;
+
+/// <summary>
+/// Provides a simple capability of storing up values in buckets, differentiated by the first nibble of the path.
+/// Effectively, this map has only <see cref="BucketCount"/> slots, but this should be more than enough to
+/// amortize writes in the tree.
+/// </summary>
+public readonly ref struct BucketMap
+{
+    public const int TotalSize = BucketCount * BucketSize;
+    public const int BucketCount = 16;
+    private const int BucketSize = 32 + 32 + 96; // key + storage key + 96 for data and others
+
+    private readonly Span<byte> _data;
+    
+    public BucketMap(Span<byte> buffer)
+    {
+        _data = buffer;
+    }
+
+    public void Clear() => _data.Clear();
+
+    /// <summary>
+    /// Tries to retrieve the existing data by the nibble.
+    /// </summary>
+    public bool TryGetByNibble(byte nibble, out Key key, out ReadOnlySpan<byte> data)
+    {
+        var slice = GetNibbleBucket(nibble);
+
+        if (slice[0] == 0)
+        {
+            // no nibble path stored
+            key = default;
+            data = default;
+            
+            return false;
+        }
+
+        var leftover = NibblePath.ReadFrom(slice, out var path);
+        var type = (DataType)leftover[0];
+        leftover = ReadSpan(leftover.Slice(1), out var additionalKey);
+
+        key = new Key(path, type, additionalKey);
+        ReadSpan(leftover, out data);
+        
+        return true;
+    }
+
+    /// <summary>
+    /// Overwrites whatever is in the map under the given key.
+    /// </summary>
+    public void Set(in Key key, ReadOnlySpan<byte> data)
+    {
+        var slice = GetNibbleBucket(key.Path.FirstNibble);
+        
+        slice.Clear();
+
+        var leftover = key.Path.WriteToWithLeftover(slice);
+        leftover[0] = (byte)key.Type;
+        leftover = WriteSpan(key.AdditionalKey, leftover.Slice(1));
+        WriteSpan(data, leftover);
+    }
+
+    private Span<byte> GetNibbleBucket(byte nibble) => _data.Slice(nibble * BucketSize, BucketSize);
+
+    private const int LengthOfLength = 1;
+    
+    private static ReadOnlySpan<byte> ReadSpan(ReadOnlySpan<byte> span, out ReadOnlySpan<byte> result)
+    {
+        var length = span[0];
+        result = span.Slice(LengthOfLength, length);
+        return span.Slice(LengthOfLength + length);
+    }
+    
+    private static Span<byte> WriteSpan(ReadOnlySpan<byte> span, Span<byte> destination)
+    {
+        destination[0] = (byte)span.Length;
+        span.CopyTo(destination.Slice(LengthOfLength));
+        return destination.Slice(LengthOfLength + span.Length);
+    }
+}

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -16,7 +16,7 @@ public readonly ref struct Key
     public readonly DataType Type;
     public readonly ReadOnlySpan<byte> AdditionalKey;
 
-    private Key(NibblePath path, DataType type, ReadOnlySpan<byte> additionalKey)
+    public Key(NibblePath path, DataType type, ReadOnlySpan<byte> additionalKey)
     {
         Path = path;
         Type = type;
@@ -90,5 +90,16 @@ public readonly ref struct Key
         return $"{nameof(Path)}: {Path.ToString()}, " +
                $"{nameof(Type)}: {Type}, " +
                $"{nameof(AdditionalKey)}: {AdditionalKey.ToHexString(false)}";
+    }
+
+    public bool Equals(in Key other)
+    {
+        if (Type != other.Type)
+            return false;
+
+        if (!Path.Equals(other.Path))
+            return false;
+
+        return AdditionalKey.SequenceEqual(other.AdditionalKey);
     }
 }


### PR DESCRIPTION
This PR introduces a softer and faster version of reusing `DataPage` component when there all children set. It does it by introducing a `BucketMap` that allows for fast direct addressing of a fixed number of components. The expected behavior is that the amount of pages written should be greatly amortized by it. To Be Continued and Measured.