### PR TITLE
Block now memoizes the hash that is used in all the calls

### DIFF
--- a/src/Paprika/Chain/InBlockMap.cs
+++ b/src/Paprika/Chain/InBlockMap.cs
@@ -19,11 +19,13 @@ public readonly struct InBlockMap
         return map.TrySet(key, data);
     }
 
-    public bool TryGet(scoped in Key key, out ReadOnlySpan<byte> result)
+    public bool TryGet(scoped in Key key, ushort hash, out ReadOnlySpan<byte> result)
     {
         var map = new SlottedArray(_page.Span);
-        return map.TryGet(key, out result);
+        return map.TryGet(key, hash, out result);
     }
+
+    public static ushort Hash(scoped in Key key) => SlottedArray.Slot.GetHash(key);
 
     public void Apply(IBatch batch)
     {

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -374,6 +374,18 @@ public readonly ref struct SlottedArray
         return false;
     }
 
+    public bool TryGet(scoped in Key key, ushort hash, out ReadOnlySpan<byte> data)
+    {
+        if (TryGetImpl(key, hash, out var span, out _))
+        {
+            data = span;
+            return true;
+        }
+
+        data = default;
+        return false;
+    }
+
     [OptimizationOpportunity(OptimizationType.CPU, "key encoding is delayed but it might be called twice, here + TrySet")]
     private bool TryGetImpl(scoped in Key key, ushort hash, out Span<byte> data, out int slotIndex)
     {


### PR DESCRIPTION
This PR precomputes the hash used in the `InBlockMap` so that it is not computed for each map.

### Before

![image](https://github.com/NethermindEth/Paprika/assets/519707/27422f11-6191-4c94-95ae-4ff910bb83aa)

### After

![image](https://github.com/NethermindEth/Paprika/assets/519707/21d7c8ba-974c-4859-b611-d559b00ea695)
