### PR TITLE
Commit optimizations

### DIFF
--- a/src/Paprika.Tests/Merkle/Commit.cs
+++ b/src/Paprika.Tests/Merkle/Commit.cs
@@ -107,6 +107,11 @@ public class Commit : ICommit
         }
     }
 
+    void ICommit.Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
+    {
+        ((ICommit)this).Set(key, Concat(payload0, payload1));
+    }
+
     void ICommit.Visit(CommitAction action, TrieType type)
     {
         foreach (var (k, v) in _before)
@@ -126,6 +131,14 @@ public class Commit : ICommit
     }
 
     public IChildCommit GetChild() => new ChildCommit(this);
+
+    private static byte[] Concat(in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
+    {
+        var bytes = new byte[payload0.Length + payload1.Length];
+        payload0.CopyTo(bytes);
+        payload1.CopyTo(bytes.AsSpan(payload0.Length));
+        return bytes;
+    }
 
     class ChildCommit : IChildCommit
     {
@@ -149,6 +162,11 @@ public class Commit : ICommit
         public void Set(in Key key, in ReadOnlySpan<byte> payload)
         {
             _data[GetKey(key)] = payload.ToArray();
+        }
+
+        public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
+        {
+            _data[GetKey(key)] = Concat(payload0, payload1);
         }
 
         public void Commit()

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -51,17 +51,7 @@ public interface ICommit
     /// <summary>
     /// Sets the value under the given key.
     /// </summary>
-    void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
-    {
-        var total = payload0.Length + payload1.Length;
-        var bytes = ArrayPool<byte>.Shared.Rent(total);
-        payload0.CopyTo(bytes);
-        payload1.CopyTo(bytes.AsSpan(payload0.Length));
-
-        Set(key, bytes.AsSpan(0, total));
-
-        ArrayPool<byte>.Shared.Return(bytes);
-    }
+    void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1);
 
     /// <summary>
     /// Visits the given <paramref name="type"/> of the changes in the given commit.

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -480,14 +480,14 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         public ReadOnlySpanOwner<byte> Get(scoped in Key key) => _commit.Get(Build(key));
 
         public void Set(in Key key, in ReadOnlySpan<byte> payload) => _commit.Set(Build(key), in payload);
-
+        
         public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
             => _commit.Set(Build(key), payload0, payload1);
 
         /// <summary>
         /// Builds the <see cref="_keccak"/> aware key, treating the path as the path for the storage.
         /// </summary>
-        private Key Build(Key key) => Key.Raw(NibblePath.FromKey(_keccak), key.Type, key.Path);
+        private Key Build(scoped in Key key) => Key.Raw(NibblePath.FromKey(_keccak), key.Type, key.Path);
 
         public void Visit(CommitAction action, TrieType type) => throw new Exception("Should not be called");
     }

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -481,6 +481,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
         public void Set(in Key key, in ReadOnlySpan<byte> payload) => _commit.Set(Build(key), in payload);
 
+        public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
+            => _commit.Set(Build(key), payload0, payload1);
+
         /// <summary>
         /// Builds the <see cref="_keccak"/> aware key, treating the path as the path for the storage.
         /// </summary>

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -480,7 +480,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         public ReadOnlySpanOwner<byte> Get(scoped in Key key) => _commit.Get(Build(key));
 
         public void Set(in Key key, in ReadOnlySpan<byte> payload) => _commit.Set(Build(key), in payload);
-        
+
         public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
             => _commit.Set(Build(key), payload0, payload1);
 


### PR DESCRIPTION
This PR makes `PrefixingCommit` delegate the chunked `Set` overload to a proper call of commit. It should remove a lot of allocations for branch + `RLP` case