### PR TITLE
Tree reporting

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -14,8 +14,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 25_000 : 3_000;
-    private const int RandomSampleSize = 260_000_000;
+    private const int BlockCount = PersistentDb ? 5_000 : 3_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;
     private const int FinalizeEvery = 32;
@@ -131,7 +130,7 @@ public static class Program
             }
 
             // waiting for finalization
-            var read = db.BeginReadOnlyBatch();
+            using var read = db.BeginReadOnlyBatch();
 
             var readingStopWatch = Stopwatch.StartNew();
             random = BuildRandom();
@@ -183,6 +182,9 @@ public static class Program
 
             // the final report
             ReportReading(counter);
+
+            var statistics = new StatisticsReporter();
+            read.Report(statistics);
 
             spectre.Cancel();
             await reportingTask;

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -14,7 +14,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 5_000 : 3_000;
+    private const int BlockCount = PersistentDb ? 25_000 : 3_000;
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;
     private const int FinalizeEvery = 32;
@@ -183,8 +183,23 @@ public static class Program
             // the final report
             ReportReading(counter);
 
-            var statistics = new StatisticsReporter();
-            read.Report(statistics);
+            var stats = new StatisticsReporter();
+            read.Report(stats);
+            var table = new Table();
+
+            table.AddColumn(new TableColumn("Level of Paprika tree"));
+            table.AddColumn(new TableColumn("Child page count"));
+            table.AddColumn(new TableColumn("Entries in page"));
+
+            foreach (var (key, level) in stats.Levels)
+            {
+                table.AddRow(
+                    new Text(key.ToString()),
+                    new Text(level.ChildCount.GetValueAtPercentile(90).ToString()),
+                    new Text(level.Entries.GetValueAtPercentile(90).ToString()));
+            }
+
+            layout[info].Update(new Panel(table.Expand()).Header("Paprika tree statistics").Expand());
 
             spectre.Cancel();
             await reportingTask;

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -278,6 +278,9 @@ public class Blockchain : IAsyncDisposable
                 Dispose();
             }
         }
+
+        public void Report(IReporter reporter) =>
+            throw new NotImplementedException("One should not report over a block");
     }
 
     /// <summary>

--- a/src/Paprika/Data/HashingMap.cs
+++ b/src/Paprika/Data/HashingMap.cs
@@ -84,6 +84,15 @@ public readonly ref struct HashingMap
         return false;
     }
 
+    public int Count
+    {
+        get
+        {
+            var indexOf = _hashes.IndexOf(NoHash);
+            return indexOf == IndexOfNotFound ? _hashes.Length : indexOf;
+        }
+    }
+
     private Span<byte> GetEntry(int position) => _entries.Slice(position * EntrySize, EntrySize);
 
     public bool TrySet(uint hash, in Key key, ReadOnlySpan<byte> value)

--- a/src/Paprika/IReadOnlyBatch.cs
+++ b/src/Paprika/IReadOnlyBatch.cs
@@ -1,6 +1,4 @@
-﻿using Nethermind.Int256;
-using Paprika.Crypto;
-using Paprika.Data;
+﻿using Paprika.Data;
 using Paprika.Store;
 
 namespace Paprika;
@@ -16,4 +14,6 @@ public interface IReadOnlyBatch : IDisposable
     /// <param name="result"></param>
     /// <returns></returns>
     bool TryGet(in Key key, out ReadOnlySpan<byte> result);
+
+    void Report(IReporter reporter);
 }

--- a/src/Paprika/Paprika.csproj
+++ b/src/Paprika/Paprika.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="HdrHistogram" Version="2.5.0" />
       <PackageReference Include="Nethermind.Numerics.Int256" Version="1.1.0" />
       <PackageReference Include="System.IO.Hashing" Version="8.0.0-preview.4.23259.5" />
     </ItemGroup>

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -267,11 +267,11 @@ public readonly unsafe struct DataPage : IPage
         if (emptyBuckets == 0)
         {
             // all filled
-            reporter.Report(level, 0, Payload.BucketCount, new HashingMap(Data.DataSpan).Count);
+            reporter.Report(level, Payload.BucketCount, new HashingMap(Data.DataSpan).Count);
         }
         else
         {
-            reporter.Report(level, emptyBuckets, Payload.BucketCount - emptyBuckets,
+            reporter.Report(level, Payload.BucketCount - emptyBuckets,
                 new NibbleBasedMap(Data.DataSpan).Count);
         }
     }

--- a/src/Paprika/Store/IReporter.cs
+++ b/src/Paprika/Store/IReporter.cs
@@ -1,0 +1,41 @@
+﻿using HdrHistogram;
+
+namespace Paprika.Store;
+
+/// <summary>
+/// Provides capability to report stats for <see cref="DataPage"/>.
+/// </summary>
+public interface IReporter
+{
+    void Report(int level, int emptyBuckets, int filledBuckets, int entriesPerPage);
+}
+
+public class StatisticsReporter : IReporter
+{
+    private readonly Dictionary<int, Level> _levels = new();
+
+    public void Report(int level, int emptyBuckets, int filledBuckets, int entriesPerPage)
+    {
+        if (_levels.TryGetValue(level, out var lvl) == false)
+        {
+            lvl = _levels[level] = new Level();
+        }
+
+        try
+        {
+            lvl.ChildCount.RecordValue(filledBuckets);
+            lvl.Entries.RecordValue(entriesPerPage);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            throw;
+        }
+    }
+
+    private class Level
+    {
+        public readonly IntHistogram ChildCount = new(1000, 5);
+        public readonly IntHistogram Entries = new(1000, 5);
+    }
+}

--- a/src/Paprika/Store/IReporter.cs
+++ b/src/Paprika/Store/IReporter.cs
@@ -12,13 +12,13 @@ public interface IReporter
 
 public class StatisticsReporter : IReporter
 {
-    private readonly Dictionary<int, Level> _levels = new();
+    public readonly SortedDictionary<int, Level> Levels = new();
 
     public void Report(int level, int emptyBuckets, int filledBuckets, int entriesPerPage)
     {
-        if (_levels.TryGetValue(level, out var lvl) == false)
+        if (Levels.TryGetValue(level, out var lvl) == false)
         {
-            lvl = _levels[level] = new Level();
+            lvl = Levels[level] = new Level();
         }
 
         try
@@ -33,7 +33,7 @@ public class StatisticsReporter : IReporter
         }
     }
 
-    private class Level
+    public class Level
     {
         public readonly IntHistogram ChildCount = new(1000, 5);
         public readonly IntHistogram Entries = new(1000, 5);

--- a/src/Paprika/Store/IReporter.cs
+++ b/src/Paprika/Store/IReporter.cs
@@ -7,30 +7,25 @@ namespace Paprika.Store;
 /// </summary>
 public interface IReporter
 {
-    void Report(int level, int emptyBuckets, int filledBuckets, int entriesPerPage);
+    void Report(int level, int filledBuckets, int entriesPerPage);
 }
 
 public class StatisticsReporter : IReporter
 {
     public readonly SortedDictionary<int, Level> Levels = new();
+    public int PageCount = 0;
 
-    public void Report(int level, int emptyBuckets, int filledBuckets, int entriesPerPage)
+    public void Report(int level, int filledBuckets, int entriesPerPage)
     {
         if (Levels.TryGetValue(level, out var lvl) == false)
         {
             lvl = Levels[level] = new Level();
         }
 
-        try
-        {
-            lvl.ChildCount.RecordValue(filledBuckets);
-            lvl.Entries.RecordValue(entriesPerPage);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-            throw;
-        }
+        PageCount++;
+
+        lvl.ChildCount.RecordValue(filledBuckets);
+        lvl.Entries.RecordValue(entriesPerPage);
     }
 
     public class Level

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -87,7 +87,7 @@ public enum PageType : byte
 /// </summary>
 public readonly unsafe struct Page : IPage, IEquatable<Page>
 {
-    public const int PageCount = 0x0100_0000; // 64GB addressable
+    public const int PageCount = 0x1000_0000; // 64GB addressable
     public const int PageAddressMask = PageCount - 1;
     public const int PageSize = 4 * 1024;
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -270,6 +270,17 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             return new DataPage(GetAt(addr)).TryGet(hash, sliced, this, out result);
         }
 
+        public void Report(IReporter reporter)
+        {
+            foreach (var addr in _rootDataPages)
+            {
+                if (addr.IsNull == false)
+                {
+                    new DataPage(GetAt(addr)).Report(reporter, this, 1);
+                }
+            }
+        }
+
         public uint BatchId { get; }
 
         public Page GetAt(DbAddress address) => _db._manager.GetAt(address);
@@ -385,6 +396,17 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             if (_disposed)
             {
                 throw new ObjectDisposedException("This batch has been disposed already.");
+            }
+        }
+
+        public void Report(IReporter reporter)
+        {
+            foreach (var addr in _root.Data.AccountPages)
+            {
+                if (addr.IsNull == false)
+                {
+                    new DataPage(GetAt(addr)).Report(reporter, this, 1);
+                }
             }
         }
 


### PR DESCRIPTION
This PR makes the runner report db usage in a much better way. It enhances it with:

1. general stats
2. per level stats, such as number of entries

![image](https://github.com/NethermindEth/Paprika/assets/519707/0d233cae-7212-4654-9cd5-d645ff6e0571)
