### PR TITLE
Merkle foundations with pre-commit hook

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -130,7 +130,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            await using (var blockchain = new Blockchain(db, FlushEvery, 1000, reporter.Observe))
+            await using (var blockchain = new Blockchain(db, null, FlushEvery, 1000, reporter.Observe))
             {
                 counter = Writer(blockchain, bigStorageAccount, random, layout[writing]);
             }

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -1,0 +1,74 @@
+﻿using Paprika.Data;
+using Paprika.Utils;
+
+namespace Paprika.Chain;
+
+/// <summary>
+/// A pre-commit behavior run by <see cref="Blockchain"/> component just before commiting a <see cref="IWorldState"/>
+/// with <see cref="IWorldState.Commit"/>. Useful to provide concerns, like the Merkle construct and others.
+/// </summary>
+public interface IPreCommitBehavior
+{
+    /// <summary>
+    /// Executed just before commit.
+    /// </summary>
+    /// <param name="commit">The object representing the commit.</param>
+    public void BeforeCommit(ICommit commit);
+}
+
+/// <summary>
+/// The set of changes applied by <see cref="IWorldState"/>.
+/// Allows for additional modifications of the data just before the commit.
+/// </summary>
+/// <remarks>
+/// To access all the keys use the enumerator:
+///
+/// public static void Foreach(this ICommit commit)
+/// {
+///     foreach (var key in commit)
+///     {
+///         key.
+///     }
+///  }
+/// </remarks>
+public interface ICommit
+{
+    /// <summary>
+    /// Tries to retrieve the result stored under the given key.
+    /// </summary>
+    /// <returns>
+    /// Whether the retrieval was successful.
+    /// </returns>
+    /// <remarks>
+    /// If successful, returns a result as an owner. Must be disposed properly.
+    /// </remarks>
+    public bool TryGet(in Key key, out ReadOnlySpanOwner<byte> result);
+
+    /// <summary>
+    /// Sets the value under the given key.
+    /// </summary>
+    void Set(in Key key, in ReadOnlySpan<byte> payload);
+
+    /// <summary>
+    /// Gets the enumerator for the keys in the given commit.
+    /// </summary>
+    /// <returns></returns>
+    IKeyEnumerator GetEnumerator();
+}
+
+/// <summary>
+/// The <see cref="Key"/> enumerator.
+/// </summary>
+public interface IKeyEnumerator : IDisposable
+{
+    /// <summary>
+    /// The current key.
+    /// </summary>
+    ref readonly Key Current { get; }
+
+    /// <summary>
+    /// Moves to the next.
+    /// </summary>
+    public bool MoveNext();
+}
+


### PR DESCRIPTION
This PR introduces a seam for the place where `Merkle` construct will be created. It is done in a way, so that `Verkle` construct in a future should be also easy to inject into it as a similar, but separate, implementation. The implementation in the `blockchain` is not done yet, but it should not prevent users from using the seam.

Effectively, this allows to implement the Merkle construct as 

```
class Merkle : IPreCommitBehavior
{
    public void BeforeCommit(ICommit commit)
    {
      // build the Merkle construct and remember to store the root under `Key.Merkle('')`
    }
}