### PR TITLE
Faster Merkle

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -393,7 +393,7 @@ public static class Program
             if (block > 0 & block % config.LogEvery == 0)
             {
                 report.AppendLine(
-                    $@"At block {block, 4}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
+                    $@"At block {block,4}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
 
                 reporting.Update(new Panel(report.ToString()).Header("Writing").Expand());
                 writing.Restart();

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -127,8 +127,7 @@ public static class Program
                 Console.WriteLine("- each account amends 1 slot in Big Storage account");
             }
 
-            var counter = 0;
-            object result;
+            int counter;
 
             // ReSharper disable once MethodSupportsCancellation
 #pragma warning disable CS4014
@@ -394,7 +393,7 @@ public static class Program
             if (block > 0 & block % config.LogEvery == 0)
             {
                 report.AppendLine(
-                    $@"At block {block}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
+                    $@"At block {block, 4}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
 
                 reporting.Update(new Panel(report.ToString()).Header("Writing").Expand());
                 writing.Restart();

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -148,7 +148,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            var preCommit = new ComputeMerkleBehavior(true, 2, 2);
+            var preCommit = new ComputeMerkleBehavior(true, 2, 1);
             //IPreCommitBehavior preCommit = null;
 
             await using (var blockchain = new Blockchain(db, preCommit, config.FlushEvery, 1000, reporter.Observe))
@@ -392,7 +392,7 @@ public static class Program
             if (block > 0 & block % config.LogEvery == 0)
             {
                 reporting.Update(
-                    new Panel($@"At block {block}. Writing last batch took {writing.Elapsed:g}").Header("Writing")
+                    new Panel($@"At block {block}. Writing last batch of {config.LogEvery} blocks took {writing.Elapsed:g}").Header("Writing")
                         .Expand());
                 writing.Restart();
             }

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -378,7 +378,8 @@ public static class Program
                 counter++;
             }
 
-            result = $"{worldState.Commit().ToString()?[..8]}...";
+            var obj = worldState.Commit();
+            result = $"{obj.ToString()?[..8]}...";
 
             // finalize
             if (toFinalize.Count >= FinalizeEvery)

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -24,7 +24,7 @@ public record Case(uint BlockCount, int AccountsPerBlock, ulong DbFileSize, bool
     bool Fsync,
     bool UseBigStorageAccount)
 {
-    public static uint NumberOfLogs => 10u;
+    public static uint NumberOfLogs => 20u;
     public uint LogEvery => BlockCount / NumberOfLogs;
 }
 
@@ -394,7 +394,7 @@ public static class Program
             if (block > 0 & block % config.LogEvery == 0)
             {
                 report.AppendLine(
-                    $@"At block {block}. This batch of {config.LogEvery} blocks took {writing.Elapsed:g}. RootHash: {result}");
+                    $@"At block {block}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
 
                 reporting.Update(new Panel(report.ToString()).Header("Writing").Expand());
                 writing.Restart();
@@ -407,7 +407,7 @@ public static class Program
         placeholder.Commit();
         blockchain.Finalize(lastBlock);
 
-        report.AppendLine($@"At block {config.BlockCount - 1}. This batch of {config.LogEvery} blocks took {writing.Elapsed:g}. RootHash: {result}");
+        report.AppendLine($@"At block {config.BlockCount - 1}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
 
         reporting.Update(new Panel(report.ToString()).Header("Writing").Expand());
 

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -60,7 +60,6 @@ public class BlockchainTests
 
         // start the third block
         using var block3A = blockchain.StartNew(Block2A, Block3A, 3);
-        block3A.Commit();
 
         block3A.GetAccount(Key0).Should().Be(account1A);
     }

--- a/src/Paprika.Tests/Chain/PreCommitBehaviorTests.cs
+++ b/src/Paprika.Tests/Chain/PreCommitBehaviorTests.cs
@@ -59,7 +59,7 @@ public class PreCommitBehaviorTests
 
         public static ReadOnlySpan<byte> Value => new byte[29];
 
-        public void BeforeCommit(ICommit commit)
+        public object BeforeCommit(ICommit commit)
         {
             commit.Set(AssignedKey, Value);
 
@@ -69,6 +69,8 @@ public class PreCommitBehaviorTests
 
             owner.IsEmpty.Should().BeFalse();
             owner.Span.SequenceEqual(Value).Should().BeTrue();
+
+            return "none";
         }
 
         private static void OnKey(in Key key, ReadOnlySpan<byte> value) => throw new Exception("Should not be called at all!");
@@ -88,13 +90,15 @@ public class PreCommitBehaviorTests
             _found = new HashSet<Keccak>();
         }
 
-        public void BeforeCommit(ICommit commit)
+        public object BeforeCommit(ICommit commit)
         {
             _found.Clear();
 
             commit.Visit(OnKey, TrieType.State);
 
             _keccaks.SetEquals(_found).Should().BeTrue();
+
+            return "none";
         }
 
         private void OnKey(in Key key, ReadOnlySpan<byte> value)

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -390,11 +390,13 @@ public class Blockchain : IAsyncDisposable
             // rent pages for the bloom
             _bloom = new HashSet<int>();
 
-            _state = new PooledSpanDictionary(Pool);
-            _storage = new PooledSpanDictionary(Pool);
+            // as pre-commit can use parallelism, make the pooled dictionaries concurrent friendly:
+            // 1. make the dictionary preserve once written values, which means that it can repeatedly read and set without worrying of ordering operations
+            // 2. set dictionary so that it allows concurrent readers
 
-            // as pre-commit can be run in parallel, make the dictionary preserve once written values.
-            _preCommit = new PooledSpanDictionary(Pool, true);
+            _state = new PooledSpanDictionary(Pool, true, true);
+            _storage = new PooledSpanDictionary(Pool, true, true);
+            _preCommit = new PooledSpanDictionary(Pool, true, true);
         }
 
         /// <summary>

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -574,13 +574,20 @@ public class Blockchain : IAsyncDisposable
 
             try
             {
+                var expected = BlockNumber - 1;
+
                 // walk all the blocks locally
                 foreach (var ancestor in _ancestors)
                 {
+                    Debug.Assert(ancestor.BlockNumber == expected);
+                    expected--;
+
                     owner = ancestor.TryGetLocal(key, keyWritten, bloom, out succeeded);
                     if (succeeded)
                         return owner;
                 }
+
+                Debug.Assert(_batch.BatchId == expected);
 
                 if (_batch.TryGet(key, out var span))
                 {

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -407,14 +407,16 @@ public class Blockchain : IAsyncDisposable
         /// <summary>
         /// Commits the block to the block chain.
         /// </summary>
-        public void Commit()
+        public object Commit()
         {
             // run pre-commit
-            _blockchain._preCommit?.BeforeCommit(this);
+            var result = _blockchain._preCommit?.BeforeCommit(this);
 
             AcquireLease();
             _blockchain.Add(this);
             _committed = true;
+
+            return result ?? "null";
         }
 
         private BufferPool Pool => _blockchain._pool;

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -22,15 +22,7 @@ public interface IPreCommitBehavior
 /// allowing for additional modifications of the data just before the commit.
 /// </summary>
 /// <remarks>
-/// Use Enumerator to access all the keys
-///
-/// public static void Foreach(this ICommit commit)
-/// {
-///     foreach (var key in commit)
-///     {
-///         key.
-///     }
-///  }
+/// Use <see cref="Visit"/> to access all the keys.
 /// </remarks>
 public interface ICommit
 {
@@ -50,7 +42,21 @@ public interface ICommit
     /// <summary>
     /// Visits the given <paramref name="type"/> of the changes in the given commit.
     /// </summary>
-    void Visit(CommitAction action, TrieType type);
+    void Visit(CommitAction action, TrieType type) => throw new Exception("No visitor available for this commit");
+
+    /// <summary>
+    /// Gets the child commit that is a thread-safe write-through commit.
+    /// </summary>
+    /// <returns>A child commit.</returns>
+    IChildCommit GetChild() => throw new Exception($"No {nameof(GetChild)} available for this commit");
+}
+
+public interface IChildCommit : ICommit, IDisposable
+{
+    /// <summary>
+    /// Commits to the parent
+    /// </summary>
+    void Commit();
 }
 
 /// <summary>

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -14,7 +14,7 @@ public interface IPreCommitBehavior
     /// Executed just before commit.
     /// </summary>
     /// <param name="commit">The object representing the commit.</param>
-    public void BeforeCommit(ICommit commit);
+    public object BeforeCommit(ICommit commit);
 }
 
 /// <summary>

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -44,19 +44,8 @@ public interface ICommit
     /// </summary>
     void Visit(CommitAction action, TrieType type) => throw new Exception("No visitor available for this commit");
 
-    /// <summary>
-    /// Gets the child commit that is a thread-safe write-through commit.
-    /// </summary>
-    /// <returns>A child commit.</returns>
-    IChildCommit GetChild() => throw new Exception($"No {nameof(GetChild)} available for this commit");
-}
-
-public interface IChildCommit : ICommit, IDisposable
-{
-    /// <summary>
-    /// Commits to the parent
-    /// </summary>
-    void Commit();
+    ICommit AsSynchronized() =>
+        throw new Exception($"No {nameof(AsSynchronized)} available for commit of type {GetType()}");
 }
 
 /// <summary>

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -44,12 +44,22 @@ public interface ICommit
     /// </summary>
     void Visit(CommitAction action, TrieType type) => throw new Exception("No visitor available for this commit");
 
-    ICommit AsSynchronized() =>
-        throw new Exception($"No {nameof(AsSynchronized)} available for commit of type {GetType()}");
+    /// <summary>
+    /// Gets the child commit that is a thread-safe write-through commit.
+    /// </summary>
+    /// <returns>A child commit.</returns>
+    IChildCommit GetChild() => throw new Exception($"No {nameof(GetChild)} available for this commit");
+}
+
+public interface IChildCommit : ICommit, IDisposable
+{
+    /// <summary>
+    /// Commits to the parent
+    /// </summary>
+    void Commit();
 }
 
 /// <summary>
 /// A delegate to be called on the each key that that the commit contains.
 /// </summary>
 public delegate void CommitAction(in Key key, ReadOnlySpan<byte> value);
-

--- a/src/Paprika/Chain/IWorldState.cs
+++ b/src/Paprika/Chain/IWorldState.cs
@@ -24,5 +24,6 @@ public interface IWorldState : IDisposable
     /// Commits the block to the chain allowing to build upon it.
     /// Also runs the <see cref="IPreCommitBehavior"/> that the blockchain was configured with.
     /// </summary>
-    void Commit();
+    /// <returns>The result of the commit that is actually <see cref="IPreCommitBehavior.BeforeCommit"/> result. </returns>
+    object Commit();
 }

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -221,6 +221,8 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         {
             _pool.Return(page);
         }
+
+        _pages.Clear();
     }
 
     public override string ToString() => $"Count: {_dict.Count}, Memory: {_pages.Count * BufferSize / 1024}kb";

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -158,7 +158,11 @@ public readonly ref struct NibblePath
     /// <summary>
     /// Trims the end of the nibble path so that it gets to the specified length.
     /// </summary>
-    public NibblePath SliceTo(int length) => new(ref _span, _odd, (byte)length);
+    public NibblePath SliceTo(int length)
+    {
+        Debug.Assert(length <= Length, "Cannot slice the NibblePath beyond its Length");
+        return new NibblePath(ref _span, _odd, (byte)length);
+    }
 
     public byte this[int nibble] => GetAt(nibble);
 

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -430,10 +430,16 @@ public readonly ref struct SlottedArray
                     {
                         if (key.StoragePath.IsEmpty)
                         {
-                            // no additional key, just assert encoded
-                            data = actual.Slice(encodedKey.Length + NibblePath.EmptyEncodedLength);
-                            slotIndex = i;
-                            return true;
+                            // the searched storage path is empty, but need to ensure that it starts right
+                            // the empty path is encoded as "[0]", compare manually
+                            if (actual[encodedKey.Length] == 0)
+                            {
+                                data = actual.Slice(encodedKey.Length + NibblePath.EmptyEncodedLength);
+                                slotIndex = i;
+                                return true;
+                            }
+
+                            continue;
                         }
 
                         // there's the additional key, assert it

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -238,12 +238,13 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
         {
             // materialize path so that it can be closure captured
             var results = new byte[NibbleSet.NibbleCount][];
-            var synchronized = commit.AsSynchronized();
 
             // parallel calculation
 #if USE_PARALLEL
+            var synchronized = commit.AsSynchronized();
             Parallel.For((long)0, NibbleSet.NibbleCount, nibble =>
 #else
+            var synchronized = commit;
             for (var nibble = 0; nibble < NibbleSet.NibbleCount; nibble++)
 #endif
             {

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -138,7 +138,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
 
     public Keccak RootHash { get; private set; }
 
-    [SkipLocalsInit]
+
     private KeccakOrRlp Compute(in Key key, ICommit commit, TrieType trieType)
     {
         using var owner = commit.Get(key);

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -88,7 +88,10 @@ public class ComputeMerkleBehavior : IPreCommitBehavior
 
             Debug.Assert(rootKeccak.DataType == KeccakOrRlp.Type.Keccak);
 
-            return new Keccak(rootKeccak.Span).ToString();
+            var value = new Keccak(rootKeccak.Span);
+            RootHash = value;
+
+            return value.ToString();
         }
 
         return "not full merkle";

--- a/src/Paprika/Merkle/NibbleSet.cs
+++ b/src/Paprika/Merkle/NibbleSet.cs
@@ -91,6 +91,9 @@ public struct NibbleSet
         }
 
         public bool this[byte nibble] => new NibbleSet(_value)[nibble];
+
+        public bool AllSet => _value == 0b1111_1111_1111_1111;
+
         public int SetCount => new NibbleSet(_value).SetCount;
         public byte SmallestNibbleSet => new NibbleSet(_value).SmallestNibbleSet;
 


### PR DESCRIPTION
This PR introduces parallelism in Merkle computation. After profiling, the most significant part was related to the `State` and it was the part that is done in parallel. The degree of parallelism now is set to 16 and is run only for the top layer. This shows a **massive speed up of 60%**.

To make it work a concept of a `IChildCommit` is introduced. It allows to pass a commit-like to a given parallel branch of computation. It works as a read-through object where writes are stored locally and reads first hit local dictionary. This allows no synchronization at all as even a simple `ReaderWriterLockSlim` showed penalty of 30% of execution!

Additionally, this PR allows to configure `PooledSpanDictionary` with two additional options. First, disables reusing of memory for the same key, so that once the span with data is retrieved, will be always correct. The second option allows for concurrent reads. This was not working before as the dictionary was using a shared buffer to materialize key as span. You can imagine the havoc with Parallel and multiple threads writing over the same memory.😅 

### Benchmarks

#### Before

<img width="1892" alt="regular-5000" src="https://github.com/NethermindEth/Paprika/assets/519707/0f144cf6-2806-4246-9ee2-9ba45bafac4a">

#### After

<img width="1897" alt="parallel-no-sync-5000" src="https://github.com/NethermindEth/Paprika/assets/519707/1f572760-35b0-4893-9d86-18a142410890">


Closes #130 