### PR TITLE
NibblePath GetHashCode performance

### DIFF
--- a/src/Paprika.Benchmarks/NibblePathBenchmarks.cs
+++ b/src/Paprika.Benchmarks/NibblePathBenchmarks.cs
@@ -6,24 +6,18 @@ namespace Paprika.Benchmarks;
 
 public class NibblePathBenchmarks
 {
+    [Params(true, false)]
+    public bool FullKeccak { get; set; }
+
     [Params(0, 1, 2, 3)]
     public int Slice { get; set; }
 
     [Benchmark(OperationsPerInvoke = 4)]
-    public int Hash_short()
+    public int Hash()
     {
-        var path = NibblePath.FromKey(stackalloc byte[3] { 0xFC, 234, 1 }, Slice);
-
-        return path.GetHashCode() ^
-               path.GetHashCode() ^
-               path.GetHashCode() ^
-               path.GetHashCode();
-    }
-
-    [Benchmark(OperationsPerInvoke = 4)]
-    public int Hash_Keccak()
-    {
-        var path = NibblePath.FromKey(Keccak.OfAnEmptyString, Slice);
+        var span = FullKeccak ? Keccak.OfAnEmptyString.BytesAsSpan : stackalloc byte[3] { 0xFC, 234, 1 };
+        var path = NibblePath.FromKey(
+            span, Slice);
 
         return path.GetHashCode() ^
                path.GetHashCode() ^

--- a/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
@@ -6,13 +6,13 @@ using Paprika.Store;
 namespace Paprika.Benchmarks;
 
 [DisassemblyDiagnoser(3)]
-public class FixedMapBenchmarks
+public class SlottedArrayBenchmarks
 {
     private readonly byte[] _writtenData = new byte[Page.PageSize];
     private readonly byte[] _writable = new byte[Page.PageSize];
     private readonly int _to;
 
-    public FixedMapBenchmarks()
+    public SlottedArrayBenchmarks()
     {
         var map = new SlottedArray(_writtenData);
 

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -491,8 +491,11 @@ public readonly ref struct NibblePath
     {
         const int prime = 374761393;
 
-        if (Length == 0)
-            return 0;
+        if (Length <= 1)
+        {
+            return Length == 0 ? 0 : GetAt(0);
+        }
+
         unchecked
         {
             ref var span = ref _span;


### PR DESCRIPTION
This PR improves `NibblePath GetHashCode` a lot. As this will be a frequent operation after #131 that moved to hash based approach, it's important to keep it fast. Further benchmarks will show how hot is it and whether there are no flaws in here.

### Benchmark results

#### Before

| Method | Slice | FullKeccak |      Mean |     Error |    StdDev |
|------- |------ |----------- |----------:|----------:|----------:|
|   Hash |     0 |      False |  4.777 ns | 0.0361 ns | 0.0337 ns |
|   Hash |     0 |       True | 54.040 ns | 0.3151 ns | 0.2631 ns |
|   Hash |     1 |      False |  4.159 ns | 0.0529 ns | 0.0495 ns |
|   Hash |     1 |       True | 54.185 ns | 0.4818 ns | 0.4507 ns |
|   Hash |     2 |      False |  3.330 ns | 0.0700 ns | 0.0655 ns |
|   Hash |     2 |       True | 52.627 ns | 0.9211 ns | 0.8165 ns |
|   Hash |     3 |      False |  2.523 ns | 0.0281 ns | 0.0249 ns |
|   Hash |     3 |       True | 53.343 ns | 1.0375 ns | 0.9705 ns |

#### After

| Method | FullKeccak | Slice |     Mean |     Error |    StdDev |
|------- |----------- |------ |---------:|----------:|----------:|
|   Hash |      False |     0 | 2.361 ns | 0.0208 ns | 0.0195 ns |
|   Hash |      False |     1 | 2.572 ns | 0.0492 ns | 0.0461 ns |
|   Hash |      False |     2 | 2.645 ns | 0.0340 ns | 0.0318 ns |
|   Hash |      False |     3 | 2.727 ns | 0.0368 ns | 0.0326 ns |
|   Hash |       True |     0 | 4.275 ns | 0.0659 ns | 0.0616 ns |
|   Hash |       True |     1 | 2.859 ns | 0.0286 ns | 0.0268 ns |
|   Hash |       True |     2 | 3.034 ns | 0.0408 ns | 0.0382 ns |
|   Hash |       True |     3 | 2.891 ns | 0.0367 ns | 0.0344 ns |