### PR TITLE
Hashing map

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -27,7 +27,7 @@ public static class Program
     private const long DbFileSize = PersistentDb ? 128 * Gb : 16 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
 
-    private const CommitOptions Commit = CommitOptions.FlushDataOnly;
+    private const CommitOptions Commit = CommitOptions.FlushDataAndRoot;
 
     private const int LogEvery = BlockCount / NumberOfLogs;
 
@@ -130,7 +130,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            await using (var blockchain = new Blockchain(db, CommitOptions.DangerNoWrite, 1000, reporter.Observe))
+            await using (var blockchain = new Blockchain(db, Commit, 1000, reporter.Observe))
             {
                 counter = Writer(blockchain, bigStorageAccount, random, layout[writing]);
             }

--- a/src/Paprika.Tests/Data/KeyTests.cs
+++ b/src/Paprika.Tests/Data/KeyTests.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Crypto;
+using Paprika.Data;
+
+namespace Paprika.Tests.Data;
+
+public class KeyTests
+{
+    private const string Path = nameof(Key.Path);
+    private const string Type = nameof(Key.Type);
+    private const string AdditionalKey = nameof(Key.AdditionalKey);
+
+    private static NibblePath Path0 => NibblePath.FromKey(Values.Key0);
+    private static NibblePath Path1A => NibblePath.FromKey(Values.Key1A);
+    private static NibblePath Path1B => NibblePath.FromKey(Values.Key1B);
+
+    [Test]
+    public void Equality_Path()
+    {
+        Key.Account(Path0).Equals(Key.Account(Path0)).Should().BeTrue($"Same {Path} & {Type}");
+
+        Key.Account(Path0).Equals(Key.Account(Path1A)).Should().BeFalse($"{Path} different at first nibble");
+
+        Key.Account(Path1A).Equals(Key.Account(Path1B)).Should().BeFalse($"{Path} different at last nibble");
+
+        const int length = 63;
+        Key.Account(Path1A.SliceTo(length)).Equals(Key.Account(Path1B.SliceTo(length))).Should()
+            .BeTrue($"Truncated {Path} on different nibble should be equal");
+    }
+
+    [Test]
+    public void Equality_Type()
+    {
+        Key.Account(Path0).Equals(Key.CodeHash(Path0)).Should().BeFalse($"Different {Type}");
+
+        Key.Account(Path0).Equals(Key.StorageCell(Path0, Keccak.Zero)).Should().BeFalse($"Different {Type}");
+    }
+
+    [Test]
+    public void Equality_AdditionalKey()
+    {
+        Key.StorageCell(Path0, Values.Key1A).Equals(Key.StorageCell(Path0, Values.Key1A)).Should()
+            .BeTrue($"Same {Path} & {Type} & {AdditionalKey}");
+
+        Key.StorageCell(Path0, Values.Key1A).Equals(Key.StorageCell(Path0, Values.Key1B)).Should()
+            .BeFalse($"Same {Path} & {Type} but different {AdditionalKey}");
+    }
+}

--- a/src/Paprika.Tests/HashingMapTests.cs
+++ b/src/Paprika.Tests/HashingMapTests.cs
@@ -8,8 +8,8 @@ namespace Paprika.Tests;
 public class HashingMapTests
 {
     private static NibblePath Path0 => NibblePath.FromKey(Values.Key0);
-    private static NibblePath Path1 => NibblePath.FromKey(Values.Key1a);
-    private static NibblePath Path2 => NibblePath.FromKey(Values.Key1b);
+    private static NibblePath Path1 => NibblePath.FromKey(Values.Key1A);
+    private static NibblePath Path2 => NibblePath.FromKey(Values.Key1B);
 
     private static ReadOnlySpan<byte> Data0 => new byte[] { 23 };
     private static ReadOnlySpan<byte> Data1 => new byte[] { 37 };
@@ -105,17 +105,17 @@ public class HashingMapTests
         e.MoveNext().Should().BeTrue();
         e.Current.Hash.Should().Be(hash0);
         e.Current.RawData.SequenceEqual(data0);
-        //e.Current.Key.Equals(key0).Should().BeTrue();
+        e.Current.Key.Equals(key0).Should().BeTrue();
 
         e.MoveNext().Should().BeTrue();
         e.Current.Hash.Should().Be(hash1);
         e.Current.RawData.SequenceEqual(data1);
-        //e.Current.Key.Equals(key1).Should().BeTrue();
+        e.Current.Key.Equals(key1).Should().BeTrue();
 
         e.MoveNext().Should().BeTrue();
         e.Current.Hash.Should().Be(hash2);
         e.Current.RawData.SequenceEqual(data2);
-        //e.Current.Key.Equals(key1).Should().BeTrue();
+        e.Current.Key.Equals(key2).Should().BeTrue();
 
         e.MoveNext().Should().BeFalse();
     }

--- a/src/Paprika.Tests/HashingMapTests.cs
+++ b/src/Paprika.Tests/HashingMapTests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Data;
+
+namespace Paprika.Tests;
+
+public class HashingMapTests
+{
+    private static NibblePath Key0 => NibblePath.FromKey(Values.Key0);
+    private static ReadOnlySpan<byte> Data0 => new byte[] { 23 };
+
+    [Test]
+    public void Set_Get()
+    {
+        Span<byte> span = stackalloc byte[HashingMap.MinSize];
+        var map = new HashingMap(span);
+
+        var key = Key.Account(Key0);
+
+        var hash = HashingMap.GetHash(key);
+        var data = Data0;
+
+        hash.Should().NotBe(HashingMap.NoCache);
+
+        map.SetAssert(hash, key, data);
+        map.GetAssert(hash, key, data);
+
+        map.TryGet(hash + 1, key, out _).Should().BeFalse();
+    }
+}
+
+static class TestExtensions
+{
+    public static void SetAssert(this HashingMap map, uint hash, in Key key, ReadOnlySpan<byte> data)
+    {
+        map.TrySet(hash, key, data).Should().BeTrue("TrySet should succeed");
+    }
+
+    public static void GetAssert(this HashingMap map, uint hash, in Key key, ReadOnlySpan<byte> expected)
+    {
+        map.TryGet(hash, key, out var actual).Should().BeTrue();
+        actual.SequenceEqual(expected).Should().BeTrue("Actual data should equal expected");
+    }
+}

--- a/src/Paprika.Tests/HashingMapTests.cs
+++ b/src/Paprika.Tests/HashingMapTests.cs
@@ -141,7 +141,7 @@ public class HashingMapTests
     }
 }
 
-static class TestExtensions
+static class HashingMapTestExtensions
 {
     public static void SetAssert(this HashingMap map, uint hash, in Key key, ReadOnlySpan<byte> data)
     {

--- a/src/Paprika.Tests/HashingMapTests.cs
+++ b/src/Paprika.Tests/HashingMapTests.cs
@@ -1,31 +1,97 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
+using Paprika.Crypto;
 using Paprika.Data;
 
 namespace Paprika.Tests;
 
 public class HashingMapTests
 {
-    private static NibblePath Key0 => NibblePath.FromKey(Values.Key0);
+    private static NibblePath Path0 => NibblePath.FromKey(Values.Key0);
+    private static NibblePath Path1 => NibblePath.FromKey(Values.Key1a);
     private static ReadOnlySpan<byte> Data0 => new byte[] { 23 };
+    private static ReadOnlySpan<byte> Data1 => new byte[] { 37 };
 
     [Test]
-    public void Set_Get()
+    public void Set_Get_Should_use_hash_for_operations()
     {
         Span<byte> span = stackalloc byte[HashingMap.MinSize];
         var map = new HashingMap(span);
 
-        var key = Key.Account(Key0);
+        var key = Key.Account(Path0);
 
         var hash = HashingMap.GetHash(key);
         var data = Data0;
 
-        hash.Should().NotBe(HashingMap.NoCache);
+        hash.Should().NotBe(HashingMap.Null);
 
         map.SetAssert(hash, key, data);
         map.GetAssert(hash, key, data);
 
-        map.TryGet(hash + 1, key, out _).Should().BeFalse();
+        var differentHash = hash + 1;
+        map.TryGet(differentHash, key, out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void On_full_should_report_false()
+    {
+        Span<byte> span = stackalloc byte[HashingMap.MinSize];
+        var map = new HashingMap(span);
+
+        var key0 = Key.Account(Path0);
+        var hash0 = HashingMap.GetHash(key0);
+
+        var key1 = Key.Account(Path0);
+        var hash1 = HashingMap.GetHash(key1);
+
+        var data = Data0;
+
+        hash0.Should().NotBe(HashingMap.Null);
+
+        map.SetAssert(hash0, key0, data);
+        map.TrySet(hash1, key1, data).Should().BeFalse();
+
+        map.GetAssert(hash0, key0, data);
+    }
+
+    [Test]
+    public void Colliding_hashes()
+    {
+        Span<byte> span = stackalloc byte[HashingMap.MinSize * 2];
+        var map = new HashingMap(span);
+
+        uint hash = 257;
+        var key0 = Key.Account(Path0);
+        var key1 = Key.Account(Path1);
+
+        var data0 = Data0;
+        var data1 = Data1;
+
+        map.SetAssert(hash, key0, data0);
+        map.SetAssert(hash, key1, data1);
+
+        map.GetAssert(hash, key0, data0);
+        map.GetAssert(hash, key1, data1);
+    }
+
+    [Test]
+    public void Clear()
+    {
+        Span<byte> span = stackalloc byte[HashingMap.MinSize];
+        var map = new HashingMap(span);
+
+        var key = Key.Account(Path0);
+
+        var hash = HashingMap.GetHash(key);
+        var data = Data0;
+
+        hash.Should().NotBe(HashingMap.Null);
+
+        map.SetAssert(hash, key, data);
+
+        map.Clear();
+
+        map.TryGet(hash, key, out _).Should().BeFalse();
     }
 }
 
@@ -39,6 +105,6 @@ static class TestExtensions
     public static void GetAssert(this HashingMap map, uint hash, in Key key, ReadOnlySpan<byte> expected)
     {
         map.TryGet(hash, key, out var actual).Should().BeTrue();
-        actual.SequenceEqual(expected).Should().BeTrue("Actual data should equal expected");
+        actual.SequenceEqual(expected).Should().BeTrue($"Actual data {actual.ToHexString(false)} should equal expected {expected.ToHexString(false)}");
     }
 }

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -70,11 +70,11 @@ public class DataPageTests : BasePageTests
         var value1B = GetValue(1);
 
         var updated = dataPage
-            .SetAccount(Key1a, value1A, batch)
-            .SetAccount(Key1b, value1B, batch);
+            .SetAccount(Key1A, value1A, batch)
+            .SetAccount(Key1B, value1B, batch);
 
-        updated.ShouldHaveAccount(Key1a, value1A, batch);
-        updated.ShouldHaveAccount(Key1b, value1B, batch);
+        updated.ShouldHaveAccount(Key1A, value1A, batch);
+        updated.ShouldHaveAccount(Key1B, value1B, batch);
     }
 
     [Test]
@@ -86,7 +86,7 @@ public class DataPageTests : BasePageTests
         var batch = NewBatch(BatchId);
         var dataPage = new DataPage(page);
 
-        const int count = 2 * 1024;
+        const int count = 1063;
 
         for (int i = 0; i < count; i++)
         {
@@ -101,6 +101,7 @@ public class DataPageTests : BasePageTests
             {
                 Debugger.Break();
             }
+
             dataPage.ShouldHaveAccount(key, GetValue(i), batch, i);
         }
     }

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -87,8 +87,6 @@ public class DataPageTests : BasePageTests
 
         const int count = 1 * 1024 * 1024;
 
-        const int offset = 0x12345678;
-
         for (int i = 0; i < count; i++)
         {
             var key = GetKey(i);
@@ -182,7 +180,8 @@ public class DataPageTests : BasePageTests
 
         // set the empty path which may happen on var-length scenarios
         var keccakKey = Key.KeccakOrRlp(NibblePath.Empty);
-        dataPage = dataPage.Set(new SetContext(keccakKey, Span<byte>.Empty, batch)).Cast<DataPage>();
+        var keccakHash = HashingMap.GetHash(keccakKey);
+        dataPage = dataPage.Set(new SetContext(keccakHash, keccakKey, Span<byte>.Empty, batch)).Cast<DataPage>();
 
         for (var i = 0; i < count; i++)
         {

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers.Binary;
+using System.Diagnostics;
 using FluentAssertions;
 using Nethermind.Int256;
 using NUnit.Framework;
@@ -85,7 +86,7 @@ public class DataPageTests : BasePageTests
         var batch = NewBatch(BatchId);
         var dataPage = new DataPage(page);
 
-        const int count = 1 * 1024 * 1024;
+        const int count = 2 * 1024;
 
         for (int i = 0; i < count; i++)
         {
@@ -96,7 +97,11 @@ public class DataPageTests : BasePageTests
         for (int i = 0; i < count; i++)
         {
             var key = GetKey(i);
-            dataPage.ShouldHaveAccount(key, GetValue(i), batch);
+            if (i == 811)
+            {
+                Debugger.Break();
+            }
+            dataPage.ShouldHaveAccount(key, GetValue(i), batch, i);
         }
     }
 
@@ -190,7 +195,8 @@ public class DataPageTests : BasePageTests
         }
 
         // assert
-        dataPage.TryGet(keccakKey, batch, out var value).Should().BeTrue();
+        var hash = HashingMap.GetHash(keccakKey);
+        dataPage.TryGet(hash, keccakKey, batch, out var value).Should().BeTrue();
         value.Length.Should().Be(0);
 
         for (int i = 0; i < count; i++)

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -175,7 +175,7 @@ public class DbTests
 
         static Keccak GetStorageAddress(int i)
         {
-            var address = Key1a;
+            var address = Key1A;
             BinaryPrimitives.WriteInt32LittleEndian(address.BytesAsSpan, i);
             return address;
         }

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -68,12 +68,16 @@ public static class TestExtensions
     public static DataPage SetStorage(this DataPage page, in Keccak key, in Keccak storage, ReadOnlySpan<byte> data,
         IBatchContext batch)
     {
-        return new DataPage(page.Set(new SetContext(Key.StorageCell(NibblePath.FromKey(key), storage), data, batch)));
+        var k = Key.StorageCell(NibblePath.FromKey(key), storage);
+        var hash = HashingMap.GetHash(k);
+        return new DataPage(page.Set(new SetContext(hash, k, data, batch)));
     }
 
     public static DataPage SetAccount(this DataPage page, in Keccak key, ReadOnlySpan<byte> data, IBatchContext batch)
     {
-        return new DataPage(page.Set(new SetContext(Key.Account(NibblePath.FromKey(key)), data, batch)));
+        var k = Key.Account(NibblePath.FromKey(key));
+        var hash = HashingMap.GetHash(k);
+        return new DataPage(page.Set(new SetContext(hash, k, data, batch)));
     }
 
     public static void ShouldHaveAccount(this DataPage read, in Keccak key, ReadOnlySpan<byte> expected,

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -91,7 +91,8 @@ public static class TestExtensions
             because += $" Iteration: {iteration}";
         }
         read.TryGet(hash, account, batch, out var value).Should().BeTrue(because);
-        value.SequenceEqual(expected).Should().BeTrue(because);
+        value.SequenceEqual(expected).Should()
+            .BeTrue($"Expected value is {expected.ToHexString(false)} while actual is {value.ToHexString(false)}");
     }
 
     public static void ShouldHaveStorage(this DataPage read, in Keccak key, in Keccak storage, ReadOnlySpan<byte> expected,

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -81,16 +81,26 @@ public static class TestExtensions
     }
 
     public static void ShouldHaveAccount(this DataPage read, in Keccak key, ReadOnlySpan<byte> expected,
-        IReadOnlyBatchContext batch)
+        IReadOnlyBatchContext batch, int? iteration = null)
     {
-        read.TryGet(Key.Account(key), batch, out var value).Should().BeTrue();
-        value.SequenceEqual(expected);
+        var account = Key.Account(key);
+        var hash = HashingMap.GetHash(account);
+        var because = $"Data for {account.Path.ToString()} should exist.";
+        if (iteration != null)
+        {
+            because += $" Iteration: {iteration}";
+        }
+        read.TryGet(hash, account, batch, out var value).Should().BeTrue(because);
+        value.SequenceEqual(expected).Should().BeTrue(because);
     }
 
     public static void ShouldHaveStorage(this DataPage read, in Keccak key, in Keccak storage, ReadOnlySpan<byte> expected,
         IReadOnlyBatchContext batch)
     {
-        read.TryGet(Key.StorageCell(NibblePath.FromKey(key), storage), batch, out var value).Should().BeTrue();
-        value.SequenceEqual(expected);
+        var storageCell = Key.StorageCell(NibblePath.FromKey(key), storage);
+        var hash = HashingMap.GetHash(storageCell);
+        var because = $"Storage at {storageCell.ToString()} should exist";
+        read.TryGet(hash, storageCell, batch, out var value).Should().BeTrue(because);
+        value.SequenceEqual(expected).Should().BeTrue();
     }
 }

--- a/src/Paprika.Tests/Values.cs
+++ b/src/Paprika.Tests/Values.cs
@@ -8,10 +8,10 @@ public static class Values
     public static readonly Keccak Key0 = new(new byte[]
         { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, });
 
-    public static readonly Keccak Key1a = new(new byte[]
+    public static readonly Keccak Key1A = new(new byte[]
         { 1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, });
 
-    public static readonly Keccak Key1b = new(new byte[]
+    public static readonly Keccak Key1B = new(new byte[]
         { 1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 8 });
 
     public static readonly UInt256 Balance0 = 13;

--- a/src/Paprika/Data/HashingMap.cs
+++ b/src/Paprika/Data/HashingMap.cs
@@ -1,0 +1,132 @@
+﻿using System.IO.Hashing;
+using System.Runtime.InteropServices;
+using Paprika.Crypto;
+
+namespace Paprika.Data;
+
+/// <summary>
+/// An in page map of key->value, used for storing values in upper levels of Paprika tree using a stable hashing.
+/// </summary>
+/// <remarks>
+/// The path is trimmed only for hashing purposes so that on all levels the same hash of the entry is used.
+/// This allows nice copying to the next level, without hash recalculation.
+///
+/// For 
+/// </remarks>
+public readonly ref struct HashingMap
+{
+    /// <summary>
+    /// A value set so that there top <see cref="SkipInitialNibbles"/> - 1 levels of the tree have a chance to be
+    /// cached in this map.
+    /// </summary>
+    private const int SkipInitialNibbles = 6;
+
+    private const int MinimumPathLength = Keccak.Size * NibblePath.NibblePerByte - SkipInitialNibbles;
+    public const uint NoCache = 0;
+    private const uint HasCache = 0b1000_0000_0000_0000;
+
+    private const int TypeBytes = 1;
+    private const int LengthOfLength = 1;
+    private const int MaxValueLength = 32;
+
+    // NibblePath.FullKeccakByteLength + TypeBytes + LengthPrefix + Keccak.Size + LengthPrefix + MaxValueLength;
+    private const int EntrySize = 88;
+    private const int HashSize = sizeof(uint);
+    private const int TotalEntrySize = EntrySize + HashSize;
+    private const int IndexOfNotFound = -1;
+    public const int MinSize = TotalEntrySize;
+
+    private readonly Span<uint> _hashes;
+    private readonly Span<byte> _entries;
+
+    public HashingMap(Span<byte> buffer)
+    {
+        var count = buffer.Length / TotalEntrySize;
+
+        _hashes = MemoryMarshal.Cast<byte, uint>(buffer).Slice(0, count);
+        _entries = buffer.Slice(count * HashSize);
+    }
+
+    public bool TryGet(uint hash, in Key key, out ReadOnlySpan<byte> value)
+    {
+        int position;
+        while ((position = _hashes.IndexOf(hash)) != IndexOfNotFound)
+        {
+            var entry = GetEntry(position);
+            var path = key.Path;
+
+            // ReSharper disable once StackAllocInsideLoop, highly unlikely as this should be only one hit
+            Span<byte> destination = stackalloc byte[path.MaxByteLength + TypeBytes + key.AdditionalKey.Length];
+            var prefix = GeneratePrefix(key, path, destination);
+
+            if (entry.StartsWith(prefix))
+            {
+                var dataLength = entry[prefix.Length];
+                value = entry.Slice(prefix.Length + LengthOfLength, dataLength);
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private Span<byte> GetEntry(int position) => _entries.Slice(position * EntrySize, EntrySize);
+
+    public bool TrySet(uint hash, in Key key, ReadOnlySpan<byte> value)
+    {
+        // no collision detection, just append at the first empty
+        var position = _hashes.IndexOf(NoCache);
+        if (position == IndexOfNotFound)
+        {
+            return false;
+        }
+
+        _hashes[position] = hash;
+
+        var path = key.Path;
+        Span<byte> destination = stackalloc byte[path.MaxByteLength + TypeBytes + key.AdditionalKey.Length];
+        var prefix = GeneratePrefix(key, path, destination);
+
+        // get the entry
+        var entry = GetEntry(position);
+
+        // copy to the entry
+        prefix.CopyTo(entry);
+        entry[prefix.Length] = (byte)value.Length;
+        value.CopyTo(entry.Slice(prefix.Length + LengthOfLength));
+
+        return true;
+    }
+
+    public static uint GetHash(in Key key)
+    {
+        if (CanBeCached(key))
+        {
+            var path = TrimPath(key);
+
+            Span<byte> destination = stackalloc byte[path.MaxByteLength + TypeBytes + key.AdditionalKey.Length];
+
+            var prefix = GeneratePrefix(key, path, destination);
+
+            return XxHash32.HashToUInt32(prefix) | HasCache;
+        }
+
+        return NoCache;
+    }
+
+    private static Span<byte> GeneratePrefix(in Key key, NibblePath sliced, Span<byte> destination)
+    {
+        var leftover = sliced.WriteToWithLeftover(destination);
+        leftover[0] = (byte)key.Type;
+        key.AdditionalKey.CopyTo(leftover.Slice(TypeBytes));
+
+        var written = destination.Slice(0,
+            destination.Length - leftover.Length + TypeBytes + key.AdditionalKey.Length);
+        return written;
+    }
+
+    private static NibblePath TrimPath(in Key key) => key.Path.SliceFrom(key.Path.Length - MinimumPathLength);
+
+    public static bool CanBeCached(in Key key) => key.Path.Length >= MinimumPathLength;
+}

--- a/src/Paprika/Data/HashingMap.cs
+++ b/src/Paprika/Data/HashingMap.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Hashing;
+﻿using System.Buffers;
+using System.IO.Hashing;
 using System.Runtime.InteropServices;
 using Paprika.Crypto;
 
@@ -22,7 +23,7 @@ public readonly ref struct HashingMap
     private const int SkipInitialNibbles = 6;
 
     private const int MinimumPathLength = Keccak.Size * NibblePath.NibblePerByte - SkipInitialNibbles;
-    public const uint NoCache = 0;
+    public const uint Null = 0;
     private const uint HasCache = 0b1000_0000_0000_0000;
 
     private const int TypeBytes = 1;
@@ -49,15 +50,20 @@ public readonly ref struct HashingMap
 
     public bool TryGet(uint hash, in Key key, out ReadOnlySpan<byte> value)
     {
-        int position;
-        while ((position = _hashes.IndexOf(hash)) != IndexOfNotFound)
+        var hashes = _hashes;
+
+        var offset = 0;
+        int index;
+
+        while ((index = hashes.IndexOf(hash)) != IndexOfNotFound)
         {
-            var entry = GetEntry(position);
-            var path = key.Path;
+            offset += index;
+
+            var entry = GetEntry(offset);
 
             // ReSharper disable once StackAllocInsideLoop, highly unlikely as this should be only one hit
-            Span<byte> destination = stackalloc byte[path.MaxByteLength + TypeBytes + key.AdditionalKey.Length];
-            var prefix = GeneratePrefix(key, path, destination);
+            Span<byte> destination = stackalloc byte[key.Path.MaxByteLength + TypeBytes + LengthOfLength + key.AdditionalKey.Length];
+            var prefix = WritePrefix(key, destination);
 
             if (entry.StartsWith(prefix))
             {
@@ -65,6 +71,15 @@ public readonly ref struct HashingMap
                 value = entry.Slice(prefix.Length + LengthOfLength, dataLength);
                 return true;
             }
+
+            if (index + 1 >= hashes.Length)
+            {
+                // the span is empty and there's not place to move forward
+                break;
+            }
+
+            hashes = hashes.Slice(index + 1);
+            offset += 1;
         }
 
         value = default;
@@ -76,7 +91,7 @@ public readonly ref struct HashingMap
     public bool TrySet(uint hash, in Key key, ReadOnlySpan<byte> value)
     {
         // no collision detection, just append at the first empty
-        var position = _hashes.IndexOf(NoCache);
+        var position = _hashes.IndexOf(Null);
         if (position == IndexOfNotFound)
         {
             return false;
@@ -84,9 +99,8 @@ public readonly ref struct HashingMap
 
         _hashes[position] = hash;
 
-        var path = key.Path;
-        Span<byte> destination = stackalloc byte[path.MaxByteLength + TypeBytes + key.AdditionalKey.Length];
-        var prefix = GeneratePrefix(key, path, destination);
+        Span<byte> destination = stackalloc byte[GetPrefixAllocationSize(key)];
+        var prefix = WritePrefix(key, destination);
 
         // get the entry
         var entry = GetEntry(position);
@@ -99,34 +113,176 @@ public readonly ref struct HashingMap
         return true;
     }
 
+    private static int GetPrefixAllocationSize(in Key key) =>
+        key.Path.MaxByteLength + // path 
+        TypeBytes +  // type
+        LengthOfLength + key.AdditionalKey.Length; // additional key
+
     public static uint GetHash(in Key key)
     {
         if (CanBeCached(key))
         {
-            var path = TrimPath(key);
+            var k = TrimToRightPathLenght(key);
 
-            Span<byte> destination = stackalloc byte[path.MaxByteLength + TypeBytes + key.AdditionalKey.Length];
+            Span<byte> destination = stackalloc byte[GetPrefixAllocationSize(key)];
 
-            var prefix = GeneratePrefix(key, path, destination);
+            var prefix = WritePrefix(k, destination);
 
             return XxHash32.HashToUInt32(prefix) | HasCache;
         }
 
-        return NoCache;
+        return Null;
     }
 
-    private static Span<byte> GeneratePrefix(in Key key, NibblePath sliced, Span<byte> destination)
+    public void Clear()
     {
-        var leftover = sliced.WriteToWithLeftover(destination);
+        _hashes.Clear();
+
+        // it's sufficient to clear the caches
+        //_entries.Clear();
+    }
+
+    private static Span<byte> WritePrefix(in Key key, Span<byte> destination)
+    {
+        var leftover = key.Path.WriteToWithLeftover(destination);
         leftover[0] = (byte)key.Type;
-        key.AdditionalKey.CopyTo(leftover.Slice(TypeBytes));
+        leftover[TypeBytes] = (byte)key.AdditionalKey.Length;
+
+        key.AdditionalKey.CopyTo(leftover.Slice(TypeBytes + LengthOfLength));
 
         var written = destination.Slice(0,
-            destination.Length - leftover.Length + TypeBytes + key.AdditionalKey.Length);
+            destination.Length - leftover.Length + TypeBytes + LengthOfLength + key.AdditionalKey.Length);
         return written;
     }
+    //
+    // private static Enumerator.Item ParseItem(ReadOnlySpan<byte> entry)
+    // {
+    //     var leftover = NibblePath.ReadFrom(entry, out var path);
+    //     var type = (DataType)leftover[0];
+    //
+    //     var leftover = sliced.WriteToWithLeftover(destination);
+    //     leftover[0] = (byte)key.Type;
+    //     key.AdditionalKey.CopyTo(leftover.Slice(TypeBytes));
+    //
+    //     var written = destination.Slice(0,
+    //         destination.Length - leftover.Length + TypeBytes + key.AdditionalKey.Length);
+    //     return written;
+    // }
+    //
+    // public Enumerator GetEnumerator() => new(this);
+    //
+    // public ref struct Enumerator
+    // {
+    //     /// <summary>The map being enumerated.</summary>
+    //     private readonly HashingMap _map;
+    //
+    //     private readonly int _count;
+    //
+    //     /// <summary>The next index to yield.</summary>
+    //     private int _index;
+    //
+    //     internal Enumerator(HashingMap map)
+    //     {
+    //         _map = map;
+    //         _count = map._hashes.IndexOf(Null);
+    //     }
+    //
+    //     /// <summary>Advances the enumerator to the next element of the span.</summary>
+    //     public bool MoveNext()
+    //     {
+    //         int index = _index + 1;
+    //         if (index < _count)
+    //         {
+    //             _index = index;
+    //             return true;
+    //         }
+    //
+    //         return false;
+    //     }
+    //
+    //     public Item Current
+    //     {
+    //         get
+    //         {
+    //             var hash = _map._hashes[_index];
+    //             var entry = _map.GetEntry(_index);
+    //
+    //             ref var slot = ref _map._slots[_index];
+    //             var span = _map.GetSlotPayload(ref slot);
+    //
+    //             ReadOnlySpan<byte> data;
+    //             NibblePath path;
+    //
+    //             // path rebuilding
+    //             Span<byte> nibbles = stackalloc byte[3];
+    //             var count = slot.DecodeNibblesFromPrefix(nibbles);
+    //
+    //             if (count == 0)
+    //             {
+    //                 // no nibbles stored in the slot, read as is.
+    //                 data = NibblePath.ReadFrom(span, out path);
+    //             }
+    //             else
+    //             {
+    //                 // there's at least one nibble extracted
+    //                 var raw = NibblePath.RawExtract(span);
+    //                 data = span.Slice(raw.Length);
+    //
+    //                 const int space = 2;
+    //
+    //                 var bytes = _bytes.AsSpan(0, raw.Length + space); //big enough to handle all cases
+    //
+    //                 // copy forward enough to allow negative pointer arithmetics
+    //                 var pathDestination = bytes.Slice(space);
+    //                 raw.CopyTo(pathDestination);
+    //
+    //                 // Terribly unsafe region!
+    //                 // Operate on the copy, pathDestination, as it will be overwritten with unsafe ref.
+    //                 NibblePath.ReadFrom(pathDestination, out path);
+    //
+    //                 var countOdd = (byte)(count & 1);
+    //                 for (var i = 0; i < count; i++)
+    //                 {
+    //                     path.UnsafeSetAt(i - count - 1, countOdd, nibbles[i]);
+    //                 }
+    //
+    //                 path = path.CopyWithUnsafePointerMoveBack(count);
+    //             }
+    //
+    //             if (slot.Type == DataType.StorageCell)
+    //             {
+    //                 const int size = Keccak.Size;
+    //                 var additionalKey = data.Slice(0, size);
+    //                 return new Item(Key.StorageCell(path, additionalKey), data.Slice(size), slot.Type);
+    //             }
+    //
+    //             return new Item(Key.Raw(path, slot.Type), data, slot.Type);
+    //         }
+    //     }
+    //
+    //     public void Dispose()
+    //     {
+    //         if (_bytes != null)
+    //             ArrayPool<byte>.Shared.Return(_bytes);
+    //     }
+    //
+    //     public readonly ref struct Item
+    //     {
+    //         public uint Hash { get; }
+    //         public DataType Type { get; }
+    //         public Key Key { get; }
+    //         public ReadOnlySpan<byte> RawData { get; }
+    //
+    //         public Item(Key key, ReadOnlySpan<byte> rawData, DataType type)
+    //         {
+    //             Type = type;
+    //             Key = key;
+    //             RawData = rawData;
+    //         }
+    //     }
+    // }
 
-    private static NibblePath TrimPath(in Key key) => key.Path.SliceFrom(key.Path.Length - MinimumPathLength);
+    private static Key TrimToRightPathLenght(in Key key) => key.SliceFrom(key.Path.Length - MinimumPathLength);
 
     public static bool CanBeCached(in Key key) => key.Path.Length >= MinimumPathLength;
 }

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -87,6 +87,11 @@ public readonly ref struct Key
 
     public Key SliceFrom(int nibbles) => new(Path.SliceFrom(nibbles), Type, AdditionalKey);
 
+    public bool Equals(in Key key)
+    {
+        return Type == key.Type && AdditionalKey.SequenceEqual(key.AdditionalKey) && Path.Equals(key.Path);
+    }
+
     public override string ToString()
     {
         return $"{nameof(Path)}: {Path.ToString()}, " +

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -68,6 +68,8 @@ public readonly ref struct NibblePath
     /// </summary>
     public int MaxByteLength => Length / 2 + 2;
 
+    public const int FullKeccakByteLength = Keccak.Size / 2 + 2;
+
     /// <summary>
     /// Writes the nibble path into the destination.
     /// </summary>

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -169,7 +169,7 @@ public readonly unsafe struct DataPage : IPage
         foreach (var item in map.EnumerateNibble(biggestNibble))
         {
             var key = item.Key.SliceFrom(NibbleCount);
-            var set = new SetContext(key, item.RawData, ctx.Batch);
+            var set = new SetContext(HashingMap.GetHash(key), key, item.RawData, ctx.Batch);
 
             dataPage = new DataPage(dataPage.Set(set));
 
@@ -317,7 +317,7 @@ public readonly unsafe struct DataPage : IPage
                 // it's ok to use item.Key, the enumerator does not changes the additional key bytes
                 var key = Key.StorageTreeStorageCell(item.Key);
 
-                dataPage = new DataPage(dataPage.Set(new SetContext(key, item.RawData, ctx.Batch)));
+                dataPage = new DataPage(dataPage.Set(new SetContext(HashingMap.GetHash(key), key, item.RawData, ctx.Batch)));
 
                 // fast delete by enumerator item
                 map.Delete(item);
@@ -343,9 +343,10 @@ public readonly unsafe struct DataPage : IPage
 
         // build a new key, based just on the storage key as the root is addressed by the account address
         var inTreeAddress = Key.StorageTreeStorageCell(ctx.Key);
+        var hash = HashingMap.GetHash(inTreeAddress);
 
         var updatedStorageTree =
-            new DataPage(storageTree).Set(new SetContext(inTreeAddress, ctx.Data, ctx.Batch));
+            new DataPage(storageTree).Set(new SetContext(hash, inTreeAddress, ctx.Data, ctx.Batch));
 
         if (updatedStorageTree.Raw != storageTree.Raw)
         {

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -109,7 +109,7 @@ public readonly unsafe struct DataPage : IPage
                     {
                         var context = new SetContext(item.Hash, item.Key, item.RawData, ctx.Batch);
 
-                        ref var addr = ref Data.Buckets[nibble];
+                        ref var addr = ref Data.Buckets[item.Key.Path.FirstNibble];
 
                         var page = ctx.Batch.GetAt(addr);
                         var updated = new DataPage(page).Set(context.SliceFrom(NibbleCount));

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -346,7 +346,10 @@ public class PagedDb : IPageResolver, IDb, IDisposable
 
             ref var addr = ref TryGetPageAlloc(key.Path.FirstNibble, out var page);
             var sliced = key.SliceFrom(RootPage.Payload.RootNibbleLevel);
-            var updated = page.Set(new SetContext(sliced, rawData, this));
+
+            var hash = HashingMap.GetHash(sliced);
+
+            var updated = page.Set(new SetContext(hash, sliced, rawData, this));
             addr = _db.GetAddress(updated);
         }
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -265,7 +265,9 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            return new DataPage(GetAt(addr)).TryGet(key.SliceFrom(RootPage.Payload.RootNibbleLevel), this, out result);
+            var sliced = key.SliceFrom(RootPage.Payload.RootNibbleLevel);
+            var hash = HashingMap.GetHash(sliced);
+            return new DataPage(GetAt(addr)).TryGet(hash, sliced, this, out result);
         }
 
         public uint BatchId { get; }
@@ -332,7 +334,9 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            return new DataPage(GetAt(addr)).TryGet(key.SliceFrom(RootPage.Payload.RootNibbleLevel), this, out result);
+            var sliced = key.SliceFrom(RootPage.Payload.RootNibbleLevel);
+            var hash = HashingMap.GetHash(sliced);
+            return new DataPage(GetAt(addr)).TryGet(hash, sliced, this, out result);
         }
 
         public void SetMetadata(uint blockNumber, in Keccak blockHash)

--- a/src/Paprika/Store/SetContext.cs
+++ b/src/Paprika/Store/SetContext.cs
@@ -7,12 +7,14 @@ namespace Paprika.Store;
 /// </summary>
 public readonly ref struct SetContext
 {
+    public readonly uint Hash;
     public readonly Key Key;
     public readonly IBatchContext Batch;
     public readonly ReadOnlySpan<byte> Data;
 
-    public SetContext(Key key, ReadOnlySpan<byte> data, IBatchContext batch)
+    public SetContext(uint hash, Key key, ReadOnlySpan<byte> data, IBatchContext batch)
     {
+        Hash = hash;
         Key = key;
         Batch = batch;
         Data = data;
@@ -21,5 +23,5 @@ public readonly ref struct SetContext
     /// <summary>
     /// Creates the set context with the <see cref="Key"/> sliced from the given nibble.
     /// </summary>
-    public SetContext SliceFrom(int nibbleCount) => new(Key.SliceFrom(nibbleCount), Data, Batch);
+    public SetContext SliceFrom(int nibbleCount) => new(Hash, Key.SliceFrom(nibbleCount), Data, Batch);
 }


### PR DESCRIPTION
This PR introduces another attempt in making writes much faster. It introduces another type of map, `HashingMap` that is based on a non-cryptographic hash of the `Key` that is inserted. The `DataPage`, once it has all the pointers to its children set, will change its behavior from `NibbleBasedMap` to use the `HashingMap`. The crux with the hashing is that the hash is based on the tail of the path, so that if a value is pushed down in the tree of Paprika, the hash does not change and can be easily remembered and passed down, without mundane recalculations. It might be changed later as passing down the hash is quite demanding. The impact is mainly IO related, as this PR greatly reduces the number of pages flushed to disk, therefore reduces the time spent in `RandomAccess.WriteAsync` and `fsync`/`FlushFileBuffers`.

### Considerations for further work

1. One could try to not flush everything at once from the `HashingMap` but rather pick up one nibble and flush it down. It's up to debate how impactful that would be as flushing the map once, allows later to fill it from 0. When flushing just a section, only one child page is written, but it does not empty the map.
2. One more consideration is path walking. If a pathwalking is required, depending on the Merkle, the hashing construct potentially should be amended to allow it in an efficient manner.
3. If pathwalking is not required that much, maybe the nibble based map could be ditched altogether? Why not to use the hash based only?