### PR TITLE
Merkle tests

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -381,7 +381,7 @@ public static class Program
             var obj = worldState.Commit();
             result = $"{obj.ToString()?[..8]}...";
 
-            // finalize
+            //finalize
             if (toFinalize.Count >= FinalizeEvery)
             {
                 // finalize first
@@ -423,8 +423,8 @@ public static class Program
 
     private static Keccak GetBigAccountKey()
     {
-        return NibblePath.Parse("0000000000000000" +
-                                "0123456789ABCDEF").UnsafeAsKeccak;
+        const string half = "0102030405060708090A0B0C0D0E0F";
+        return NibblePath.Parse(half + half).UnsafeAsKeccak;
     }
 
     private static Keccak GetStorageAddress(int counter)

--- a/src/Paprika.Tests/Merkle/Commit.cs
+++ b/src/Paprika.Tests/Merkle/Commit.cs
@@ -254,4 +254,14 @@ public class Commit : ICommit
 
         return commit;
     }
+
+    public void MergeAfterToBefore()
+    {
+        foreach (var kvp in _after)
+        {
+            _before[kvp.Key] = kvp.Value;
+        }
+
+        _after.Clear();
+    }
 }

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -43,6 +43,7 @@ public class RootHashFuzzyTests
     }
 
     [TestCase(nameof(Accounts_100_Storage_1))]
+    [TestCase(nameof(Accounts_1000_Storage_1000))]
     public async Task In_memory_run(string test)
     {
         var generator = Build(test);
@@ -53,9 +54,7 @@ public class RootHashFuzzyTests
 
         using var block = blockchain.StartNew(Keccak.Zero, Keccak.EmptyTreeHash, 1);
 
-        generator.Run(block);
-
-        var rootHash = block.Commit().ToString();
+        var rootHash = generator.Run(block);
         AssertRootHash(rootHash, generator);
     }
 
@@ -138,7 +137,7 @@ public class RootHashFuzzyTests
             }
         }
 
-        public void Run(IWorldState commit)
+        public string Run(IWorldState commit)
         {
             var random = GetRandom();
 
@@ -159,6 +158,8 @@ public class RootHashFuzzyTests
                     commit.SetStorage(keccak, storageKey, storageValue.ToByteArray());
                 }
             }
+
+            return commit.Commit().ToString();
         }
 
         private static Random GetRandom()

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -1,54 +1,111 @@
-﻿using FluentAssertions;
+﻿using System.Reflection;
+using FluentAssertions;
 using NUnit.Framework;
 using Paprika.Chain;
 using Paprika.Crypto;
 using Paprika.Data;
 using Paprika.Merkle;
+using Paprika.Store;
 
 namespace Paprika.Tests.Merkle;
 
 public class RootHashFuzzyTests
 {
-    [TestCase(1000, "b255eb6261dc19f0639d13624e384b265759d2e4171c0eb9487e82d2897729f0")]
-    [TestCase(10_000, "48864c880bd7610f9bad9aff765844db83c17cab764f5444b43c0076f6cf6c03")]
-    public void Big_random(int count, string hexString)
+    [TestCase(nameof(Accounts_1000))]
+    [TestCase(nameof(Accounts_10_000))]
+    public void Compute_Twice(string test)
     {
-        var generator = new CaseGenerator(count, 0);
+        var generator = Build(test);
 
         var commit = new Commit();
 
         generator.Run(commit);
 
         // assert twice to ensure that the root is not changed
-        AssertRoot(hexString, commit);
+        AssertRoot(generator.RootHash, commit);
 
-        AssertRoot(hexString, commit);
+        AssertRoot(generator.RootHash, commit);
     }
 
-    [TestCase(1, 1, "954f21233681f1b941ef67b30c85b64bfb009452b7f01b28de28eb4c1d2ca258")]
-    [TestCase(1, 100, "c8cf5e6b84e39beeac713a42546cc977581d9b31307efa2b1b288ccd828f278e")]
-    [TestCase(100, 1, "68965a86aec45d3863d2c6de07fcdf75ac420dca0c0f45776704bfc9295593ac")]
-    [TestCase(1000, 1, "b8bdf00f1f389a1445867e5c14ccf17fd21d915c01492bed3e70f74de7f42248")]
-    [TestCase(1000, 1000, "4f474648522dc59d4d4a918e301d9d36ac200029027d28605cd2ab32f37321f8")]
-    public void Big_random_storage(int count, int storageCount, string hexString)
+    [TestCase(nameof(Accounts_1_Storage_1))]
+    [TestCase(nameof(Accounts_1_Storage_100))]
+    [TestCase(nameof(Accounts_100_Storage_1))]
+    [TestCase(nameof(Accounts_1000_Storage_1))]
+    [TestCase(nameof(Accounts_1000_Storage_1000))]
+    public void Over_one_mock_commit(string test)
     {
-        var generator = new CaseGenerator(count, storageCount);
+        var generator = Build(test);
 
         var commit = new Commit();
         generator.Run(commit);
 
-        AssertRoot(hexString, commit);
+        AssertRoot(generator.RootHash, commit);
     }
 
-    class CaseGenerator
+    [TestCase(nameof(Accounts_100_Storage_1))]
+    public async Task In_memory_run(string test)
+    {
+        var generator = Build(test);
+
+        using var db = PagedDb.NativeMemoryDb(32 * 1024 * 1024, 2);
+        var merkle = new ComputeMerkleBehavior(true, 2, 2);
+        await using var blockchain = new Blockchain(db, merkle);
+
+        using var block = blockchain.StartNew(Keccak.Zero, Keccak.EmptyTreeHash, 1);
+
+        generator.Run(block);
+
+        var rootHash = block.Commit().ToString();
+        AssertRootHash(rootHash, generator);
+    }
+
+    private static void AssertRootHash(string? rootHash, CaseGenerator generator)
+    {
+        rootHash = rootHash.Replace("0x", "");
+        var actual = NibblePath.Parse(rootHash).UnsafeAsKeccak;
+
+        actual.Should().Be(generator.RootHashAsKeccak, "Root hashes should match");
+    }
+
+    private static CaseGenerator Build(string name) => (CaseGenerator)typeof(RootHashFuzzyTests)
+        .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).First(m => m.Name == name)
+        .Invoke(null, null) ?? throw new NullReferenceException("Cannot find!");
+
+    private static CaseGenerator Accounts_1000() =>
+        new(1000, 0, "b255eb6261dc19f0639d13624e384b265759d2e4171c0eb9487e82d2897729f0");
+
+    private static CaseGenerator Accounts_10_000() =>
+        new(10000, 0, "48864c880bd7610f9bad9aff765844db83c17cab764f5444b43c0076f6cf6c03");
+
+    private static CaseGenerator Accounts_1_Storage_1() =>
+        new(1, 1, "954f21233681f1b941ef67b30c85b64bfb009452b7f01b28de28eb4c1d2ca258");
+
+    private static CaseGenerator Accounts_1_Storage_100() =>
+        new(1, 100, "c8cf5e6b84e39beeac713a42546cc977581d9b31307efa2b1b288ccd828f278e");
+
+    private static CaseGenerator Accounts_100_Storage_1() =>
+        new(100, 1, "68965a86aec45d3863d2c6de07fcdf75ac420dca0c0f45776704bfc9295593ac");
+
+    private static CaseGenerator Accounts_1000_Storage_1() =>
+        new(1000, 1, "b8bdf00f1f389a1445867e5c14ccf17fd21d915c01492bed3e70f74de7f42248");
+
+    private static CaseGenerator Accounts_1000_Storage_1000() => new(1000, 1000,
+        "4f474648522dc59d4d4a918e301d9d36ac200029027d28605cd2ab32f37321f8");
+
+    private class CaseGenerator
     {
         private readonly int _count;
         private readonly int _storageCount;
+        public readonly string RootHash;
+        public readonly Keccak RootHashAsKeccak;
 
-        public CaseGenerator(int count, int storageCount)
+        public CaseGenerator(int count, int storageCount, string rootHash)
         {
             _count = count;
             _storageCount = storageCount;
+            RootHash = rootHash;
+
+            RootHashAsKeccak = new Keccak(Convert.FromHexString(RootHash));
         }
 
         public void Run(Commit commit)
@@ -59,7 +116,7 @@ public class RootHashFuzzyTests
 
         public void Run(ICommit commit)
         {
-            Random random = new(13);
+            var random = GetRandom();
             Span<byte> account = stackalloc byte[Account.MaxByteCount];
 
             for (var i = 0; i < _count; i++)
@@ -80,7 +137,36 @@ public class RootHashFuzzyTests
                 }
             }
         }
+
+        public void Run(IWorldState commit)
+        {
+            var random = GetRandom();
+
+            for (var i = 0; i < _count; i++)
+            {
+                // account data first
+                var keccak = random.NextKeccak();
+                var value = (uint)random.Next();
+
+                var a = new Account(value, value);
+                commit.SetAccount(keccak, a);
+
+                // storage data second
+                for (var j = 0; j < _storageCount; j++)
+                {
+                    var storageKey = random.NextKeccak();
+                    var storageValue = random.Next();
+                    commit.SetStorage(keccak, storageKey, storageValue.ToByteArray());
+                }
+            }
+        }
+
+        private static Random GetRandom()
+        {
+            return new(13);
+        }
     }
+
     private static void AssertRoot(string hex, ICommit commit)
     {
         var merkle = new ComputeMerkleBehavior(true);

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -1,0 +1,94 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Chain;
+using Paprika.Crypto;
+using Paprika.Data;
+using Paprika.Merkle;
+
+namespace Paprika.Tests.Merkle;
+
+public class RootHashFuzzyTests
+{
+    [TestCase(1000, "b255eb6261dc19f0639d13624e384b265759d2e4171c0eb9487e82d2897729f0")]
+    [TestCase(10_000, "48864c880bd7610f9bad9aff765844db83c17cab764f5444b43c0076f6cf6c03")]
+    public void Big_random(int count, string hexString)
+    {
+        var generator = new CaseGenerator(count, 0);
+
+        var commit = new Commit();
+
+        generator.Run(commit);
+
+        // assert twice to ensure that the root is not changed
+        AssertRoot(hexString, commit);
+
+        AssertRoot(hexString, commit);
+    }
+
+    [TestCase(1, 1, "954f21233681f1b941ef67b30c85b64bfb009452b7f01b28de28eb4c1d2ca258")]
+    [TestCase(1, 100, "c8cf5e6b84e39beeac713a42546cc977581d9b31307efa2b1b288ccd828f278e")]
+    [TestCase(100, 1, "68965a86aec45d3863d2c6de07fcdf75ac420dca0c0f45776704bfc9295593ac")]
+    [TestCase(1000, 1, "b8bdf00f1f389a1445867e5c14ccf17fd21d915c01492bed3e70f74de7f42248")]
+    [TestCase(1000, 1000, "4f474648522dc59d4d4a918e301d9d36ac200029027d28605cd2ab32f37321f8")]
+    public void Big_random_storage(int count, int storageCount, string hexString)
+    {
+        var generator = new CaseGenerator(count, storageCount);
+
+        var commit = new Commit();
+        generator.Run(commit);
+
+        AssertRoot(hexString, commit);
+    }
+
+    class CaseGenerator
+    {
+        private readonly int _count;
+        private readonly int _storageCount;
+
+        public CaseGenerator(int count, int storageCount)
+        {
+            _count = count;
+            _storageCount = storageCount;
+        }
+
+        public void Run(Commit commit)
+        {
+            Run((ICommit)commit);
+            commit.MergeAfterToBefore();
+        }
+
+        public void Run(ICommit commit)
+        {
+            Random random = new(13);
+            Span<byte> account = stackalloc byte[Account.MaxByteCount];
+
+            for (var i = 0; i < _count; i++)
+            {
+                // account data first
+                var keccak = random.NextKeccak();
+                var value = (uint)random.Next();
+
+                var a = new Account(value, value);
+                commit.Set(Key.Account(keccak), a.WriteTo(account));
+
+                // storage data second
+                for (var j = 0; j < _storageCount; j++)
+                {
+                    var storageKey = random.NextKeccak();
+                    var storageValue = random.Next();
+                    commit.Set(Key.StorageCell(NibblePath.FromKey(keccak), storageKey), storageValue.ToByteArray());
+                }
+            }
+        }
+    }
+    private static void AssertRoot(string hex, ICommit commit)
+    {
+        var merkle = new ComputeMerkleBehavior(true);
+
+        merkle.BeforeCommit(commit);
+
+        var keccak = new Keccak(Convert.FromHexString(hex));
+
+        merkle.RootHash.Should().Be(keccak);
+    }
+}

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -140,9 +140,9 @@ public class RootHashFuzzyTests
         public string Run(Blockchain blockchain, int newBlockEvery = Int32.MaxValue)
         {
             var counter = 0;
-            
+
             var block = blockchain.StartNew(Keccak.Zero, Keccak.EmptyTreeHash, 1);
-            
+
             var random = GetRandom();
 
             for (var i = 0; i < _count; i++)
@@ -162,14 +162,14 @@ public class RootHashFuzzyTests
                     var storageKey = random.NextKeccak();
                     var storageValue = random.Next();
                     block.SetStorage(keccak, storageKey, storageValue.ToByteArray());
-                    
+
                     Next(ref counter, newBlockEvery, ref block, blockchain);
                 }
             }
 
             var rootHash = block.Commit().ToString();
             block.Dispose();
-            
+
             return rootHash;
 
             static void Next(ref int counter, int newBlockEvery, ref IWorldState block, Blockchain blockchain)

--- a/src/Paprika.Tests/Merkle/RootHashTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashTests.cs
@@ -65,7 +65,7 @@ public class RootHashTests
     [TestCase(10_000, "48864c880bd7610f9bad9aff765844db83c17cab764f5444b43c0076f6cf6c03")]
     public void Big_random(int count, string hexString)
     {
-        var generator = new CaseGenerator(count, 0, hexString);
+        var generator = new CaseGenerator(count, 0);
 
         var commit = new Commit();
 
@@ -84,7 +84,7 @@ public class RootHashTests
     [TestCase(1000, 1000, "4f474648522dc59d4d4a918e301d9d36ac200029027d28605cd2ab32f37321f8")]
     public void Big_random_storage(int count, int storageCount, string hexString)
     {
-        var generator = new CaseGenerator(count, storageCount, hexString);
+        var generator = new CaseGenerator(count, storageCount);
 
         var commit = new Commit();
         generator.Run(commit);
@@ -126,16 +126,20 @@ public class RootHashTests
     {
         private readonly int _count;
         private readonly int _storageCount;
-        private readonly string _rootHash;
 
-        public CaseGenerator(int count, int storageCount, string rootHash)
+        public CaseGenerator(int count, int storageCount)
         {
             _count = count;
             _storageCount = storageCount;
-            _rootHash = rootHash;
         }
 
         public void Run(Commit commit)
+        {
+            Run((ICommit)commit);
+            commit.MergeAfterToBefore();
+        }
+
+        public void Run(ICommit commit)
         {
             Random random = new(13);
             Span<byte> account = stackalloc byte[Account.MaxByteCount];

--- a/src/Paprika.Tests/Merkle/RootHashTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashTests.cs
@@ -61,37 +61,6 @@ public class RootHashTests
         AssertRoot("73130daa1ae507554a72811c06e28d4fee671bfe2e1d0cef828a7fade54384f9", commit);
     }
 
-    [TestCase(1000, "b255eb6261dc19f0639d13624e384b265759d2e4171c0eb9487e82d2897729f0")]
-    [TestCase(10_000, "48864c880bd7610f9bad9aff765844db83c17cab764f5444b43c0076f6cf6c03")]
-    public void Big_random(int count, string hexString)
-    {
-        var generator = new CaseGenerator(count, 0);
-
-        var commit = new Commit();
-
-        generator.Run(commit);
-
-        // assert twice to ensure that the root is not changed
-        AssertRoot(hexString, commit);
-
-        AssertRoot(hexString, commit);
-    }
-
-    [TestCase(1, 1, "954f21233681f1b941ef67b30c85b64bfb009452b7f01b28de28eb4c1d2ca258")]
-    [TestCase(1, 100, "c8cf5e6b84e39beeac713a42546cc977581d9b31307efa2b1b288ccd828f278e")]
-    [TestCase(100, 1, "68965a86aec45d3863d2c6de07fcdf75ac420dca0c0f45776704bfc9295593ac")]
-    [TestCase(1000, 1, "b8bdf00f1f389a1445867e5c14ccf17fd21d915c01492bed3e70f74de7f42248")]
-    [TestCase(1000, 1000, "4f474648522dc59d4d4a918e301d9d36ac200029027d28605cd2ab32f37321f8")]
-    public void Big_random_storage(int count, int storageCount, string hexString)
-    {
-        var generator = new CaseGenerator(count, storageCount);
-
-        var commit = new Commit();
-        generator.Run(commit);
-
-        AssertRoot(hexString, commit);
-    }
-
     [Test]
     public void Extension()
     {
@@ -120,47 +89,5 @@ public class RootHashTests
         var keccak = new Keccak(Convert.FromHexString(hex));
 
         merkle.RootHash.Should().Be(keccak);
-    }
-
-    class CaseGenerator
-    {
-        private readonly int _count;
-        private readonly int _storageCount;
-
-        public CaseGenerator(int count, int storageCount)
-        {
-            _count = count;
-            _storageCount = storageCount;
-        }
-
-        public void Run(Commit commit)
-        {
-            Run((ICommit)commit);
-            commit.MergeAfterToBefore();
-        }
-
-        public void Run(ICommit commit)
-        {
-            Random random = new(13);
-            Span<byte> account = stackalloc byte[Account.MaxByteCount];
-
-            for (var i = 0; i < _count; i++)
-            {
-                // account data first
-                var keccak = random.NextKeccak();
-                var value = (uint)random.Next();
-
-                var a = new Account(value, value);
-                commit.Set(Key.Account(keccak), a.WriteTo(account));
-
-                // storage data second
-                for (var j = 0; j < _storageCount; j++)
-                {
-                    var storageKey = random.NextKeccak();
-                    var storageValue = random.Next();
-                    commit.Set(Key.StorageCell(NibblePath.FromKey(keccak), storageKey), storageValue.ToByteArray());
-                }
-            }
-        }
     }
 }

--- a/src/Paprika.Tests/Merkle/RootHashTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashTests.cs
@@ -65,24 +65,16 @@ public class RootHashTests
     [TestCase(10_000, "48864c880bd7610f9bad9aff765844db83c17cab764f5444b43c0076f6cf6c03")]
     public void Big_random(int count, string hexString)
     {
+        var generator = new CaseGenerator(count, 0, hexString);
+
         var commit = new Commit();
 
-        Random random = new(13);
-        Span<byte> account = stackalloc byte[Account.MaxByteCount];
+        generator.Run(commit);
 
-        for (int i = 0; i < count; i++)
-        {
-            var key = random.NextKeccak();
-            uint value = (uint)random.Next();
-            commit.Set(Key.Account(key), new Account(value, value).WriteTo(account));
-        }
+        // assert twice to ensure that the root is not changed
+        AssertRoot(hexString, commit);
 
-        AssertRootFirst(hexString, commit);
-        AssertRootSecond(hexString, commit);
-
-        // use two separate method
-        static void AssertRootFirst(string hex, Commit commit) => AssertRoot(hex, commit);
-        static void AssertRootSecond(string hex, Commit commit) => AssertRoot(hex, commit);
+        AssertRoot(hexString, commit);
     }
 
     [TestCase(1, 1, "954f21233681f1b941ef67b30c85b64bfb009452b7f01b28de28eb4c1d2ca258")]

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -74,7 +74,14 @@ public readonly ref struct NibblePath
     /// Returns the underlying payload as <see cref="Keccak"/>.
     /// It does it in an unsafe way and requires an external check whether it's possible.
     /// </summary>
-    public ref Keccak UnsafeAsKeccak => ref Unsafe.As<byte, Keccak>(ref _span);
+    public ref Keccak UnsafeAsKeccak
+    {
+        get
+        {
+            Debug.Assert(Length == KeccakNibbleCount);
+            return ref Unsafe.As<byte, Keccak>(ref _span);
+        }
+    }
 
     private NibblePath(ReadOnlySpan<byte> key, int nibbleFrom, int length)
     {


### PR DESCRIPTION
This PR refactors Merkle tests that provide a parity with Nethermind `TrieNode` behavior and ensure that the `RootHash` is right. As the ordering of inserts into Merkle Patricia Trie and intermediate root recalculations should not impact the final value, a new tests are added that use the same data but commit them in some intervals. The assertion of the `RootHash` is preserved.

This PR fixes also a mistake in the Massive Storage Trees that was introduced in `Paprika.Runner` making it fail with proper recalculation of the keccak. This was a result of an unsafe ref taken over a much too short array. This is fixed and guarded with `Debug.Assert` now.