### PR TITLE
New Prefix Trees

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -350,7 +350,7 @@ To address this `Merkle` is implemented as a pre-commit hook. This hook is run w
 1. Visit all the accounts that were not accessed in 2., but were remembered in 1, meaning Accounts that had their storage modified but no changes to codehash, balance, nonce. For each key:
    1. walk through the MPT of Account State to create/amend Trie nodes
 1. Calculate the Root Hash
-   1. a. for each of accounts that had their storage modified (from 1.),
+   1. for each of accounts that had their storage modified (from 1.),
       1. calculate the storage root hash
       1. store it in the account (decode account, encode, set)
    1. calculate the root hash of the State. **Parallel**

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -34,7 +34,7 @@ public static class Program
         new(100, 1000, 1 * Gb, false, TimeSpan.FromSeconds(5), false, false);
 
     private static readonly Case InMemorySmall =
-        new(10_000, 1000, 11 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+        new(10_000, 1000, 11 * Gb, false, TimeSpan.FromSeconds(5), false, true);
     private static readonly Case InMemoryMedium =
         new(50_000, 1000, 32 * Gb, false, TimeSpan.FromSeconds(5), false, false);
     private static readonly Case

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -51,7 +51,6 @@ public static class Program
     private const int RandomSeed = 17;
     private const long Gb = 1024 * 1024 * 1024L;
     private const int UseStorageEveryNAccounts = 10;
-    private const int BigStorageAccountSlotCount = 1_000_000;
 
     public static async Task Main(String[] args)
     {
@@ -206,9 +205,8 @@ public static class Program
 
                 if (config.UseBigStorageAccount)
                 {
-                    var index = i % BigStorageAccountSlotCount;
-                    var storageAddress = GetStorageAddress(index);
-                    var expectedStorageValue = GetBigAccountValue(index);
+                    var storageAddress = GetStorageAddress(i);
+                    var expectedStorageValue = GetBigAccountValue(i);
                     read.AssertStorageValue(bigStorageAccount, storageAddress, expectedStorageValue);
                 }
 
@@ -371,8 +369,7 @@ public static class Program
                         bigStorageAccountCreated = true;
                     }
 
-                    var index = counter % BigStorageAccountSlotCount;
-                    var storageAddress = GetStorageAddress(index);
+                    var storageAddress = GetStorageAddress(counter);
                     var storageValue = GetBigAccountValue(counter);
 
                     worldState.SetStorage(bigStorageAccount, storageAddress, storageValue);

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -7,6 +7,7 @@ using HdrHistogram;
 using Nethermind.Int256;
 using Paprika.Chain;
 using Paprika.Crypto;
+using Paprika.Data;
 using Paprika.Merkle;
 using Paprika.Store;
 using Paprika.Tests;
@@ -31,7 +32,7 @@ public record Case(uint BlockCount, int AccountsPerBlock, ulong DbFileSize, bool
 public static class Program
 {
     private static readonly Case InMemoryReallySmall =
-        new(100, 1000, 1 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+        new(100, 1000, 1 * Gb, false, TimeSpan.FromSeconds(5), false, true);
 
     private static readonly Case InMemorySmall =
         new(10_000, 1000, 11 * Gb, false, TimeSpan.FromSeconds(5), false, true);
@@ -425,10 +426,8 @@ public static class Program
 
     private static Keccak GetBigAccountKey()
     {
-        Keccak key = default;
-        var random = new Random(RandomSeed + 1);
-        random.NextBytes(key.BytesAsSpan);
-        return key;
+        return NibblePath.Parse("0000000000000000" +
+                                "0123456789ABCDEF").UnsafeAsKeccak;
     }
 
     private static Keccak GetStorageAddress(int counter)
@@ -440,6 +439,5 @@ public static class Program
         return key;
     }
 
-    private static byte[] GetBigAccountValue(int counter) =>
-        (new UInt256((ulong)(counter * 2246822519U), (ulong)(counter * 374761393U))).ToBigEndian();
+    private static byte[] GetBigAccountValue(int counter) => new UInt256(1, (ulong)counter).ToBigEndian();
 }

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -426,7 +426,7 @@ public static class Program
     private static Keccak GetBigAccountKey()
     {
         Keccak key = default;
-        var random = new Random(17);
+        var random = new Random(RandomSeed + 1);
         random.NextBytes(key.BytesAsSpan);
         return key;
     }

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -299,7 +299,7 @@ public class DataPageTests : BasePageTests
     }
 
     [Test]
-    public void PrefixTreeExtraction()
+    public void Small_prefix_tree_with_regular()
     {
         var page = AllocPage();
         page.Clear();
@@ -346,6 +346,45 @@ public class DataPageTests : BasePageTests
         for (var i = 0; i < ushort.MaxValue; i++)
         {
             dataPage.ShouldHaveAccount(GetKey(i), GetValue(i), batch);
+        }
+    }
+
+    [Test]
+    public void Massive_prefix_tree()
+    {
+        var page = AllocPage();
+        page.Clear();
+
+        var batch = NewBatch(BatchId);
+        var dataPage = new DataPage(page);
+
+        const int count = 256;
+
+        var account = Keccak.EmptyTreeHash;
+
+        dataPage = dataPage
+            .SetAccount(account, GetValue(0), batch)
+            .SetMerkle(account, GetValue(1), batch);
+
+        for (var i = 0; i < count; i++)
+        {
+            var storage = GetKey(i);
+
+            dataPage = dataPage
+                .SetStorage(account, storage, GetValue(i), batch)
+                .SetMerkle(account, NibblePath.FromKey(storage), GetValue(i), batch);
+        }
+
+        // assert
+        dataPage.ShouldHaveAccount(account, GetValue(0), batch);
+        dataPage.ShouldHaveMerkle(account, GetValue(1), batch);
+
+        for (var i = 0; i < count; i++)
+        {
+            var storage = GetKey(i);
+
+            dataPage.ShouldHaveStorage(account, storage, GetValue(i), batch);
+            dataPage.ShouldHaveMerkle(account, NibblePath.FromKey(storage), GetValue(i), batch);
         }
     }
 }

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -358,7 +358,7 @@ public class DataPageTests : BasePageTests
         var batch = NewBatch(BatchId);
         var dataPage = new DataPage(page);
 
-        const int count = 256;
+        const int count = 10_000;
 
         var account = Keccak.EmptyTreeHash;
 
@@ -369,10 +369,9 @@ public class DataPageTests : BasePageTests
         for (var i = 0; i < count; i++)
         {
             var storage = GetKey(i);
-
             dataPage = dataPage
                 .SetStorage(account, storage, GetValue(i), batch)
-                .SetMerkle(account, NibblePath.FromKey(storage), GetValue(i), batch);
+                .SetMerkle(account, GetMerkleKey(storage, i), GetValue(i), batch);
         }
 
         // assert
@@ -384,7 +383,14 @@ public class DataPageTests : BasePageTests
             var storage = GetKey(i);
 
             dataPage.ShouldHaveStorage(account, storage, GetValue(i), batch);
-            dataPage.ShouldHaveMerkle(account, NibblePath.FromKey(storage), GetValue(i), batch);
+            dataPage.ShouldHaveMerkle(account, GetMerkleKey(storage, i), GetValue(i), batch);
+        }
+
+        return;
+
+        static NibblePath GetMerkleKey(in Keccak storage, int i)
+        {
+            return NibblePath.FromKey(storage).SliceTo(Math.Min(i + 1, NibblePath.KeccakNibbleCount));
         }
     }
 }

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -278,6 +278,7 @@ public class DataPageTests : BasePageTests
             // skip till set
             random.NextKeccak();
         }
+
         {
             var storagePath = NibblePath.FromKey(random.NextKeccak());
             var merkleKey = Key.Raw(account, DataType.Merkle, storagePath);
@@ -294,6 +295,57 @@ public class DataPageTests : BasePageTests
             dataPage.TryGet(merkleKey, batch, out var actual).Should().BeTrue();
             var value = i == deleteAt ? ReadOnlySpan<byte>.Empty : GetValue(i);
             actual.SequenceEqual(value).Should().BeTrue($"Does not match for i: {i} and delete at: {deleteAt}");
+        }
+    }
+
+    [Test]
+    public void PrefixTreeExtraction()
+    {
+        var page = AllocPage();
+        page.Clear();
+
+        var batch = NewBatch(BatchId);
+        var dataPage = new DataPage(page);
+
+        const int count = 19; // this is the number until a prefix tree is extracted
+
+        var account = Keccak.EmptyTreeHash;
+
+        dataPage = dataPage
+            .SetAccount(account, GetValue(0), batch)
+            .SetMerkle(account, GetValue(1), batch);
+
+        for (var i = 0; i < count; i++)
+        {
+            var storage = GetKey(i);
+
+            dataPage = dataPage
+                .SetStorage(account, storage, GetValue(i), batch)
+                .SetMerkle(account, NibblePath.FromKey(storage), GetValue(i), batch);
+        }
+
+        // write 256 more to fill up the page for each nibble
+        for (var i = 0; i < ushort.MaxValue; i++)
+        {
+            dataPage = dataPage.SetAccount(GetKey(i), GetValue(i), batch);
+        }
+
+        // assert
+        dataPage.ShouldHaveAccount(account, GetValue(0), batch);
+        dataPage.ShouldHaveMerkle(account, GetValue(1), batch);
+
+        for (var i = 0; i < count; i++)
+        {
+            var storage = GetKey(i);
+
+            dataPage.ShouldHaveStorage(account, storage, GetValue(i), batch);
+            dataPage.ShouldHaveMerkle(account, NibblePath.FromKey(storage), GetValue(i), batch);
+        }
+
+        // write 256 more to fill up the page for each nibble
+        for (var i = 0; i < ushort.MaxValue; i++)
+        {
+            dataPage.ShouldHaveAccount(GetKey(i), GetValue(i), batch);
         }
     }
 }

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -191,16 +191,6 @@ public class DbTests
 
             header.BatchId.Should().BeGreaterThan(0);
             header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard, PageType.PrefixPage);
-            if (header.PageType is PageType.PrefixPage or PageType.Abandoned)
-            {
-                header.TreeLevel.Should().BeGreaterOrEqualTo(0);
-            }
-            else
-            {
-                // any non-root data should be bigger than 0
-                header.TreeLevel.Should().BeGreaterThan(0);
-            }
-
             header.PaprikaVersion.Should().Be(1);
         }
     }

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -190,8 +190,8 @@ public class DbTests
             var header = page.Header;
 
             header.BatchId.Should().BeGreaterThan(0);
-            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard, PageType.MassiveStorageTree);
-            if (header.PageType is PageType.MassiveStorageTree or PageType.Abandoned)
+            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard, PageType.PrefixPage);
+            if (header.PageType is PageType.PrefixPage or PageType.Abandoned)
             {
                 header.TreeLevel.Should().BeGreaterOrEqualTo(0);
             }

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -88,6 +88,48 @@ public static class TestExtensions
         return new DataPage(page.Set(new SetContext(k, data, batch)));
     }
 
+    public static DataPage SetMerkle(this DataPage page, in Keccak key, ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        var k = Key.Merkle(NibblePath.FromKey(key));
+        return new DataPage(page.Set(new SetContext(k, data, batch)));
+    }
+
+    public static DataPage SetMerkle(this DataPage page, in Keccak key, in NibblePath storagePath, ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        var k = Key.Raw(NibblePath.FromKey(key), DataType.Merkle, storagePath);
+        return new DataPage(page.Set(new SetContext(k, data, batch)));
+    }
+
+    public static void ShouldHaveMerkle(this DataPage read, in Keccak key, ReadOnlySpan<byte> expected,
+        IReadOnlyBatchContext batch, int? iteration = null)
+    {
+        var account = Key.Merkle(NibblePath.FromKey(key));
+        var because = $"Merkle for {account.Path.ToString()} should exist.";
+        if (iteration != null)
+        {
+            because += $" Iteration: {iteration}";
+        }
+
+        read.TryGet(account, batch, out var value).Should().BeTrue(because);
+        value.SequenceEqual(expected).Should()
+            .BeTrue($"Expected value is {expected.ToHexString(false)} while actual is {value.ToHexString(false)}");
+    }
+
+    public static void ShouldHaveMerkle(this DataPage read, in Keccak key, NibblePath storagePath, ReadOnlySpan<byte> expected,
+        IReadOnlyBatchContext batch, int? iteration = null)
+    {
+        var k = Key.Raw(NibblePath.FromKey(key), DataType.Merkle, storagePath);
+        var because = $"Merkle for {k.ToString()} should exist.";
+        if (iteration != null)
+        {
+            because += $" Iteration: {iteration}";
+        }
+
+        read.TryGet(k, batch, out var value).Should().BeTrue(because);
+        value.SequenceEqual(expected).Should()
+            .BeTrue($"Expected value is {expected.ToHexString(false)} while actual is {value.ToHexString(false)}");
+    }
+
     public static void ShouldHaveAccount(this DataPage read, in Keccak key, ReadOnlySpan<byte> expected,
         IReadOnlyBatchContext batch, int? iteration = null)
     {

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -58,7 +58,8 @@ public static class TestExtensions
 
         if (value.SequenceEqual(expected) == false)
         {
-            throw new InvalidOperationException($"Invalid storage value for account number {key.ToString()} @ {storage.ToString()}!");
+            throw new InvalidOperationException($"Invalid storage value for account number {key.ToString()} @ {storage.ToString()}! " +
+                                                $"Expected was '{expected.ToHexString(false)}' while actual '{value.ToHexString(false)}'");
         }
     }
 

--- a/src/Paprika/Data/DataType.cs
+++ b/src/Paprika/Data/DataType.cs
@@ -17,21 +17,11 @@ public enum DataType : byte
     StorageCell = 1,
 
     /// <summary>
-    /// [key, 2]-> the DbAddress of the root page of the storage trie,
-    /// </summary>
-    StorageTreeRootPageAddress = 2,
-
-    /// <summary>
-    /// [storageCellIndex, 3]-> the StorageCell index, without the prefix of the account
-    /// </summary>
-    StorageTreeStorageCell = 3,
-
-    /// <summary>
     /// As enums cannot be partial, this is for storing the Merkle.
     /// </summary>
-    Merkle = 4,
+    Merkle = 2,
 
-    // 5, 6 - available
+    // 3, 4, 5, 6 - available
 
     /// <summary>
     /// Special type for <see cref="SlottedArray"/>. 

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -55,18 +55,6 @@ public readonly ref partial struct Key
     public static Key StorageCell(NibblePath path, ReadOnlySpan<byte> keccak) =>
         new(path, DataType.StorageCell, NibblePath.FromKey(keccak));
 
-    /// <summary>
-    /// Builds the key identifying the value of the <see cref="DbAddress"/> for the root of the storage tree.
-    /// </summary>
-    public static Key StorageTreeRootPageAddress(NibblePath path) =>
-        new(path, DataType.StorageTreeRootPageAddress, NibblePath.Empty);
-
-    /// <summary>
-    /// Treat the additional key as the key and drop the additional notion.
-    /// </summary>
-    public static Key StorageTreeStorageCell(Key originalKey) =>
-        new(originalKey.StoragePath, DataType.StorageTreeStorageCell, NibblePath.Empty);
-
     [DebuggerStepThrough]
     public Key SliceFrom(int nibbles) => new(Path.SliceFrom(nibbles), Type, StoragePath);
 

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -483,6 +483,8 @@ public readonly ref struct NibblePath
 
     private static readonly char[] Hex = "0123456789ABCDEF".ToArray();
 
+    public bool EndsWith(in NibblePath other) => SliceFrom(Length - other.Length).Equals(other);
+
     public bool Equals(in NibblePath other)
     {
         if (other.Length != Length || (other._odd & OddBit) != (_odd & OddBit))

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -363,18 +363,6 @@ public readonly ref struct SlottedArray
         return false;
     }
 
-    public bool TryGet(scoped in Key key, ushort hash, out ReadOnlySpan<byte> data)
-    {
-        if (TryGetImpl(key, hash, out var span, out _))
-        {
-            data = span;
-            return true;
-        }
-
-        data = default;
-        return false;
-    }
-
     [OptimizationOpportunity(OptimizationType.CPU, "key encoding is delayed but it might be called twice, here + TrySet")]
     private bool TryGetImpl(scoped in Key key, ushort hash, out Span<byte> data, out int slotIndex)
     {

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -212,14 +212,11 @@ public readonly ref struct SlottedArray
     /// <returns>
     /// The nibble and how much of the page is occupied by storage cells that start their key with the nibble.
     /// </returns>
-    public (byte nibble, double storageCellPercentageInPage) GetBiggestNibbleStats()
+    public byte GetBiggestNibble()
     {
         const int bucketCount = 16;
 
-        Span<byte> storageCellCount = stackalloc byte[bucketCount];
         Span<byte> slotCount = stackalloc byte[bucketCount];
-
-        var totalSlotCount = 0;
 
         var to = _header.Low / Slot.Size;
         for (var i = 0; i < to; i++)
@@ -234,13 +231,7 @@ public readonly ref struct SlottedArray
 
                 var index = firstNibble % bucketCount;
 
-                if (slot.Type == DataType.StorageCell)
-                {
-                    storageCellCount[index]++;
-                }
-
                 slotCount[index]++;
-                totalSlotCount++;
             }
         }
 
@@ -256,9 +247,7 @@ public readonly ref struct SlottedArray
             }
         }
 
-        var storageCellPercentageInPage = (double)storageCellCount[maxNibble] / totalSlotCount;
-
-        return ((byte)maxNibble, storageCellPercentageInPage);
+        return (byte)maxNibble;
     }
 
     private static int GetTotalSpaceRequired(ReadOnlySpan<byte> key, ReadOnlySpan<byte> storageKey,

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -147,6 +147,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             // read the existing account
             var key = Key.Account(accountAddress);
             using var accountOwner = commit.Get(key);
+
+            Debug.Assert(accountOwner.IsEmpty == false, "The account should exist");
+
             Account.ReadFrom(accountOwner.Span, out var account);
 
             // update it

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -43,7 +43,6 @@ public readonly struct AbandonedPage : IPage
         // no more space, needs another next AbandonedPage
         var newPage = batch.GetNewPage(out var nextAddr, true);
 
-        newPage.Header.TreeLevel = 0;
         newPage.Header.PageType = PageType.Abandoned;
         newPage.Header.PaprikaVersion = PageHeader.CurrentVersion;
 

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -113,6 +113,7 @@ public readonly unsafe struct DataPage : IPage
                 return Set(ctx);
             }
 
+            // create child as the same type as the parent
             child = ctx.Batch.GetNewPage(out Data.Buckets[biggestNibble], true);
             child.Header.PageType = Header.PageType;
         }
@@ -127,7 +128,7 @@ public readonly unsafe struct DataPage : IPage
         foreach (var item in map.EnumerateNibble(biggestNibble))
         {
             var key = item.Key.SliceFrom(NibbleCount);
-            var set = new SetContext(key, item.RawData, ctx.Batch);
+            var set = new SetContext(key, item.RawData, ctx.Batch, ctx.IsPrefixed);
 
             dataPage = new DataPage(dataPage.Set(set));
 

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -285,7 +285,7 @@ public readonly unsafe struct DataPage : IPage
     private static bool TryExtractAsPrefixTree(byte nibble, in SetContext ctx, in SlottedArray map, out DbAddress address)
     {
         // required as enumerator destroys paths when enumeration moves to the next value
-        Span<byte> accountPathBytes = stackalloc byte[ctx.Key.Path.MaxByteLength];
+        Span<byte> accountPathBytes = stackalloc byte[NibblePath.FullKeccakByteLength];
         NibblePath accountPath = NibblePath.Empty;
 
         // assert that all StorageCells have the same prefix

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -55,14 +55,9 @@ public struct PageHeader
     [FieldOffset(4)] public byte PaprikaVersion;
 
     /// <summary>
-    /// The level of the tree the page represents.
-    /// </summary>
-    [FieldOffset(5)] public byte TreeLevel;
-
-    /// <summary>
     /// The type of the page.
     /// </summary>
-    [FieldOffset(6)] public PageType PageType;
+    [FieldOffset(5)] public PageType PageType;
 }
 
 public enum PageType : byte

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -74,7 +74,7 @@ public enum PageType : byte
     /// <summary>
     /// The page is a part of the tree use for massive storage accounts.
     /// </summary>
-    MassiveStorageTree = 2,
+    PrefixPage = 2,
 
     Abandoned = 3
 }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -403,7 +403,6 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 p = GetNewPage(out addr, true);
 
                 p.Header.PageType = PageType.Standard;
-                p.Header.TreeLevel = 1; // the root is level 0, start with 1
             }
             else
             {
@@ -522,7 +521,6 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             var newPage = GetNewPage(out var firstAddr, true);
 
             newPage.Header.PageType = PageType.Abandoned;
-            newPage.Header.TreeLevel = 0;
             newPage.Header.PaprikaVersion = 1;
 
             var first = new AbandonedPage(newPage)

--- a/src/Paprika/Store/SetContext.cs
+++ b/src/Paprika/Store/SetContext.cs
@@ -10,12 +10,14 @@ public readonly ref struct SetContext
     public readonly Key Key;
     public readonly IBatchContext Batch;
     public readonly ReadOnlySpan<byte> Data;
+    public readonly bool IsPrefixed;
 
-    public SetContext(Key key, ReadOnlySpan<byte> data, IBatchContext batch)
+    public SetContext(Key key, ReadOnlySpan<byte> data, IBatchContext batch, bool isPrefixed = false)
     {
         Key = key;
         Batch = batch;
         Data = data;
+        IsPrefixed = isPrefixed;
     }
 
     /// <summary>


### PR DESCRIPTION
This PR replaces the massive storage trees with a much faster and simpler construct of a prefix tree. The prefix tree is pointed at using the general parent->child branching. At the same time it uses a prefix that is encoded as prefix, but checked as suffix which allows to push it down with no costs at all. This also, greatly reduced the complexity of the search and insertion as no checks are required whether or not at the given level a massive storage tree is there.