### PR TITLE
MemoryMappedPageManager has now options to only force flush

### DIFF
--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -19,11 +19,18 @@ public unsafe class NativeMemoryPageManager : PointerPageManager
 
     protected override void* Ptr => _ptr;
 
-    public override void Flush() { }
+    public override void Flush()
+    {
+    }
+
+    public override void ForceFlush()
+    {
+    }
 
     public override void Dispose() => NativeMemory.AlignedFree(_ptr);
 
-    public override ValueTask FlushPages(ICollection<DbAddress> addresses, CommitOptions options) => ValueTask.CompletedTask;
+    public override ValueTask FlushPages(ICollection<DbAddress> addresses, CommitOptions options) =>
+        ValueTask.CompletedTask;
 
     public override ValueTask FlushRootPage(DbAddress rootPage, CommitOptions options) => ValueTask.CompletedTask;
 }

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Paprika.Data;
 
 namespace Paprika.Store.PageManagers;
 
@@ -38,6 +37,8 @@ public abstract unsafe class PointerPageManager : IPageManager
     public abstract ValueTask FlushRootPage(DbAddress rootPage, CommitOptions options);
 
     public abstract void Flush();
+
+    public abstract void ForceFlush();
 
     public abstract void Dispose();
 }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -90,7 +90,9 @@ public class PagedDb : IPageResolver, IDb, IDisposable
         new(new NativeMemoryPageManager(size, historyDepth), historyDepth);
 
     public static PagedDb MemoryMappedDb(ulong size, byte historyDepth, string directory, bool flushToDisk = true) =>
-        new(new MemoryMappedPageManager(size, historyDepth, directory, flushToDisk), historyDepth);
+        new(
+            new MemoryMappedPageManager(size, historyDepth, directory,
+                flushToDisk ? PersistenceOptions.FlushFile : PersistenceOptions.MMapOnly), historyDepth);
 
     private void ReportRead(long number = 1) => _reads.Add(number);
     private void ReportWrite() => _writes.Add(1);


### PR DESCRIPTION
This PR allows to use `MemoryMappedPageManager` in an unsafe but fast way, allowing to postpone flushing till the end.