### PR TITLE
Fluent assertions

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -14,7 +14,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 20_000 : 3_000;
+    private const int BlockCount = PersistentDb ? 25_000 : 3_000;
     private const int RandomSampleSize = 260_000_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;

--- a/src/Paprika.Tests/Data/NibblePathTests.PrefixTests.cs
+++ b/src/Paprika.Tests/Data/NibblePathTests.PrefixTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using FluentAssertions;
+using NUnit.Framework;
 using Paprika.Data;
 
 namespace Paprika.Tests.Data;
@@ -28,8 +29,9 @@ public class NibblePathHexPrefixTests
         Span<byte> destination = stackalloc byte[path.HexEncodedLength];
 
         path.HexEncode(destination, flag);
-        Assert.AreEqual(1, destination.Length);
-        Assert.AreEqual(byte1, destination[0]);
+
+        destination.Length.Should().Be(1);
+        destination[0].Should().Be(byte1);
     }
 
     [TestCase(false, (byte)3, (byte)7, (byte)13, (byte)19, (byte)125)]
@@ -52,9 +54,8 @@ public class NibblePathHexPrefixTests
         Span<byte> destination = stackalloc byte[path.HexEncodedLength];
         path.HexEncode(destination, flag);
 
-        Assert.AreEqual(2, path.HexEncodedLength);
-        Assert.AreEqual(byte1, destination[0]);
-        Assert.AreEqual(byte2, destination[1]);
+        path.HexEncodedLength.Should().Be(2);
+        destination.ToArray().Should().BeEquivalentTo(new[] { byte1, byte2 });
     }
 
     [TestCase(false, (byte)3, (byte)7, (byte)0, (byte)55)]
@@ -77,9 +78,8 @@ public class NibblePathHexPrefixTests
 
         path.HexEncode(destination, flag);
 
-        Assert.AreEqual(2, path.HexEncodedLength);
-        Assert.AreEqual(byte1, destination[0]);
-        Assert.AreEqual(byte2, destination[1]);
+        path.HexEncodedLength.Should().Be(2);
+        destination.ToArray().Should().BeEquivalentTo(new[] { byte1, byte2 });
     }
 
     // [TestCase(false, (byte)3, (byte)7, (byte)0, (byte)55)]

--- a/src/Paprika.Tests/Data/NibblePathTests.cs
+++ b/src/Paprika.Tests/Data/NibblePathTests.cs
@@ -23,7 +23,7 @@ public class NibblePathTests
 
         NibblePath.ReadFrom(destination, out var parsed);
 
-        Assert.IsTrue(parsed.Equals(path));
+        parsed.Equals(path).Should().BeTrue();
     }
 
     [Test]
@@ -63,8 +63,8 @@ public class NibblePathTests
 
     private static void AssertDiffAt(in NibblePath path1, in NibblePath path2, int diffAt)
     {
-        Assert.AreEqual(diffAt, path1.FindFirstDifferentNibble(path2));
-        Assert.AreEqual(diffAt, path2.FindFirstDifferentNibble(path1));
+        path1.FindFirstDifferentNibble(path2).Should().Be(diffAt);
+        path2.FindFirstDifferentNibble(path1).Should().Be(diffAt);
     }
 
     [Test]
@@ -155,35 +155,35 @@ public class NibblePathTests
         var sliced = original.SliceFrom(sliceFrom);
         var expected = NibblePath.FromKey(span.Slice(sliceFrom / 2), 0);
 
-        Assert.IsTrue(expected.Equals(sliced));
+        expected.Equals(sliced).Should().BeTrue();
     }
 
     [Test]
     public void ToString_even_even()
     {
         var path = NibblePath.FromKey(stackalloc byte[] { 0x12, 0x34, 0x56, 0x78 });
-        Assert.AreEqual("12345678", path.ToString());
+        path.ToString().Should().Be("12345678");
     }
 
     [Test]
     public void ToString_odd_odd()
     {
         var path = NibblePath.FromKey(stackalloc byte[] { 0x12, 0x34, 0x56, 0x78 }, 1);
-        Assert.AreEqual("2345678", path.ToString());
+        path.ToString().Should().Be("2345678");
     }
 
     [Test]
     public void ToString_odd_even()
     {
         var path = NibblePath.FromKey(stackalloc byte[] { 0x12, 0x34, 0x56, 0x78 }, 1).SliceTo(6);
-        Assert.AreEqual("234567", path.ToString());
+        path.ToString().Should().Be("234567");
     }
 
     [Test]
     public void ToString_even_odd()
     {
         var path = NibblePath.FromKey(stackalloc byte[] { 0x12, 0x34, 0x56, 0x78 }).SliceTo(7);
-        Assert.AreEqual("1234567", path.ToString());
+        path.ToString().Should().Be("1234567");
     }
 
     [TestCase(0, false, 1)]
@@ -193,7 +193,7 @@ public class NibblePathTests
     public void NibbleAt(int at, bool odd, byte result)
     {
         var path = NibblePath.FromKey(stackalloc byte[] { 0x12, 0x34, 0x56 }, odd ? 1 : 0);
-        Assert.AreEqual(result, path.GetAt(at));
+        path.GetAt(at).Should().Be(result);
     }
 
     [TestCase(0, 4)]


### PR DESCRIPTION
This PR replaces obsolete `Assert.AreEqual` with fluent assertions based on `.Should`