### PR TITLE
Clean runner

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -35,7 +35,6 @@ public static class Program
     private const int UseStorageEveryNAccounts = 10;
     private const bool UseBigStorageAccount = false;
     private const int BigStorageAccountSlotCount = 1_000_000;
-    private static readonly UInt256[] BigStorageAccountValues = new UInt256[BigStorageAccountSlotCount];
 
     public static async Task Main(String[] args)
     {
@@ -167,7 +166,7 @@ public static class Program
                 {
                     var index = i % BigStorageAccountSlotCount;
                     var storageAddress = GetStorageAddress(index);
-                    var expectedStorageValue = BigStorageAccountValues[index];
+                    var expectedStorageValue = GetBigAccountValue(index);
                     var actualStorage = read.GetStorage(bigStorageAccount, storageAddress);
 
                     if (actualStorage != expectedStorageValue)
@@ -264,8 +263,7 @@ public static class Program
 
                     var index = counter % BigStorageAccountSlotCount;
                     var storageAddress = GetStorageAddress(index);
-                    var storageValue = GetBigAccountStorageValue(counter);
-                    BigStorageAccountValues[index] = storageValue;
+                    var storageValue = GetBigAccountValue(counter);
 
                     worldState.SetStorage(bigStorageAccount, storageAddress, storageValue);
                 }
@@ -333,4 +331,7 @@ public static class Program
         BinaryPrimitives.WriteInt32LittleEndian(key.BytesAsSpan, counter);
         return key;
     }
+
+    private static UInt256 GetBigAccountValue(int counter) =>
+        new((ulong)(counter * 2246822519U), (ulong)(counter * 374761393U));
 }

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -313,8 +313,6 @@ public static class Program
 
     private static UInt256 GetStorageValue(int counter) => (UInt256)counter + 100000;
 
-    private static UInt256 GetBigAccountStorageValue(int counter) => (UInt256)counter + 123456;
-
     private static Keccak GetBigAccountKey()
     {
         Keccak key = default;


### PR DESCRIPTION
The PR cleans the runner from the account allocations, moving it back to `Random` to don't allocate when not needed