### PR TITLE
HasingMap entry size fixup

### DIFF
--- a/src/Paprika.Tests/HashingMapTests.cs
+++ b/src/Paprika.Tests/HashingMapTests.cs
@@ -139,6 +139,25 @@ public class HashingMapTests
 
         map.TryGet(hash, key, out _).Should().BeFalse();
     }
+
+    [Test]
+    public void Biggest_value()
+    {
+        Span<byte> span = stackalloc byte[HashingMap.MinSize];
+        var map = new HashingMap(span);
+
+        Span<byte> data = stackalloc byte[32];
+        data.Fill(0x71);
+
+        Keccak keccak = default;
+        keccak.BytesAsSpan.Fill(0xFF);
+
+        var key = Key.StorageCell(NibblePath.FromKey(keccak), keccak);
+        var hash = HashingMap.GetHash(key);
+
+        map.SetAssert(hash, key, data);
+        map.GetAssert(hash, key, data);
+    }
 }
 
 static class HashingMapTestExtensions

--- a/src/Paprika/Data/HashingMap.cs
+++ b/src/Paprika/Data/HashingMap.cs
@@ -28,7 +28,7 @@ public readonly ref struct HashingMap
     private const int MaxValueLength = 32;
 
     // NibblePath.FullKeccakByteLength + TypeBytes + LengthPrefix + Keccak.Size + LengthPrefix + MaxValueLength;
-    private const int EntrySize = 88;
+    private const int EntrySize = 100;
     private const int HashSize = sizeof(uint);
     private const int TotalEntrySize = EntrySize + HashSize;
     private const int IndexOfNotFound = -1;


### PR DESCRIPTION
This PR provides a tests and amends the `HashingMap` to be able to handle any entry that it requested to store. There was a bug with storage cells in there.