### PR TITLE
Faster assertsions for runner

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -17,7 +17,7 @@ namespace Paprika.Runner;
 
 public static class Program
 {
-    private const int BlockCount = PersistentDb ? 100_000 : 20_000;
+    private const int BlockCount = PersistentDb ? 100_000 : 50_000;
 
     private const int AccountsPerBlock = 1000;
     private const int MaxReorgDepth = 64;
@@ -27,14 +27,14 @@ public static class Program
 
     private const int NumberOfLogs = PersistentDb ? 100 : 10;
 
-    private const long DbFileSize = PersistentDb ? 64 * Gb : 24 * Gb;
+    private const long DbFileSize = PersistentDb ? 64 * Gb : 16 * Gb;
     private const long Gb = 1024 * 1024 * 1024L;
 
     private static readonly TimeSpan FlushEvery = TimeSpan.FromSeconds(10);
 
     private const int LogEvery = BlockCount / NumberOfLogs;
 
-    private const bool PersistentDb = true;
+    private const bool PersistentDb = false;
 
     /// <summary>
     /// Whether perform a real FSYNC. Set to false, to make disk based tests faster.
@@ -165,12 +165,7 @@ public static class Program
                 {
                     var storageAddress = GetStorageAddress(i);
                     var expectedStorageValue = GetStorageValue(i);
-                    var actualStorage = read.GetStorage(key, storageAddress);
-
-                    if (actualStorage.SequenceEqual(expectedStorageValue) == false)
-                    {
-                        throw new InvalidOperationException($"Invalid storage for account number {i}!");
-                    }
+                    read.AssertStorageValue(key, storageAddress, expectedStorageValue);
                 }
 
                 if (UseBigStorageAccount)
@@ -178,12 +173,7 @@ public static class Program
                     var index = i % BigStorageAccountSlotCount;
                     var storageAddress = GetStorageAddress(index);
                     var expectedStorageValue = GetBigAccountValue(index);
-                    var actualStorage = read.GetStorage(bigStorageAccount, storageAddress);
-
-                    if (actualStorage.SequenceEqual(expectedStorageValue) == false)
-                    {
-                        throw new InvalidOperationException($"Invalid storage for big storage account at index {i}!");
-                    }
+                    read.AssertStorageValue(bigStorageAccount, storageAddress, expectedStorageValue);
                 }
 
                 if (i > 0 & i % logReadEvery == 0)

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Buffers.Binary;
 using FluentAssertions;
 using Nethermind.Int256;
+using NUnit.Framework;
 using Paprika.Crypto;
 using Paprika.Data;
 using Paprika.Store;
@@ -37,16 +38,28 @@ public static class TestExtensions
 
     public static Account GetAccount(this IReadOnlyBatch read, in Keccak key)
     {
-        read.TryGet(Key.Account(key), out var value).Should().BeTrue($"Key: {key.ToString()} should exist.");
+        if (!read.TryGet(Key.Account(key), out var value))
+        {
+            Assert.Fail($"Key: {key.ToString()} should exist.");
+        }
+            
+            
         Account.ReadFrom(value, out var account);
         return account;
     }
 
-    public static byte[] GetStorage(this IReadOnlyBatch read, in Keccak key, in Keccak storage)
+    public static void AssertStorageValue(this IReadOnlyBatch read, in Keccak key, in Keccak storage, 
+        ReadOnlySpan<byte> expected)
     {
-        read.TryGet(Key.StorageCell(NibblePath.FromKey(key), storage), out var value).Should()
-            .BeTrue($"Storage for the account: {key.ToString()} @ {storage.ToString()} should exist.");
-        return value.ToArray();
+        if (!read.TryGet(Key.StorageCell(NibblePath.FromKey(key), storage), out var value))
+        {
+            Assert.Fail($"Storage for the account: {key.ToString()} @ {storage.ToString()} should exist.");
+        }
+
+        if (value.SequenceEqual(expected) == false)
+        {
+            throw new InvalidOperationException($"Invalid storage value for account number {key.ToString()} @ {storage.ToString()}!");
+        }
     }
 
     public static void ShouldHaveStorage(this IReadOnlyBatch read, in Keccak key, in Keccak storage,

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -42,13 +42,13 @@ public static class TestExtensions
         {
             Assert.Fail($"Key: {key.ToString()} should exist.");
         }
-            
-            
+
+
         Account.ReadFrom(value, out var account);
         return account;
     }
 
-    public static void AssertStorageValue(this IReadOnlyBatch read, in Keccak key, in Keccak storage, 
+    public static void AssertStorageValue(this IReadOnlyBatch read, in Keccak key, in Keccak storage,
         ReadOnlySpan<byte> expected)
     {
         if (!read.TryGet(Key.StorageCell(NibblePath.FromKey(key), storage), out var value))


### PR DESCRIPTION
This PR amends `Paprika.Runner` to not use `FluentAssertions` for the massive number of comparisons. It uses a simple `if` instead of `Should` that showed 15% (20% if hex encoding is counted in)

![image_720](https://github.com/NethermindEth/Paprika/assets/519707/bdfa36df-fc27-467f-8304-747801466b39)
