### PR TITLE
Minor adjustements

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -34,9 +34,11 @@ public static class Program
         new(100, 1000, 1 * Gb, false, TimeSpan.FromSeconds(5), false, false);
 
     private static readonly Case InMemorySmall =
-        new(5_000, 1000, 11 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+        new(10_000, 1000, 11 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+    private static readonly Case InMemoryMedium =
+        new(50_000, 1000, 32 * Gb, false, TimeSpan.FromSeconds(5), false, false);
     private static readonly Case
-        InMemoryBig = new(100_000, 1000, 48 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+        InMemoryBig = new(100_000, 1000, 56 * Gb, false, TimeSpan.FromSeconds(5), false, false);
     private static readonly Case DiskSmallNoFlush =
         new(50_000, 1000, 11 * Gb, true, TimeSpan.FromSeconds(5), false, false);
     private static readonly Case DiskSmallFlushFile =
@@ -148,7 +150,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            var preCommit = new ComputeMerkleBehavior(true, 2, 1);
+            using var preCommit = new ComputeMerkleBehavior(true, 2, 1);
             //IPreCommitBehavior preCommit = null;
 
             await using (var blockchain = new Blockchain(db, preCommit, config.FlushEvery, 1000, reporter.Observe))

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -31,6 +31,8 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
 
     private readonly object _key;
 
+    private static readonly ThreadLocal<byte[]> ConcurrentBuffers = new(() => new byte[KeyBytesCount]);
+
     private byte[] KeyBuffer =>
         _allowConcurrentReaders ? Unsafe.As<ThreadLocal<byte[]>>(_key).Value! : Unsafe.As<byte[]>(_key);
 
@@ -55,9 +57,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         _allowConcurrentReaders = allowConcurrentReaders;
         _dict = new Dictionary<KeySpan, ValueSpan>(this);
 
-        _key = allowConcurrentReaders
-            ? new ThreadLocal<byte[]>(() => new byte[KeyBytesCount])
-            : new byte[KeyBytesCount];
+        _key = allowConcurrentReaders ? ConcurrentBuffers : new byte[KeyBytesCount];
 
         AllocateNewPage();
     }


### PR DESCRIPTION
A few minor adjustments bulked together:

1. one new test case for runner
2. shared concurrent buffers for `PooledSpanDicitonary` (no need to recreate buffers for each dictionary, can be static)
3. histograms for Merkle to see timings in real time
4. a concurrency bug fixed in `PagedDb`. The last root was updated without lock and occasionally (concurrency 😋 ) was faulting