### PR TITLE
Merkle zero-copy fixes

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -177,7 +177,8 @@ public static class Program
                     // the account has the storage, compare only: balance, nonce and codehash as the storage will be different
                     if (!actual.Nonce.Equals(expected.Nonce) ||
                         !actual.Balance.Equals(expected.Balance) ||
-                        !actual.CodeHash.Equals(expected.CodeHash))
+                        !actual.CodeHash.Equals(expected.CodeHash) ||
+                        actual.StorageRootHash.Equals(Keccak.EmptyTreeHash)) // should not be empty!
                     {
                         throw new InvalidOperationException(
                             $"Invalid account state for account number {i} with address {key.ToString()}. " +

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -710,7 +710,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
 
                         // Important! Make it the last as it's updating the existing key
                         commit.SetExtension(key, extPath);
-                        
+
                         return;
                     }
                 case Node.Type.Branch:

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -17,6 +17,11 @@ namespace Paprika.Merkle;
 ///  construct.
 /// 2. calls the computation of the Merkle RootHash when needed.
 /// </summary>
+/// <remarks>
+/// Important: even though the underlying storage does COW, it's not done on the commit level. This means
+/// that if there's an update for the given key, the key should be first read and worked with,
+/// only to be updated at the end of the processing. Otherwise, the data using zero-copy could be overwritten.
+/// </remarks>
 public class ComputeMerkleBehavior : IPreCommitBehavior
 {
     /// <summary>


### PR DESCRIPTION
This PR introduces fixes to the `Merkle` behavior. The errors were a result of setting the key, while the underlying memory was used by zero copy, by-ref mechanism. Moving the setting for the key as the last part of the specific block ensures, that all the data that are needed are read first and only then, the original key is updated.