### PR TITLE
Dangling readonly batch fix

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -25,10 +25,10 @@ public static class Program
 
     private const int NumberOfLogs = PersistentDb ? 100 : 10;
 
-    private const long DbFileSize = PersistentDb ? 256 * Gb : 16 * Gb;
+    private const long DbFileSize = PersistentDb ? 64 * Gb : 16 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
 
-    private static readonly TimeSpan FlushEvery = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan FlushEvery = TimeSpan.FromSeconds(10);
 
     private const int LogEvery = BlockCount / NumberOfLogs;
 


### PR DESCRIPTION
This PR fixes a dangling readonly batch that was blowing up the database. Additionally, it makes the `Blockchain` component as it should have been from the first place, meaning: if there's no block with the parent hash that has been added to the db, open the readonly batch only then and treat this as the parent (asserting what is needed before).