### PR TITLE
Fix for the write error

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -14,7 +14,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 10_000 : 3_000;
+    private const int BlockCount = PersistentDb ? 20_000 : 3_000;
     private const int RandomSampleSize = 260_000_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -86,23 +86,19 @@ public class DataPageTests : BasePageTests
         var batch = NewBatch(BatchId);
         var dataPage = new DataPage(page);
 
-        const int count = 1063;
+        const int count = 128 * 1024;
+        const int seed = 13;
 
-        for (int i = 0; i < count; i++)
+        var random = new Random(seed);
+        for (var i = 0; i < count; i++)
         {
-            var key = GetKey(i);
-            dataPage = dataPage.SetAccount(key, GetValue(i), batch);
+            dataPage = dataPage.SetAccount(random.NextKeccak(), GetValue(i), batch);
         }
 
-        for (int i = 0; i < count; i++)
+        random = new Random(seed);
+        for (var i = 0; i < count; i++)
         {
-            var key = GetKey(i);
-            if (i == 811)
-            {
-                Debugger.Break();
-            }
-
-            dataPage.ShouldHaveAccount(key, GetValue(i), batch, i);
+            dataPage.ShouldHaveAccount(random.NextKeccak(), GetValue(i), batch, i);
         }
     }
 

--- a/src/Paprika.Tests/Store/DbAddressTests.cs
+++ b/src/Paprika.Tests/Store/DbAddressTests.cs
@@ -13,6 +13,16 @@ public class DbAddressTests
         var a2 = DbAddress.Page(2);
 
         // ReSharper disable once EqualExpressionComparison
-        object.Equals(a1, a1).Should().BeTrue();
+        Equals(a1, a1).Should().BeTrue();
+        Equals(a1, a2).Should().BeFalse();
+    }
+
+    [Test]
+    public void FileOffset_overflow()
+    {
+        long page = Page.PageCount - 1;
+        var address = DbAddress.Page((uint)page);
+
+        address.FileOffset.Should().Be(page * Page.PageSize);
     }
 }

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -105,4 +105,11 @@ public static class TestExtensions
         read.TryGet(hash, storageCell, batch, out var value).Should().BeTrue(because);
         value.SequenceEqual(expected).Should().BeTrue();
     }
+
+    public static Keccak NextKeccak(this Random random)
+    {
+        Keccak keccak = default;
+        random.NextBytes(keccak.BytesAsSpan);
+        return keccak;
+    }
 }

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -52,7 +52,8 @@ public class Blockchain : IAsyncDisposable
 
     private static readonly TimeSpan DefaultFlushDelay = TimeSpan.FromSeconds(1);
 
-    public Blockchain(PagedDb db, TimeSpan? minFlushDelay = null, int? finalizationQueueLimit = null, Action? beforeMetricsDisposed = null)
+    public Blockchain(PagedDb db, TimeSpan? minFlushDelay = null, int? finalizationQueueLimit = null,
+        Action? beforeMetricsDisposed = null)
     {
         _db = db;
         _minFlushDelay = minFlushDelay ?? DefaultFlushDelay;
@@ -76,7 +77,8 @@ public class Blockchain : IAsyncDisposable
             });
         }
 
-        var genesis = new Block(GenesisHash, new ReadOnlyBatchCountingRefs(db.BeginReadOnlyBatch()), GenesisHash, 0, this);
+        var genesis = new Block(GenesisHash, new ReadOnlyBatchCountingRefs(db.BeginReadOnlyBatch()), GenesisHash, 0,
+            this);
 
         _blocksByNumber[0] = new[] { genesis };
         _blocksByHash[GenesisHash] = genesis;
@@ -134,14 +136,24 @@ public class Blockchain : IAsyncDisposable
 
                 timer.Stop();
 
+                // measure
+                var count = flushed.Count;
+
+                if (count == 0)
+                {
+                    // nothing
+                    continue;
+                }
+
                 var flushWatch = Stopwatch.StartNew();
                 _db.Flush();
                 _flusherFlushInMs.Record((int)flushWatch.ElapsedMilliseconds);
 
-                // measure
-                var count = flushed.Count;
+                if (timer.ElapsedMilliseconds > 0)
+                {
+                    _flusherBlockPerS.Record((int)(count * 1000 / timer.ElapsedMilliseconds));
+                }
 
-                _flusherBlockPerS.Record((int)(count * 1000 / timer.ElapsedMilliseconds));
                 _flusherQueueCount.Subtract(count);
 
                 // publish the reader to the blocks following up the flushed one
@@ -286,7 +298,8 @@ public class Blockchain : IAsyncDisposable
         // one of: Block as the parent, or IReadOnlyBatch if flushed
         private RefCountingDisposable _previous;
 
-        public Block(Keccak parentHash, RefCountingDisposable parent, Keccak hash, uint blockNumber, Blockchain blockchain)
+        public Block(Keccak parentHash, RefCountingDisposable parent, Keccak hash, uint blockNumber,
+            Blockchain blockchain)
         {
             _previous = parent;
             _blockchain = blockchain;

--- a/src/Paprika/Crypto/Keccak.cs
+++ b/src/Paprika/Crypto/Keccak.cs
@@ -36,7 +36,7 @@ public readonly struct Keccak : IEquatable<Keccak>
     /// <returns>
     ///     <string>0x0000000000000000000000000000000000000000000000000000000000000000</string>
     /// </returns>
-    public static Keccak Zero { get; } = default;
+    public static Keccak Zero => default;
 
     public Keccak(byte[]? bytes)
     {

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -1,4 +1,5 @@
-﻿using Paprika.Crypto;
+﻿using System.Diagnostics;
+using Paprika.Crypto;
 using Paprika.Store;
 
 namespace Paprika.Data;
@@ -85,6 +86,7 @@ public readonly ref struct Key
     public static Key KeccakOrRlp(NibblePath path) =>
         new(path, DataType.KeccakOrRlp, ReadOnlySpan<byte>.Empty);
 
+    [DebuggerStepThrough]
     public Key SliceFrom(int nibbles) => new(Path.SliceFrom(nibbles), Type, AdditionalKey);
 
     public bool Equals(in Key key)

--- a/src/Paprika/Data/NibbleBasedMap.cs
+++ b/src/Paprika/Data/NibbleBasedMap.cs
@@ -1,5 +1,6 @@
 ﻿using System.Buffers;
 using System.Diagnostics;
+using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Paprika.Crypto;
@@ -614,6 +615,11 @@ public readonly ref struct NibbleBasedMap
                 $"{nameof(Type)}: {Type}, {nameof(Prefix)}: {Prefix}, {nameof(ItemAddress)}: {ItemAddress}";
         }
     }
+
+    public override string ToString() =>
+        $"{nameof(Count)}: {Count}, " +
+        $"{nameof(CapacityLeft)}: {CapacityLeft}, " +
+        $"Hash of content: {XxHash32.HashToUInt32(_raw)}";
 
     [StructLayout(LayoutKind.Explicit, Size = Size)]
     private struct Header

--- a/src/Paprika/Store/DbAddress.cs
+++ b/src/Paprika/Store/DbAddress.cs
@@ -26,6 +26,14 @@ public readonly struct DbAddress : IEquatable<DbAddress>
     public uint Raw => _value;
 
     /// <summary>
+    /// Gets the offset in the file.
+    /// </summary>
+    /// <remarks>
+    /// Long here is required! Otherwise int overflow will turn it to negative value!
+    /// </remarks>
+    public long FileOffset => (long)_value * Store.Page.PageSize;
+
+    /// <summary>
     /// Creates a database address that represents a jump to another database <see cref="Store.Page"/>.
     /// </summary>
     /// <param name="page">The page to go to.</param>

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -71,8 +71,9 @@ public class MemoryMappedPageManager : PointerPageManager
             {
                 // a regular address to write
                 _pendingWrites.Add(WriteAt(addr).AsTask());
-                await AwaitWrites();
             }
+
+            await AwaitWrites();
         }
 
         if (options != CommitOptions.DangerNoFlush && options != CommitOptions.DangerNoWrite)
@@ -83,9 +84,8 @@ public class MemoryMappedPageManager : PointerPageManager
 
     private ValueTask WriteAt(DbAddress addr)
     {
-        var offset = addr.Raw * Page.PageSize;
         var page = GetAt(addr);
-        return RandomAccess.WriteAsync(_file.SafeFileHandle, Own(page).Memory, offset);
+        return RandomAccess.WriteAsync(_file.SafeFileHandle, Own(page).Memory, addr.FileOffset);
     }
 
     private async Task AwaitWrites()

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -21,10 +21,7 @@ public abstract unsafe class PointerPageManager : IPageManager
 
         Debug.Assert(address.IsValidPageAddress, "The address page is invalid and breaches max page count");
 
-        // Long here is required! Otherwise int overflow will turn it to negative value!
-        // ReSharper disable once SuggestVarOrType_BuiltInTypes
-        long offset = ((long)(int)address) * Page.PageSize;
-        return new Page((byte*)Ptr + offset);
+        return new Page((byte*)Ptr + address.FileOffset);
     }
 
     public DbAddress GetAddress(in Page page)

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -418,6 +418,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             _db.ReportCommit(watch.Elapsed);
         }
 
+        [DebuggerStepThrough]
         public override Page GetAt(DbAddress address) => _db.GetAt(address);
 
         public override DbAddress GetAddress(Page page) => _db.GetAddress(page);


### PR DESCRIPTION
This PR focuses on fixing the overflow error 😭 . The data were written at the wrong page as the offset silently overflown in the `MemoryMappedPageManager`. Now, with a new property of `DbAddress` that does the calculation in one place this should not be the case.

Additionally, a few `[DebuggerStepThrough]` are added to help future battles.

One more thing is that `AwaitWrites` are properly awaited at the end of the writing loop!