### PR TITLE
Merkle Keccak Memoization

### DIFF
--- a/src/Paprika.Tests/Merkle/RootHashTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashTests.cs
@@ -76,7 +76,12 @@ public class RootHashTests
             commit.Set(Key.Account(new Keccak(key)), new Account(value, value).WriteTo(account));
         }
 
-        AssertRoot(hexString, commit);
+        AssertRootFirst(hexString, commit);
+        AssertRootSecond(hexString, commit);
+
+        // use two separate method
+        static void AssertRootFirst(string hex, Commit commit) => AssertRoot(hex, commit);
+        static void AssertRootSecond(string hex, Commit commit) => AssertRoot(hex, commit);
     }
 
     [Test]

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -82,6 +82,8 @@ public readonly ref struct NibblePath
     /// </summary>
     public int MaxByteLength => Length / 2 + 2;
 
+    public const int KeccakNibbleCount = Keccak.Size * NibblePerByte;
+
     public const int FullKeccakByteLength = Keccak.Size / 2 + 2;
 
     /// <summary>

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -23,12 +23,9 @@ public static class CommitExtensions
         commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]));
     }
 
-    public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, KeccakOrRlp keccak)
+    public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, Keccak keccak)
     {
-        Debug.Assert(keccak.DataType == KeccakOrRlp.Type.Keccak);
-        var actual = new Keccak(keccak.Span);
-
-        var branch = new Node.Branch(children, actual);
+        var branch = new Node.Branch(children, keccak);
         commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]));
     }
 

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -1,5 +1,7 @@
 using Paprika.Chain;
+using Paprika.Crypto;
 using Paprika.Data;
+using Paprika.RLP;
 
 namespace Paprika.Merkle;
 
@@ -16,6 +18,13 @@ public static class CommitExtensions
 
     public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children)
     {
+        var branch = new Node.Branch(children);
+        commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]));
+    }
+
+    public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, KeccakOrRlp keccak)
+    {
+        throw new NotImplementedException();
         var branch = new Node.Branch(children);
         commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]));
     }

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Paprika.Chain;
 using Paprika.Crypto;
 using Paprika.Data;
@@ -24,8 +25,10 @@ public static class CommitExtensions
 
     public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, KeccakOrRlp keccak)
     {
-        throw new NotImplementedException();
-        var branch = new Node.Branch(children);
+        Debug.Assert(keccak.DataType == KeccakOrRlp.Type.Keccak);
+        var actual = new Keccak(keccak.Span);
+
+        var branch = new Node.Branch(children, actual);
         commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]));
     }
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -162,7 +162,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
 
     private bool ShouldMemoizeBranchKeccak(in NibblePath branchPath)
     {
-        var level = NibblePath.KeccakNibbleCount - branchPath.Length - _minimumTreeLevelToMemoizeKeccak;
+        var level = branchPath.Length - _minimumTreeLevelToMemoizeKeccak;
 
         // memoize only if the branch is deeper than _minimumTreeLevelToMemoizeKeccak and every _memoizeKeccakEvery
         return level >= 0 && level % _memoizeKeccakEvery == 0;

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -141,7 +141,17 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
 
         ArrayPool<byte>.Shared.Return(bytes);
 
+        if (ShouldMemoizeBranchKeccak(key.Path))
+        {
+            commit.SetBranch(key, branch.Children, result);
+        }
+
         return result;
+    }
+
+    private static bool ShouldMemoizeBranchKeccak(NibblePath branchPath)
+    {
+        return false;
     }
 
     private static KeccakOrRlp EncodeExtension(in Key key, ICommit commit, scoped in Node.Extension ext,

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -26,11 +26,20 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
     /// </remarks>
     private const int MaxBufferNeeded = 1024;
 
-    private readonly bool _fullMerkle;
+    public const int DefaultMinimumTreeLevelToMemoizeKeccak = 2;
+    public const int MemoizeKeccakEveryNLevel = 2;
 
-    public ComputeMerkleBehavior(bool fullMerkle = false)
+    private readonly bool _fullMerkle;
+    private readonly int _minimumTreeLevelToMemoizeKeccak;
+    private readonly int _memoizeKeccakEvery;
+
+    public ComputeMerkleBehavior(bool fullMerkle = false,
+        int minimumTreeLevelToMemoizeKeccak = DefaultMinimumTreeLevelToMemoizeKeccak,
+        int memoizeKeccakEvery = MemoizeKeccakEveryNLevel)
     {
         _fullMerkle = fullMerkle;
+        _minimumTreeLevelToMemoizeKeccak = minimumTreeLevelToMemoizeKeccak;
+        _memoizeKeccakEvery = memoizeKeccakEvery;
     }
 
     public void BeforeCommit(ICommit commit)
@@ -52,7 +61,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
     public Keccak RootHash { get; private set; }
 
     [SkipLocalsInit]
-    private static KeccakOrRlp Compute(in Key key, ICommit commit, TrieType trieType)
+    private KeccakOrRlp Compute(in Key key, ICommit commit, TrieType trieType)
     {
         using var owner = commit.Get(key);
         if (owner.IsEmpty)
@@ -96,7 +105,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
         return keccakOrRlp;
     }
 
-    private static KeccakOrRlp EncodeBranch(Key key, ICommit commit, scoped in Node.Branch branch, TrieType trieType)
+    private KeccakOrRlp EncodeBranch(Key key, ICommit commit, scoped in Node.Branch branch, TrieType trieType)
     {
         var bytes = ArrayPool<byte>.Shared.Rent(MaxBufferNeeded);
 
@@ -149,12 +158,13 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
         return result;
     }
 
-    private static bool ShouldMemoizeBranchKeccak(NibblePath branchPath)
+    private bool ShouldMemoizeBranchKeccak(NibblePath branchPath)
     {
-        return false;
+        var level = NibblePath.KeccakNibbleCount - branchPath.Length - _minimumTreeLevelToMemoizeKeccak;
+        return level >= 0 && level % _memoizeKeccakEvery == 0;
     }
 
-    private static KeccakOrRlp EncodeExtension(in Key key, ICommit commit, scoped in Node.Extension ext,
+    private KeccakOrRlp EncodeExtension(in Key key, ICommit commit, scoped in Node.Extension ext,
         TrieType trieType)
     {
         Span<byte> span = stackalloc byte[Math.Max(ext.Path.HexEncodedLength, key.Path.MaxByteLength + 1)];


### PR DESCRIPTION
This PR introduces a memoization of Merkle hashes, so that the whole tree does not have its hashes recalculated constantly but rather memoizes some of them to make the computation faster. The behavior is configurable, so that one can opt for having more `Keccak`s stored (more data flying through the disk) or more compute. This is done with two parameters:

1. `minimumTreeLevelToMemoizeKeccak` - the level from which cache the `Keccak`, defaults to `2`, which means that by default only trees that over level 2
2. `memoizeKeccakEvery` - memoize every `memoizeKeccakEvery`th level after the boundary above, defaults to `2`

Default settings make the following branches (counting from 0 - root) levels cached: 2, 4, 6 etc.

```csharp
public ComputeMerkleBehavior(bool fullMerkle = false,
  int minimumTreeLevelToMemoizeKeccak = 2,
  int memoizeKeccakEvery = 2)
```

Solves #120 