### PR TITLE
Benchmarks and tests for RLP

### DIFF
--- a/src/Paprika.Benchmarks/MerkleBenchmarks.cs
+++ b/src/Paprika.Benchmarks/MerkleBenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
+using Paprika.Crypto;
 using Paprika.Data;
 using Paprika.Merkle;
 
@@ -7,13 +8,47 @@ namespace Paprika.Benchmarks;
 [MemoryDiagnoser]
 public class MerkleBenchmarks
 {
+    private static readonly Keccak SomeKeccak = Keccak.Compute(new byte[] { 1 });
+
     private static readonly Account Eoa = new(1_000_000, 100);
+    private static readonly Account Contract = new(1_000_000, 100, SomeKeccak, SomeKeccak);
 
     [Benchmark]
     public byte EOA_Leaf()
     {
         Span<byte> key = stackalloc byte[1] { 1 };
         Node.Leaf.KeccakOrRlp(NibblePath.FromKey(key), in Eoa, out var result);
+
+        // prevent not used result elimination
+        return result.Span[0];
+    }
+
+    [Benchmark]
+    public byte Contract_Leaf()
+    {
+        Span<byte> key = stackalloc byte[1] { 1 };
+        Node.Leaf.KeccakOrRlp(NibblePath.FromKey(key), in Contract, out var result);
+
+        // prevent not used result elimination
+        return result.Span[0];
+    }
+
+    [Benchmark]
+    public byte Storage_long_path()
+    {
+        Span<byte> value = stackalloc byte[1] { 1 };
+        Node.Leaf.KeccakOrRlp(NibblePath.FromKey(SomeKeccak), value, out var result);
+
+        // prevent not used result elimination
+        return result.Span[0];
+    }
+
+    [Benchmark]
+    public byte Storage_short_path()
+    {
+        Span<byte> key = stackalloc byte[1] { 1 };
+        Span<byte> value = stackalloc byte[1] { 3 };
+        Node.Leaf.KeccakOrRlp(NibblePath.FromKey(key), value, out var result);
 
         // prevent not used result elimination
         return result.Span[0];

--- a/src/Paprika.Tests/Merkle/HashingTests.cs
+++ b/src/Paprika.Tests/Merkle/HashingTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Nethermind.Int256;
 using NUnit.Framework;
 using Paprika.Crypto;
@@ -42,7 +43,7 @@ public class HashingTests
 
     [Test]
     [TestCaseSource(nameof(_keysBalancesNoncesHexStrings))]
-    public void Leaf_keccak(Keccak key, UInt256 balance, UInt256 nonce, string hexString)
+    public void Account_leaf(Keccak key, UInt256 balance, UInt256 nonce, string hexString)
     {
         var account = new Account(balance, nonce);
 
@@ -51,5 +52,18 @@ public class HashingTests
 
         Assert.That(computedHash.DataType, Is.EqualTo(KeccakOrRlp.Type.Keccak));
         Assert.That(new Keccak(computedHash.Span), Is.EqualTo(expectedHash));
+    }
+
+    [Test]
+    public void Storage_leaf_small()
+    {
+        Span<byte> value = stackalloc byte[1] { 3 };
+        Span<byte> key = stackalloc byte[1] { 1 };
+        var path = NibblePath.FromKey(key);
+
+        Node.Leaf.KeccakOrRlp(path, value, out var result);
+
+        result.DataType.Should().Be(KeccakOrRlp.Type.Rlp);
+        result.Span.ToArray().Should().BeEquivalentTo(new byte[] { 0xC4, 0x82, 0x20, 0x01, 0x03 });
     }
 }

--- a/src/Paprika/RLP/KeccakOrRlp.cs
+++ b/src/Paprika/RLP/KeccakOrRlp.cs
@@ -21,7 +21,7 @@ public readonly ref struct KeccakOrRlp
 
     public Span<byte> Span => DataType == Type.Keccak
         ? _keccak.BytesAsSpan
-        : _keccak.BytesAsSpan.Slice(NonKeccakOffset + _keccak.BytesAsSpan[0]);
+        : _keccak.BytesAsSpan.Slice(NonKeccakOffset, _keccak.BytesAsSpan[0]);
 
     private KeccakOrRlp(Type dataType, scoped Span<byte> data)
     {


### PR DESCRIPTION
This PR introduces a few benchmarks for RLP and Merkle. It also provides a test and fixes one of the flaws that were lurking there (a wrong Span slice for embedded nodes).