### PR TITLE
Key now uses NibblePath as the additional key

### DIFF
--- a/src/Paprika.Tests/Data/KeyTests.cs
+++ b/src/Paprika.Tests/Data/KeyTests.cs
@@ -9,7 +9,7 @@ public class KeyTests
 {
     private const string Path = nameof(Key.Path);
     private const string Type = nameof(Key.Type);
-    private const string AdditionalKey = nameof(Key.AdditionalKey);
+    private const string AdditionalKey = nameof(Key.StoragePath);
 
     private static NibblePath Path0 => NibblePath.FromKey(Values.Key0);
     private static NibblePath Path1A => NibblePath.FromKey(Values.Key1A);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -409,7 +409,7 @@ public class Blockchain : IAsyncDisposable
             else if (key.Type == DataType.StorageCell)
             {
                 key.Path.AddToHashCode(ref code);
-                code.AddBytes(key.AdditionalKey);
+                key.StoragePath.AddToHashCode(ref code);
             }
             else if (key.Type == DataType.Merkle)
             {

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -30,6 +30,13 @@ public readonly ref struct NibblePath
 
     public static NibblePath Empty => default;
 
+    /// <summary>
+    /// The byte length of an empty path.
+    /// </summary>
+    public const int EmptyEncodedLength = 1;
+
+    public bool IsEmpty => Length == 0;
+
     public static NibblePath Parse(string hex)
     {
         var nibbles = new byte[(hex.Length + 1) / 2];

--- a/src/Paprika/Merkle/Key.cs
+++ b/src/Paprika/Merkle/Key.cs
@@ -3,5 +3,5 @@ namespace Paprika.Data;
 
 public readonly ref partial struct Key
 {
-    public static Key Merkle(NibblePath path) => new(path, DataType.Merkle, ReadOnlySpan<byte>.Empty);
+    public static Key Merkle(NibblePath path) => new(path, DataType.Merkle, NibblePath.Empty);
 }


### PR DESCRIPTION
This PR changes the way `Key` is organized and migrates the second part of it from an agnostic `ReadOnlySpan<byte>` to `NibblePath` that properly represents the path in Paprika. This is also an enabler for #121 as it will allow to store Merkle keys for storage contracts as they will require the second part truncation. 

Let me provide an example for encoding `Merkle` root for the storage of an account `0xABCD`. It will require to create `Key.Merkle('0xABCD', '')` which previously, was not possible to store properly. Now, with a full `NibblePath` support, we're good to go.