### PR TITLE
RootPage should have one data root

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -32,7 +32,7 @@ public static class Program
 {
     private static readonly Case InMemoryReallySmall =
         new(5_000, 1000, 1 * Gb, false, TimeSpan.FromSeconds(5), false, false);
-    
+
     private static readonly Case InMemorySmall =
         new(50_000, 1000, 11 * Gb, false, TimeSpan.FromSeconds(5), false, false);
     private static readonly Case

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -30,6 +30,9 @@ public record Case(uint BlockCount, int AccountsPerBlock, ulong DbFileSize, bool
 
 public static class Program
 {
+    private static readonly Case InMemoryReallySmall =
+        new(5_000, 1000, 1 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+    
     private static readonly Case InMemorySmall =
         new(50_000, 1000, 11 * Gb, false, TimeSpan.FromSeconds(5), false, false);
     private static readonly Case
@@ -50,7 +53,7 @@ public static class Program
     public static async Task Main(String[] args)
     {
         // select the case
-        var caseName = (args.Length > 0 ? args[0] : nameof(InMemorySmall)).ToLowerInvariant();
+        var caseName = (args.Length > 0 ? args[0] : nameof(InMemoryReallySmall)).ToLowerInvariant();
         var cases = typeof(Program)
             .GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
             .Where(f => f.FieldType == typeof(Case))

--- a/src/Paprika/Utils/Printer.cs
+++ b/src/Paprika/Utils/Printer.cs
@@ -75,7 +75,7 @@ public class Printer : IPageVisitor
             {
                 (Type, "Root"),
                 ("BatchId", page.Header.BatchId.ToString()),
-                ("DataPages", ListPages(page.Data.AccountPages)),
+                ("DataPage", page.Data.DataRoot.ToString()),
                 ("NextFreePage", page.Data.NextFreePage.ToString()),
                 ("Abandoned", ListPages(page.Data.AbandonedPages))
             };


### PR DESCRIPTION
This PR changes the behavior of `RootPage` so that it does not provide an initial fan out of 16, but only points to one `DataPage`, the data root. This, with no slice over the initial key, should allow to keep data that have their keys empty (`Key.Merkle('')` for example) in the root of the data, without additional logic.

Effectively, it turns  `DbAddress[]` to `DbAddress` and pushes logic for the first level into the data.

Closes #118 