### PR TITLE
Account serialization optimization

### DIFF
--- a/src/Paprika.Tests/Data/AccountTests.cs
+++ b/src/Paprika.Tests/Data/AccountTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using Nethermind.Int256;
+using NUnit.Framework;
+using Paprika.Data;
+
+namespace Paprika.Tests.Data;
+
+public class AccountTests
+{
+    private static readonly UInt256 EthInWei = 1_000_000_000_000_000_000;
+    private static readonly UInt256 Eth1000 = 1000UL * EthInWei;
+    private static readonly UInt256 EthMax = 120_000_000UL * EthInWei;
+    private static readonly UInt256 TotalTxCount = 2_000_000_000;
+
+    [Test]
+    public void Small_should_compress()
+    {
+        var expected = new Account(1, 1);
+        var data = expected.WriteTo(stackalloc byte[Account.MaxByteCount]);
+
+        data.Length.Should().Be(3);
+
+        Account.ReadFrom(data, out var account);
+        account.Should().Be(expected);
+    }
+
+    [TestCaseSource(nameof(GetEOAData))]
+    public void EOA(UInt256 balance, UInt256 nonce)
+    {
+        var expected = new Account(balance, nonce);
+        var data = expected.WriteTo(stackalloc byte[Account.MaxByteCount]);
+
+        Account.ReadFrom(data, out var account);
+        account.Should().Be(expected);
+    }
+
+    private static IEnumerable<TestCaseData> GetEOAData()
+    {
+        yield return new TestCaseData(UInt256.Zero, UInt256.Zero).SetName("Zeros");
+        yield return new TestCaseData(Eth1000, (UInt256)10000).SetName("Reasonable");
+        yield return new TestCaseData(EthMax, TotalTxCount).SetName("Max");
+    }
+}

--- a/src/Paprika.Tests/Data/SerializerTests.cs
+++ b/src/Paprika.Tests/Data/SerializerTests.cs
@@ -7,28 +7,23 @@ namespace Paprika.Tests.Data;
 
 public class SerializerTests
 {
-    private static readonly UInt256 EthInWei = 1_000_000_000_000_000_000;
-    private static readonly UInt256 Eth1000 = 1000UL * EthInWei;
-    private static readonly UInt256 EthMax = 120_000_000UL * EthInWei;
-    private static readonly UInt256 TotalTxCount = 2_000_000_000;
-
-    [TestCaseSource(nameof(GetEOAData))]
-    public void EOA(UInt256 balance, UInt256 nonce)
+    [TestCaseSource(nameof(GetStorageValues))]
+    public void Storage(UInt256 expected)
     {
-        Span<byte> destination = stackalloc byte[Serializer.BalanceNonceMaxByteCount];
+        Span<byte> data = stackalloc byte[Serializer.MaxUint256SizeWithPrefix];
+        var serialized = Serializer.WriteStorageValue(data, expected);
+        Serializer.ReadStorageValue(serialized, out var actual);
 
-        var expected = new Account(balance, nonce);
-        var actual = Serializer.WriteAccount(destination, expected);
-
-        Serializer.ReadAccount(actual, out var account);
-
-        account.Should().Be(expected);
+        expected.Should().Be(actual);
     }
 
-    static IEnumerable<TestCaseData> GetEOAData()
+    public static IEnumerable<TestCaseData> GetStorageValues()
     {
-        yield return new TestCaseData(UInt256.Zero, UInt256.Zero).SetName("Zeros");
-        yield return new TestCaseData(Eth1000, (UInt256)10000).SetName("Reasonable");
-        yield return new TestCaseData(EthMax, TotalTxCount).SetName("Max");
+        yield return new TestCaseData(UInt256.Zero);
+        yield return new TestCaseData(UInt256.One);
+        yield return new TestCaseData(new UInt256(ulong.MaxValue));
+        yield return new TestCaseData(new UInt256(ulong.MaxValue, ulong.MaxValue));
+        yield return new TestCaseData(new UInt256(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue));
+        yield return new TestCaseData(new UInt256(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue));
     }
 }

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -21,17 +21,16 @@ public static class TestExtensions
 
     public static void ShouldHaveAccount(this IReadOnlyBatch read, in Keccak key, in Account expected)
     {
-        Span<byte> payload = stackalloc byte[Serializer.BalanceNonceMaxByteCount];
-        var raw = Serializer.WriteAccount(payload, expected);
+        var raw = expected.WriteTo(stackalloc byte[Account.MaxByteCount]);
 
         read.TryGet(Key.Account(key), out var value).Should().BeTrue();
-        value.SequenceEqual(raw);
+        value.SequenceEqual(raw).Should().BeTrue();
     }
 
     public static Account GetAccount(this IReadOnlyBatch read, in Keccak key)
     {
         read.TryGet(Key.Account(key), out var value).Should().BeTrue($"Key: {key.ToString()} should exist.");
-        Serializer.ReadAccount(value, out var account);
+        Account.ReadFrom(value, out var account);
         return account;
     }
 

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -1,4 +1,5 @@
 ﻿using Nethermind.Int256;
+using Paprika.Data;
 
 namespace Paprika;
 
@@ -29,4 +30,90 @@ public readonly struct Account : IEquatable<Account>
     public static bool operator !=(Account left, Account right) => !left.Equals(right);
 
     public override string ToString() => $"{nameof(Nonce)}: {Nonce}, {nameof(Balance)}: {Balance}";
+
+    public const int MaxByteCount = BigPreambleLength + // preamble 
+                                    Serializer.Uint256Size + // balance
+                                    Serializer.Uint256Size; // nonce
+
+    private const ulong SevenBytesULong = 0x00_FF_FF_FF_FF_FF_FF_FF;
+
+    /// <summary>
+    /// Seven bytes max for the nonce.
+    /// </summary>
+    private static readonly UInt256 MaxDenseNonce = new(SevenBytesULong);
+
+    /// <summary>
+    /// 15 bytes max for the balance.
+    /// </summary>
+    private static readonly UInt256 MaxDenseBalance = new(ulong.MaxValue, SevenBytesULong);
+
+    private const byte DensePreambleLength = 1;
+    private const byte DenseMask = 0b1000_0000;
+    private const byte DenseNonceLengthShift = 4;
+    private const byte DenseNonceLengthMask = 0b0111_0000;
+    private const byte DenseBalanceMask = 0b0000_1111;
+
+    private const byte BigPreambleLength = 2;
+    private const byte BigPreambleBalanceIndex = 0;
+    private const byte BigPreambleNonceIndex = 1;
+
+    /// <summary>
+    /// Serializes the account balance and nonce.
+    /// </summary>
+    /// <returns>The actual payload written.</returns>
+    public Span<byte> WriteTo(Span<byte> destination)
+    {
+        if (Balance <= MaxDenseBalance && Nonce <= MaxDenseNonce)
+        {
+            // special case, we can encode it a dense way
+            var span = destination.Slice(DensePreambleLength);
+            span = Balance.WriteWithLeftover(span, out var balanceLength);
+            Nonce.WriteWithLeftover(span, out var nonceLength);
+
+            destination[0] = (byte)(DenseMask | balanceLength | (nonceLength << DenseNonceLengthShift));
+            return destination.Slice(0, DensePreambleLength + balanceLength + nonceLength);
+        }
+
+        {
+            // really big numbers
+            var span = destination.Slice(BigPreambleLength);
+            span = Balance.WriteWithLeftover(span, out var balanceLength);
+            Nonce.WriteWithLeftover(span, out var nonceLength);
+
+            destination[BigPreambleBalanceIndex] = (byte)balanceLength;
+            destination[BigPreambleNonceIndex] = (byte)nonceLength;
+
+            return destination.Slice(0, BigPreambleLength + balanceLength + nonceLength);
+        }
+    }
+
+    /// <summary>
+    /// Reads the account balance and nonce.
+    /// </summary>
+    public static void ReadFrom(ReadOnlySpan<byte> source, out Account account)
+    {
+        var first = source[0];
+        if ((first & DenseMask) == DenseMask)
+        {
+            // special case, decode the dense
+            var nonceLength = (first & DenseNonceLengthMask) >> DenseNonceLengthShift;
+            var balanceLength = first & DenseBalanceMask;
+
+            Serializer.ReadFrom(source.Slice(DensePreambleLength, balanceLength), out var balance);
+            Serializer.ReadFrom(source.Slice(DensePreambleLength + balanceLength, nonceLength), out var nonce);
+
+            account = new Account(balance, nonce);
+            return;
+        }
+
+        {
+            var balanceLength = source[BigPreambleBalanceIndex];
+            var nonceLength = source[BigPreambleNonceIndex];
+
+            Serializer.ReadFrom(source.Slice(BigPreambleLength, balanceLength), out var balance);
+            Serializer.ReadFrom(source.Slice(BigPreambleLength + balanceLength, nonceLength), out var nonce);
+
+            account = new Account(balance, nonce);
+        }
+    }
 }

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -384,7 +384,7 @@ public class Blockchain : IAsyncDisposable
             if (owner.Span.IsEmpty)
                 return default;
 
-            Serializer.ReadAccount(owner.Span, out var result);
+            Account.ReadFrom(owner.Span, out var result);
             return result;
         }
 
@@ -398,9 +398,7 @@ public class Blockchain : IAsyncDisposable
             _bloom.Set(BloomForAccountOperation(key));
 
             var path = NibblePath.FromKey(key);
-
-            Span<byte> payload = stackalloc byte[Serializer.BalanceNonceMaxByteCount];
-            payload = Serializer.WriteAccount(payload, account);
+            var payload = account.WriteTo(stackalloc byte[Account.MaxByteCount]);
 
             Set(Key.Account(path), payload);
         }


### PR DESCRIPTION
This PR makes the change in the way how accounts are serialized. For 99.9%, if not all, it should save 1 byte per account. As accounts are encoded usually within 60-80, it should save 1%, maybe 2% 👀 

Just to compare tree sizes with the `Paprika.Runner`:
- before: `Size of this Paprika tree: 337MB`
- after:  `Size of this Paprika tree: 319MB`

Solves #105