### PR TITLE
Rlp memoization 2

### DIFF
--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -23,10 +23,16 @@ public static class CommitExtensions
         commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]));
     }
 
-    public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, Keccak keccak)
+    public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, ReadOnlySpan<byte> rlp)
+    {
+        var branch = new Node.Branch(children);
+        commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]), rlp);
+    }
+
+    public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, Keccak keccak, ReadOnlySpan<byte> rlp)
     {
         var branch = new Node.Branch(children, keccak);
-        commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]));
+        commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]), rlp);
     }
 
     public static void SetExtension(this ICommit commit, in Key key, in NibblePath path)

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -554,7 +554,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         }
 
         // read the existing one
-        Node.ReadFrom(owner.Span, out var type, out var leaf, out var ext, out var branch);
+        var leftover = Node.ReadFrom(owner.Span, out var type, out var leaf, out var ext, out var branch);
         switch (type)
         {
             case Node.Type.Leaf:
@@ -623,9 +623,10 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                         or DeleteStatus.ExtensionToLeaf
                         or DeleteStatus.BranchToLeafOrExtension)
                     {
-                        if (branch.HasKeccak)
+                        // if either has the keccak or has the leftover rlp, clean
+                        if (branch.HasKeccak || leftover.IsEmpty == false)
                         {
-                            // reset keccak
+                            // reset
                             commit.SetBranch(key, branch.Children);
                         }
 

--- a/src/Paprika/Merkle/Node.cs
+++ b/src/Paprika/Merkle/Node.cs
@@ -101,6 +101,8 @@ public static partial class Node
             return source.Slice(Size);
         }
 
+        public static Header Peek(ReadOnlySpan<byte> source) => new(source[0]);
+
         public bool Equals(in Header other)
         {
             return _header.Equals(other._header);
@@ -331,6 +333,27 @@ public static partial class Node
 
             return leftover;
         }
+
+        /// <summary>
+        /// Skips the branch at source, returning just the leftover.
+        /// </summary>
+        public static ReadOnlySpan<byte> Skip(ReadOnlySpan<byte> source)
+        {
+            Header.ReadFrom(source, out var header);
+            return source.Slice(GetBranchDataLength(header));
+        }
+
+        /// <summary>
+        /// Gets only branch data cleaning any leftovers.
+        /// </summary>
+        public static ReadOnlySpan<byte> GetOnlyBranchData(ReadOnlySpan<byte> source)
+        {
+            Header.ReadFrom(source, out var header);
+            return source[..GetBranchDataLength(header)];
+        }
+
+        private static int GetBranchDataLength(Header header) =>
+            Header.Size + NibbleSet.MaxByteSize + (HeaderHasKeccak(header) ? Keccak.Size : 0);
 
         public bool Equals(in Branch other)
         {

--- a/src/Paprika/Merkle/RlpMemo.cs
+++ b/src/Paprika/Merkle/RlpMemo.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics;
+using Paprika.Crypto;
+using Paprika.RLP;
+
+namespace Paprika.Merkle;
+
+public readonly ref struct RlpMemo
+{
+    private readonly Span<byte> _buffer;
+
+    public const int Size = NibbleSet.NibbleCount * Keccak.Size;
+
+    public RlpMemo(Span<byte> buffer)
+    {
+        Debug.Assert(buffer.Length == Size);
+
+        _buffer = buffer;
+    }
+
+    public ReadOnlySpan<byte> Raw => _buffer;
+
+    public void SetRaw(ReadOnlySpan<byte> keccak, byte nibble)
+    {
+        Debug.Assert(keccak.Length == Keccak.Size);
+        keccak.CopyTo(GetAtNibble(nibble));
+    }
+
+    public void Set(in KeccakOrRlp keccakOrRlp, byte nibble)
+    {
+        var span = GetAtNibble(nibble);
+
+        if (keccakOrRlp.DataType == KeccakOrRlp.Type.Keccak)
+        {
+            keccakOrRlp.Span.CopyTo(span);
+        }
+        else
+        {
+            // on rlp, memoize none
+            span.Clear();
+        }
+    }
+
+    public void Clear(byte nibble)
+    {
+        GetAtNibble(nibble).Clear();
+    }
+
+    public bool TryGetKeccak(byte nibble, out ReadOnlySpan<byte> keccak)
+    {
+        var span = GetAtNibble(nibble);
+
+        if (span.IndexOfAnyExcept((byte)0) >= 0)
+        {
+            keccak = span;
+            return true;
+        }
+
+        keccak = default;
+        return false;
+    }
+
+    private Span<byte> GetAtNibble(byte nibble) => _buffer.Slice(nibble * Keccak.Size, Keccak.Size);
+}

--- a/src/Paprika/Utils/ReadOnlySpanOwner.cs
+++ b/src/Paprika/Utils/ReadOnlySpanOwner.cs
@@ -21,4 +21,9 @@ public readonly ref struct ReadOnlySpanOwner<T>
     /// Disposes the owner provided as <see cref="IDisposable"/> once.
     /// </summary>
     public void Dispose() => _owner?.Dispose();
+
+    /// <summary>
+    /// Answers whether this span is owned and provided by <paramref name="owner"/>.
+    /// </summary>
+    public bool IsOwnedBy(object owner) => ReferenceEquals(owner, _owner);
 }


### PR DESCRIPTION
This PR introduces a memoization technique for intermediate `RLP`s of `Branch` nodes of the Merkle tree which speed ups the execution of the Merkle phase by:

1. reducing recalculations of Keccaks of children
2. reducing the number of queries against the database

This is done by appending the memoized set of Keccaks (512 bytes) at the end of the serialized branch. This allows to get it in one read from the underlying `ICommit` and use whenever they are needed. To prohibit these memoized data to be stored and blow up the database, `IPreCommitBehavior` is enhanced with one more method that allows to inspect data just before they are applied on the `PagedDb`. 

The last but not least, `ReadOnlySpanOwner` is extended to allow it to check whether an object is the underlying owner. If it is, then RLP is not copied as the data are from this commit. This allows to save a lot by not copying to a borrowed buffer, but rather by making the rlp writable.

### Benchmarks

#### Before

![image](https://github.com/NethermindEth/Paprika/assets/519707/dfc9ce4f-d084-4812-9d60-338d3f8a0cce)

#### After

![image-1](https://github.com/NethermindEth/Paprika/assets/519707/c7a2b631-6e0a-4467-b7bb-51ddcb65198e)

#### After the aggressive owner check

![image](https://github.com/NethermindEth/Paprika/assets/519707/d2934088-d178-4b11-9b2e-db36465b9e2f)


Closes #154