### PR TITLE
Aggressive page reuse

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -17,7 +17,8 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 25_000 : 10_000;
+    private const int BlockCount = PersistentDb ? 15_000 : 2_000;
+
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;
     private const int FinalizeEvery = 32;
@@ -26,7 +27,7 @@ public static class Program
 
     private const int NumberOfLogs = PersistentDb ? 100 : 10;
 
-    private const long DbFileSize = PersistentDb ? 64 * Gb : 16 * Gb;
+    private const long DbFileSize = PersistentDb ? 64 * Gb : 24 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
 
     private static readonly TimeSpan FlushEvery = TimeSpan.FromSeconds(10);
@@ -140,7 +141,7 @@ public static class Program
             }
 
             // waiting for finalization
-            using var read = db.BeginReadOnlyBatch();
+            using var read = db.BeginReadOnlyBatch("Runner - reading");
 
             var readingStopWatch = Stopwatch.StartNew();
             random = BuildRandom();

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -17,7 +17,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 15_000 : 2_000;
+    private const int BlockCount = PersistentDb ? 15_000 : 50_000;
 
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;

--- a/src/Paprika/IDb.cs
+++ b/src/Paprika/IDb.cs
@@ -12,5 +12,5 @@ public interface IDb
     /// Starts a readonly batch that preserves a snapshot of the database as in the moment of its creation.
     /// </summary>
     /// <returns></returns>
-    IReadOnlyBatch BeginReadOnlyBatch();
+    IReadOnlyBatch BeginReadOnlyBatch(string name = "");
 }

--- a/src/Paprika/IReadOnlyBatch.cs
+++ b/src/Paprika/IReadOnlyBatch.cs
@@ -16,4 +16,6 @@ public interface IReadOnlyBatch : IDisposable
     bool TryGet(scoped in Key key, out ReadOnlySpan<byte> result);
 
     void Report(IReporter reporter);
+
+    public uint BatchId { get; }
 }

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -6,10 +6,19 @@ public unsafe class NativeMemoryPageManager : PointerPageManager
 {
     private readonly void* _ptr;
 
-    public NativeMemoryPageManager(ulong size) : base(size)
+    public NativeMemoryPageManager(ulong size, byte historyDepth) : base(size)
     {
         _ptr = NativeMemory.AlignedAlloc((UIntPtr)size, (UIntPtr)Page.PageSize);
+
         NativeMemory.Clear(_ptr, (UIntPtr)size);
+
+        // NativeMemory.Fill(_ptr, (UIntPtr)size, byte.MaxValue);
+        //
+        // // clear first pages to make it clean
+        // for (var i = 0; i < historyDepth; i++)
+        // {
+        //     GetAt(new DbAddress((uint)i)).Clear();
+        // }
     }
 
     protected override void* Ptr => _ptr;

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -10,15 +10,11 @@ public unsafe class NativeMemoryPageManager : PointerPageManager
     {
         _ptr = NativeMemory.AlignedAlloc((UIntPtr)size, (UIntPtr)Page.PageSize);
 
-        NativeMemory.Clear(_ptr, (UIntPtr)size);
-
-        // NativeMemory.Fill(_ptr, (UIntPtr)size, byte.MaxValue);
-        //
-        // // clear first pages to make it clean
-        // for (var i = 0; i < historyDepth; i++)
-        // {
-        //     GetAt(new DbAddress((uint)i)).Clear();
-        // }
+        // clear first pages to make it clean
+        for (var i = 0; i < historyDepth; i++)
+        {
+            GetAt(new DbAddress((uint)i)).Clear();
+        }
     }
 
     protected override void* Ptr => _ptr;

--- a/src/Paprika/Utils/RefCountingDisposable.cs
+++ b/src/Paprika/Utils/RefCountingDisposable.cs
@@ -58,4 +58,8 @@ public abstract class RefCountingDisposable : IDisposable
     }
 
     protected abstract void CleanUp();
+
+    public int Counter => Volatile.Read(ref _counter);
+
+    public override string ToString() => $"Counter: {Volatile.Read(ref _counter)}";
 }


### PR DESCRIPTION
This PR makes a big change in how the flushing mechanism of `Blockchain` works in `Paprika` making it much more aggressive in reusing them without dropping the existing safety.

Before, the snapshot of the database was taken only after the whole batch of blocks was finalized. This, as the batching mechanism used smart-batching, resulted in prolonged periods of time where there was an active `ReadOnlyBatch` that pointed hundreds if not thousands of blocks behind (depends on the flush timeout). This, made Paprika reuse pages less as they were blocked for longer periods of time.

After this PR, every single time a block is committed to `PagedDb`, a new `ReadOnlyBatch` is started. This means, that even for longer flush timeouts, the reading batch won't block from page reuse. The reusability of the pages can be observed in metrics, where they show reuses at every single commit, while previously, there were longer gaps of no pages being reused (batch was held for longer periods of time) followed by reuse them all.

### Runs 

#### 50 million accounts

![image](https://github.com/NethermindEth/Paprika/assets/519707/91da6c3e-cbe0-4eb1-9a7e-54dbfa8c25ce)

#### 100 million accounts

![image](https://github.com/NethermindEth/Paprika/assets/519707/cde73789-50f7-4fa2-9633-773b6d263e7a)



Closes #137 
Closes #106

