### PR TITLE
Account with CodeHash and StorageRootHash

### DIFF
--- a/src/Paprika.Benchmarks/MerkleBenchmarks.cs
+++ b/src/Paprika.Benchmarks/MerkleBenchmarks.cs
@@ -1,0 +1,21 @@
+﻿using BenchmarkDotNet.Attributes;
+using Paprika.Data;
+using Paprika.Merkle;
+
+namespace Paprika.Benchmarks;
+
+[MemoryDiagnoser]
+public class MerkleBenchmarks
+{
+    private static readonly Account Eoa = new(1_000_000, 100);
+
+    [Benchmark]
+    public byte EOA_Leaf()
+    {
+        Span<byte> key = stackalloc byte[1] { 1 };
+        Node.Leaf.KeccakOrRlp(NibblePath.FromKey(key), in Eoa, out var result);
+
+        // prevent not used result elimination
+        return result.Span[0];
+    }
+}

--- a/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
+++ b/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
@@ -8,7 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Paprika.Benchmarks/Program.cs
+++ b/src/Paprika.Benchmarks/Program.cs
@@ -11,7 +11,6 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        //new FixedMapBenchmarks().Read_nonexistent_keys();
-        var summary = BenchmarkRunner.Run(typeof(Program).Assembly);
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run();
     }
 }

--- a/src/Paprika.Tests/Data/AccountTests.cs
+++ b/src/Paprika.Tests/Data/AccountTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Nethermind.Int256;
 using NUnit.Framework;
+using Paprika.Crypto;
 using Paprika.Data;
 
 namespace Paprika.Tests.Data;
@@ -13,7 +14,7 @@ public class AccountTests
     private static readonly UInt256 TotalTxCount = 2_000_000_000;
 
     [Test]
-    public void Small_should_compress()
+    public void EOA_Small_should_compress()
     {
         var expected = new Account(1, 1);
         var data = expected.WriteTo(stackalloc byte[Account.MaxByteCount]);
@@ -24,8 +25,8 @@ public class AccountTests
         account.Should().Be(expected);
     }
 
-    [TestCaseSource(nameof(GetEOAData))]
-    public void EOA(UInt256 balance, UInt256 nonce)
+    [TestCaseSource(nameof(GetEoaData))]
+    public void Eoa(UInt256 balance, UInt256 nonce)
     {
         var expected = new Account(balance, nonce);
         var data = expected.WriteTo(stackalloc byte[Account.MaxByteCount]);
@@ -34,10 +35,42 @@ public class AccountTests
         account.Should().Be(expected);
     }
 
-    private static IEnumerable<TestCaseData> GetEOAData()
+    [Test]
+    public void Contract_Small_should_compress()
+    {
+        var expected = new Account(1, 1, CodeHash, StorageRoot);
+        var data = expected.WriteTo(stackalloc byte[Account.MaxByteCount]);
+
+        data.Length.Should().Be(3 + Keccak.Size * 2);
+
+        Account.ReadFrom(data, out var account);
+        account.Should().Be(expected);
+    }
+    
+    [TestCaseSource(nameof(GetContractData))]
+    public void Contract(UInt256 balance, UInt256 nonce, Keccak codeHash, Keccak storageRootHash)
+    {
+        var expected = new Account(balance, nonce);
+        var data = expected.WriteTo(stackalloc byte[Account.MaxByteCount]);
+
+        Account.ReadFrom(data, out var account);
+        account.Should().Be(expected);
+    }
+
+    private static IEnumerable<TestCaseData> GetEoaData()
     {
         yield return new TestCaseData(UInt256.Zero, UInt256.Zero).SetName("Zeros");
         yield return new TestCaseData(Eth1000, (UInt256)10000).SetName("Reasonable");
         yield return new TestCaseData(EthMax, TotalTxCount).SetName("Max");
+    }
+
+    private static readonly Keccak CodeHash = Keccak.Compute(new byte[] { 0, 1, 2, 3 });
+    private static readonly Keccak StorageRoot = Keccak.Compute(new byte[] { 0, 1, 2, 5, 6, 8 });
+
+    private static IEnumerable<TestCaseData> GetContractData()
+    {
+        yield return new TestCaseData(UInt256.Zero, UInt256.Zero, CodeHash, StorageRoot).SetName("No balance, no nonce");
+        yield return new TestCaseData(Eth1000, (UInt256)10000, CodeHash, StorageRoot).SetName("Reasonable");
+        yield return new TestCaseData(EthMax, TotalTxCount, CodeHash, StorageRoot).SetName("Max");
     }
 }

--- a/src/Paprika.Tests/Data/AccountTests.cs
+++ b/src/Paprika.Tests/Data/AccountTests.cs
@@ -46,7 +46,7 @@ public class AccountTests
         Account.ReadFrom(data, out var account);
         account.Should().Be(expected);
     }
-    
+
     [TestCaseSource(nameof(GetContractData))]
     public void Contract(UInt256 balance, UInt256 nonce, Keccak codeHash, Keccak storageRootHash)
     {

--- a/src/Paprika.Tests/Data/KeyTests.cs
+++ b/src/Paprika.Tests/Data/KeyTests.cs
@@ -32,8 +32,6 @@ public class KeyTests
     [Test]
     public void Equality_Type()
     {
-        Key.Account(Path0).Equals(Key.CodeHash(Path0)).Should().BeFalse($"Different {Type}");
-
         Key.Account(Path0).Equals(Key.StorageCell(Path0, Keccak.Zero)).Should().BeFalse($"Different {Type}");
     }
 

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -14,32 +14,32 @@ public readonly struct Account : IEquatable<Account>
     public readonly UInt256 Balance;
     public readonly UInt256 Nonce;
     public readonly Keccak CodeHash;
-    public readonly Keccak StorageRoot;
+    public readonly Keccak StorageRootHash;
 
     public Account(UInt256 balance, UInt256 nonce)
     {
         Balance = balance;
         Nonce = nonce;
         CodeHash = EmptyCodeHash;
-        StorageRoot = EmptyStorageRoot;
+        StorageRootHash = EmptyStorageRoot;
     }
 
-    public Account(UInt256 balance, UInt256 nonce, Keccak codeHash, Keccak storageRoot)
+    public Account(UInt256 balance, UInt256 nonce, Keccak codeHash, Keccak storageRootHash)
     {
         Balance = balance;
         Nonce = nonce;
         CodeHash = codeHash;
-        StorageRoot = storageRoot;
+        StorageRootHash = storageRootHash;
     }
 
     public bool Equals(Account other) => Balance.Equals(other.Balance) &&
                                          Nonce == other.Nonce &&
                                          CodeHash == other.CodeHash &&
-                                         StorageRoot == other.StorageRoot;
+                                         StorageRootHash == other.StorageRootHash;
 
     public override bool Equals(object? obj) => obj is Account other && Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(Balance, Nonce, CodeHash, StorageRoot);
+    public override int GetHashCode() => HashCode.Combine(Balance, Nonce, CodeHash, StorageRootHash);
 
     public static bool operator ==(Account left, Account right) => left.Equals(right);
 
@@ -111,7 +111,7 @@ public readonly struct Account : IEquatable<Account>
             }
 
             CodeHash.BytesAsSpan.CopyTo(destination.Slice(balanceAndNonceLength));
-            StorageRoot.BytesAsSpan.CopyTo(destination.Slice(balanceAndNonceLength + Keccak.Size));
+            StorageRootHash.BytesAsSpan.CopyTo(destination.Slice(balanceAndNonceLength + Keccak.Size));
 
             return destination.Slice(0, balanceAndNonceLength + Keccak.Size + Keccak.Size);
         }
@@ -126,13 +126,13 @@ public readonly struct Account : IEquatable<Account>
             destination[BigPreambleNonceIndex] = (byte)nonceLength;
 
             CodeHash.BytesAsSpan.CopyTo(span);
-            StorageRoot.BytesAsSpan.CopyTo(span.Slice(Keccak.Size));
+            StorageRootHash.BytesAsSpan.CopyTo(span.Slice(Keccak.Size));
 
             return destination.Slice(0, BigPreambleLength + balanceLength + nonceLength + Keccak.Size + Keccak.Size);
         }
     }
 
-    private bool CodeHashOrStorageRootExist => CodeHash != EmptyCodeHash || StorageRoot != EmptyStorageRoot;
+    private bool CodeHashOrStorageRootExist => CodeHash != EmptyCodeHash || StorageRootHash != EmptyStorageRoot;
 
     /// <summary>
     /// Reads the account balance and nonce.

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -1,4 +1,5 @@
 ﻿using Nethermind.Int256;
+using Paprika.Crypto;
 using Paprika.Data;
 
 namespace Paprika;
@@ -12,18 +13,33 @@ public readonly struct Account : IEquatable<Account>
 
     public readonly UInt256 Balance;
     public readonly UInt256 Nonce;
+    public readonly Keccak CodeHash;
+    public readonly Keccak StorageRoot;
 
     public Account(UInt256 balance, UInt256 nonce)
     {
         Balance = balance;
         Nonce = nonce;
+        CodeHash = EmptyCodeHash;
+        StorageRoot = EmptyStorageRoot;
     }
 
-    public bool Equals(Account other) => Balance.Equals(other.Balance) && Nonce == other.Nonce;
+    public Account(UInt256 balance, UInt256 nonce, Keccak codeHash, Keccak storageRoot)
+    {
+        Balance = balance;
+        Nonce = nonce;
+        CodeHash = codeHash;
+        StorageRoot = storageRoot;
+    }
+
+    public bool Equals(Account other) => Balance.Equals(other.Balance) &&
+                                         Nonce == other.Nonce &&
+                                         CodeHash == other.CodeHash &&
+                                         StorageRoot == other.StorageRoot;
 
     public override bool Equals(object? obj) => obj is Account other && Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(Balance, Nonce);
+    public override int GetHashCode() => HashCode.Combine(Balance, Nonce, CodeHash, StorageRoot);
 
     public static bool operator ==(Account left, Account right) => left.Equals(right);
 
@@ -33,25 +49,34 @@ public readonly struct Account : IEquatable<Account>
 
     public const int MaxByteCount = BigPreambleLength + // preamble 
                                     Serializer.Uint256Size + // balance
-                                    Serializer.Uint256Size; // nonce
+                                    Serializer.Uint256Size + // nonce
+                                    Keccak.Size + // CodeHash
+                                    Keccak.Size; // StorageRootHash
+
 
     private const ulong SevenBytesULong = 0x00_FF_FF_FF_FF_FF_FF_FF;
+    private const ulong ThreeBytesULong = 0x00_00_00_00_00_FF_FF_FF;
 
     /// <summary>
     /// Seven bytes max for the nonce.
     /// </summary>
-    private static readonly UInt256 MaxDenseNonce = new(SevenBytesULong);
+    private static readonly UInt256 MaxDenseNonce = new(ThreeBytesULong);
 
     /// <summary>
     /// 15 bytes max for the balance.
     /// </summary>
     private static readonly UInt256 MaxDenseBalance = new(ulong.MaxValue, SevenBytesULong);
 
+    private static readonly Keccak EmptyCodeHash = Keccak.OfAnEmptyString;
+    private static readonly Keccak EmptyStorageRoot = Keccak.EmptyTreeHash;
+
     private const byte DensePreambleLength = 1;
     private const byte DenseMask = 0b1000_0000;
     private const byte DenseNonceLengthShift = 4;
-    private const byte DenseNonceLengthMask = 0b0111_0000;
+    private const byte DenseNonceLengthMask = 0b0011_0000;
     private const byte DenseBalanceMask = 0b0000_1111;
+    private const byte DenseCodeHashAndStorageRootExistMask = 0b0100_0000;
+    private const byte DenseCodeHashAndStorageRootExistShift = 6;
 
     private const byte BigPreambleLength = 2;
     private const byte BigPreambleBalanceIndex = 0;
@@ -70,22 +95,44 @@ public readonly struct Account : IEquatable<Account>
             span = Balance.WriteWithLeftover(span, out var balanceLength);
             Nonce.WriteWithLeftover(span, out var nonceLength);
 
-            destination[0] = (byte)(DenseMask | balanceLength | (nonceLength << DenseNonceLengthShift));
-            return destination.Slice(0, DensePreambleLength + balanceLength + nonceLength);
+            var codeHashStorageRootExist = CodeHashOrStorageRootExist;
+
+            destination[0] = (byte)(DenseMask |
+                                    balanceLength |
+                                    (nonceLength << DenseNonceLengthShift) |
+                                    ((codeHashStorageRootExist ? 1 : 0) << DenseCodeHashAndStorageRootExistShift));
+
+            var balanceAndNonceLength = DensePreambleLength + balanceLength + nonceLength;
+
+            // CodeHash & StorageRootHash flags
+            if (!codeHashStorageRootExist)
+            {
+                return destination.Slice(0, balanceAndNonceLength);
+            }
+
+            CodeHash.BytesAsSpan.CopyTo(destination.Slice(balanceAndNonceLength));
+            StorageRoot.BytesAsSpan.CopyTo(destination.Slice(balanceAndNonceLength + Keccak.Size));
+
+            return destination.Slice(0, balanceAndNonceLength + Keccak.Size + Keccak.Size);
         }
 
         {
             // really big numbers
             var span = destination.Slice(BigPreambleLength);
             span = Balance.WriteWithLeftover(span, out var balanceLength);
-            Nonce.WriteWithLeftover(span, out var nonceLength);
+            span = Nonce.WriteWithLeftover(span, out var nonceLength);
 
             destination[BigPreambleBalanceIndex] = (byte)balanceLength;
             destination[BigPreambleNonceIndex] = (byte)nonceLength;
 
-            return destination.Slice(0, BigPreambleLength + balanceLength + nonceLength);
+            CodeHash.BytesAsSpan.CopyTo(span);
+            StorageRoot.BytesAsSpan.CopyTo(span.Slice(Keccak.Size));
+
+            return destination.Slice(0, BigPreambleLength + balanceLength + nonceLength + Keccak.Size + Keccak.Size);
         }
     }
+
+    private bool CodeHashOrStorageRootExist => CodeHash != EmptyCodeHash || StorageRoot != EmptyStorageRoot;
 
     /// <summary>
     /// Reads the account balance and nonce.
@@ -102,7 +149,19 @@ public readonly struct Account : IEquatable<Account>
             Serializer.ReadFrom(source.Slice(DensePreambleLength, balanceLength), out var balance);
             Serializer.ReadFrom(source.Slice(DensePreambleLength + balanceLength, nonceLength), out var nonce);
 
-            account = new Account(balance, nonce);
+            var codeHashStorageRootExist =
+                (first & DenseCodeHashAndStorageRootExistMask) == DenseCodeHashAndStorageRootExistMask;
+
+            if (codeHashStorageRootExist == false)
+            {
+                account = new Account(balance, nonce);
+                return;
+            }
+
+            account = new Account(balance, nonce,
+                new Keccak(source.Slice(DensePreambleLength + balanceLength + nonceLength, Keccak.Size)),
+                new Keccak(source.Slice(DensePreambleLength + balanceLength + nonceLength + Keccak.Size, Keccak.Size)));
+
             return;
         }
 
@@ -113,7 +172,10 @@ public readonly struct Account : IEquatable<Account>
             Serializer.ReadFrom(source.Slice(BigPreambleLength, balanceLength), out var balance);
             Serializer.ReadFrom(source.Slice(BigPreambleLength + balanceLength, nonceLength), out var nonce);
 
-            account = new Account(balance, nonce);
+            account = new Account(balance, nonce,
+                new Keccak(source.Slice(BigPreambleLength + balanceLength + nonceLength, Keccak.Size)),
+                new Keccak(source.Slice(BigPreambleLength + balanceLength + nonceLength + Keccak.Size, Keccak.Size))
+            );
         }
     }
 }

--- a/src/Paprika/Data/DataType.cs
+++ b/src/Paprika/Data/DataType.cs
@@ -6,40 +6,30 @@
 public enum DataType : byte
 {
     /// <summary>
-    /// [key, 0]-> account (balance, nonce)
+    /// [key, 0]-> account (balance, nonce, codeHash, storageRootHash)
     /// </summary>
     Account = 0,
 
     /// <summary>
-    /// [key, 1]-> codeHash
-    /// </summary>
-    CodeHash = 1,
-
-    /// <summary>
-    /// [key, 2]-> storageRootHash
-    /// </summary>
-    StorageRootHash = 2,
-
-    /// <summary>
-    /// [key, 3]-> [index][value],
+    /// [key, 1]-> [index][value],
     /// add to the key and use first 32 bytes of data as key
     /// </summary>
-    StorageCell = 3,
+    StorageCell = 1,
 
     /// <summary>
-    /// [key, 4]-> the DbAddress of the root page of the storage trie,
+    /// [key, 2]-> the DbAddress of the root page of the storage trie,
     /// </summary>
-    StorageTreeRootPageAddress = 4,
+    StorageTreeRootPageAddress = 2,
 
     /// <summary>
-    /// [storageCellIndex, 5]-> the StorageCell index, without the prefix of the account
+    /// [storageCellIndex, 3]-> the StorageCell index, without the prefix of the account
     /// </summary>
-    StorageTreeStorageCell = 5,
+    StorageTreeStorageCell = 3,
 
     /// <summary>
     /// As enums cannot be partial, this is for storing the Merkle.
     /// </summary>
-    Merkle = 6,
+    Merkle = 4,
 
     Deleted = 7,
     // one bit more is possible as delete is now a data type

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -37,17 +37,6 @@ public readonly ref partial struct Key
     public static Key Account(in Keccak key) => Account(NibblePath.FromKey(key));
 
     /// <summary>
-    /// Builds the key for <see cref="DataType.CodeHash"/>.
-    /// </summary>
-    public static Key CodeHash(NibblePath path) => new(path, DataType.CodeHash, NibblePath.Empty);
-
-    /// <summary>
-    /// Builds the key for <see cref="DataType.StorageRootHash"/>.
-    /// </summary>
-    public static Key StorageRootHash(NibblePath path) =>
-        new(path, DataType.StorageRootHash, NibblePath.Empty);
-
-    /// <summary>
     /// Builds the key for <see cref="DataType.StorageCell"/>.
     /// </summary>
     /// <remarks>

--- a/src/Paprika/Merkle/Hashing.cs
+++ b/src/Paprika/Merkle/Hashing.cs
@@ -9,15 +9,10 @@ public static partial class Node
 {
     public ref partial struct Leaf
     {
-        public static void KeccakOrRlp(NibblePath nibblePath, Account account, out KeccakOrRlp result) =>
-            KeccakOrRlp(nibblePath, account, Keccak.OfAnEmptyString, Keccak.EmptyTreeHash, out result);
-
         [SkipLocalsInit]
-        private static void KeccakOrRlp(
-            NibblePath nibblePath,
-            Account account,
-            Keccak codeHash,
-            Keccak storageRootHash,
+        public static void KeccakOrRlp(
+            scoped in NibblePath nibblePath,
+            scoped in Account account,
             out KeccakOrRlp result
         )
         {
@@ -33,8 +28,8 @@ public static partial class Node
                 .StartSequence(accountRlpLength)
                 .Encode(account.Nonce)
                 .Encode(account.Balance)
-                .Encode(storageRootHash)
-                .Encode(codeHash);
+                .Encode(account.StorageRootHash)
+                .Encode(account.CodeHash);
 
             // Stage 2: result = KeccakOrRlp(nibblePath, accountRlp)
             Span<byte> hexPath = stackalloc byte[nibblePath.HexEncodedLength];

--- a/src/Paprika/RLP/Rlp.cs
+++ b/src/Paprika/RLP/Rlp.cs
@@ -15,10 +15,14 @@ public static class Rlp
             return 1;
         }
 
-        Span<byte> bytes = stackalloc byte[32];
+        const int size = 32;
+        Span<byte> bytes = stackalloc byte[size];
         item.ToBigEndian(bytes);
-        int length = bytes.WithoutLeadingZeros().Length;
-        return length + 1;
+
+        // at least one will be set as the first check is above, zero would not pass it
+        var index = bytes.IndexOfAnyExcept((byte)0);
+        var lengthWithoutLeadingZeroes = size - index;
+        return lengthWithoutLeadingZeroes + 1;
     }
 
     public static int LengthOf(ReadOnlySpan<byte> span)
@@ -52,10 +56,12 @@ public static class Rlp
         {
             return 1;
         }
+
         if (value < 1 << 16)
         {
             return 2;
         }
+
         if (value < 1 << 24)
         {
             return 3;


### PR DESCRIPTION
This PR merges `CodeHash` and `StorageRootHash` where they belong, into the `Account` construct. 

The main reason, beside Ethereum spec related is that reading this values separately, which is required for RLP encoding of leafs, would result in a read amplification. Writing them and reading them together makes it much easier to deal with. 

The next reason is limiting the number of `Key` types, marked with `DataType`.

The last reason is much easier RLP/Keccak computation in the Merkle plugin, where first Storage tries are computed. As they need to write the roots, its easier to read the account, update and store, just to have it later merkleized for the state tree.

The `design.md` is updated accordingly.