### PR TITLE
SlottedArray fix

### DIFF
--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -74,14 +74,7 @@ public readonly ref struct NibblePath
     /// Returns the underlying payload as <see cref="Keccak"/>.
     /// It does it in an unsafe way and requires an external check whether it's possible.
     /// </summary>
-    public ref Keccak UnsafeAsKeccak
-    {
-        get
-        {
-            Debug.Assert(Length == KeccakNibbleCount);
-            return ref Unsafe.As<byte, Keccak>(ref _span);
-        }
-    }
+    public ref Keccak UnsafeAsKeccak => ref Unsafe.As<byte, Keccak>(ref _span);
 
     private NibblePath(ReadOnlySpan<byte> key, int nibbleFrom, int length)
     {

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -415,9 +415,8 @@ public readonly ref struct SlottedArray
                                 slotIndex = i;
                                 return true;
                             }
-
-                            continue;
                         }
+                        else
 
                         // there's the additional key, assert it
                         // do it by slicing off first the encoded and then check the additional
@@ -457,15 +456,16 @@ public readonly ref struct SlottedArray
     private Span<byte> GetSlotPayload(ref Slot slot)
     {
         // assert whether the slot has a previous, if not use data.length
-        int previousSlotAddress = Unsafe.IsAddressLessThan(ref _slots[0], ref slot)
+        var previousSlotAddress = Unsafe.IsAddressLessThan(ref _slots[0], ref slot)
             ? Unsafe.Add(ref slot, -1).ItemAddress
             : _data.Length;
 
-        return _data.Slice(slot.ItemAddress, previousSlotAddress - slot.ItemAddress);
+        var length = previousSlotAddress - slot.ItemAddress;
+        return _data.Slice(slot.ItemAddress, length);
     }
 
     [StructLayout(LayoutKind.Explicit, Size = Size)]
-    public struct Slot
+    private struct Slot
     {
         public const int Size = 4;
 


### PR DESCRIPTION
This PR fixes one misbehaving of `SlottedArray` while it was jumping to the next loop spin without properly searching of the next item. It' fixed now.