### PR TITLE
Merkle nodes amendments

### DIFF
--- a/src/Paprika.Tests/Merkle/NodeTests.cs
+++ b/src/Paprika.Tests/Merkle/NodeTests.cs
@@ -17,8 +17,8 @@ public class NodeTests
     {
         var header = new Node.Header(nodeType, metadata);
 
-        Assert.That(header.NodeType, Is.EqualTo(nodeType));
-        Assert.That(header.Metadata, Is.EqualTo(metadata));
+        header.NodeType.Should().Be(nodeType);
+        header.Metadata.Should().Be(metadata);
     }
 
     [Test]
@@ -36,8 +36,8 @@ public class NodeTests
         var encoded = header.WriteTo(buffer);
         var leftover = Node.Header.ReadFrom(encoded, out var decoded);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(decoded.Equals(header), $"Expected {header.ToString()}, got {decoded.ToString()}");
+        leftover.Length.Should().Be(0);
+        decoded.Should().Be(header, $"Expected {header.ToString()}, got {decoded.ToString()}");
     }
 
     [Test]
@@ -46,8 +46,8 @@ public class NodeTests
         ushort nibbles = 0b0000_0000_0000_0011;
         var branch = new Node.Branch(new NibbleSet.Readonly(nibbles), Values.Key0);
 
-        Assert.That(branch.Header.NodeType, Is.EqualTo(Node.Type.Branch));
-        Assert.That(branch.Keccak, Is.EqualTo(Values.Key0));
+        branch.Header.NodeType.Should().Be(Node.Type.Branch);
+        branch.Keccak.Should().Be(Values.Key0);
     }
 
     [Test]
@@ -83,7 +83,7 @@ public class NodeTests
 
         foreach (var nibble in expected)
         {
-            Assert.That(branch.Children[nibble], $"Nibble {nibble} was expected to be set, but it's not");
+            branch.Children[nibble].Should().BeTrue($"Nibble {nibble} was expected to be set, but it's not");
         }
     }
 
@@ -93,7 +93,7 @@ public class NodeTests
         ushort nibbles = 0b0110_1001_0101_1010;
         var branch = new Node.Branch(new NibbleSet.Readonly(nibbles));
 
-        Assert.That(branch.Keccak, Is.EqualTo(Keccak.Zero));
+        branch.Keccak.Should().Be(Keccak.Zero);
     }
 
     private static object[] _branchReadWriteCases =
@@ -113,8 +113,8 @@ public class NodeTests
         var encoded = branch.WriteTo(buffer);
         var leftover = Node.Branch.ReadFrom(encoded, out var decoded);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(decoded.Equals(branch), $"Expected {branch.ToString()}, got {decoded.ToString()}");
+        leftover.Length.Should().Be(0);
+        decoded.Equals(branch).Should().BeTrue($"Expected {branch.ToString()}, got {decoded.ToString()}");
     }
 
     [Test]
@@ -129,8 +129,8 @@ public class NodeTests
         var encoded = branch.WriteTo(buffer);
         var leftover = Node.Branch.ReadFrom(encoded, out var decoded);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(decoded.Equals(branch), $"Expected {branch.ToString()}, got {decoded.ToString()}");
+        leftover.Length.Should().Be(0);
+        decoded.Equals(branch).Should().BeTrue($"Expected {branch.ToString()}, got {decoded.ToString()}");
     }
 
     [Test]
@@ -146,8 +146,8 @@ public class NodeTests
         Span<byte> hasKeccakBuffer = stackalloc byte[hasKeccak.MaxByteLength];
         var encodedHasKeccak = hasKeccak.WriteTo(hasKeccakBuffer);
 
-        Assert.That(noKeccak.MaxByteLength, Is.LessThan(hasKeccak.MaxByteLength));
-        Assert.That(encodedNoKeccak.Length, Is.LessThan(encodedHasKeccak.Length));
+        noKeccak.MaxByteLength.Should().BeLessThan(hasKeccak.MaxByteLength);
+        encodedNoKeccak.Length.Should().BeLessThan(encodedHasKeccak.Length);
     }
 
     [Test]
@@ -157,8 +157,8 @@ public class NodeTests
 
         var leaf = new Node.Leaf(path);
 
-        Assert.That(leaf.Header.NodeType, Is.EqualTo(Node.Type.Leaf));
-        Assert.That(leaf.Path.Equals(path), $"Expected {path.ToString()}, got {leaf.Path.ToString()}");
+        leaf.Header.NodeType.Should().Be(Node.Type.Leaf);
+        leaf.Path.Equals(path).Should().BeTrue($"Expected {path.ToString()}, got {leaf.Path.ToString()}");
     }
 
     private static object[] _leafReadWriteCases =
@@ -179,8 +179,8 @@ public class NodeTests
         var encoded = leaf.WriteTo(buffer);
         var leftover = Node.Leaf.ReadFrom(encoded, out var decoded);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(decoded.Equals(leaf), $"Expected {leaf.ToString()}, got {decoded.ToString()}");
+        leftover.Length.Should().Be(0);
+        decoded.Equals(leaf).Should().BeTrue($"Expected {leaf.ToString()}, got {decoded.ToString()}");
     }
 
     [Test]
@@ -190,8 +190,8 @@ public class NodeTests
 
         var extension = new Node.Extension(path);
 
-        Assert.That(extension.Header.NodeType, Is.EqualTo(Node.Type.Extension));
-        Assert.That(extension.Path.Equals(path), $"Expected {path.ToString()}, got {extension.Path.ToString()}");
+        extension.Header.NodeType.Should().Be(Node.Type.Extension);
+        extension.Path.Equals(path).Should().BeTrue($"Expected {path.ToString()}, got {extension.Path.ToString()}");
     }
 
     private static object[] _extensionReadWriteCases =
@@ -212,8 +212,8 @@ public class NodeTests
         var encoded = extension.WriteTo(buffer);
         var leftover = Node.Extension.ReadFrom(encoded, out var decoded);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(decoded.Equals(extension), $"Expected {extension.ToString()}, got {decoded.ToString()}");
+        leftover.Length.Should().Be(0);
+        decoded.Equals(extension).Should().BeTrue($"Expected {extension.ToString()}, got {decoded.ToString()}");
     }
 
     [Test]
@@ -227,9 +227,9 @@ public class NodeTests
         var encoded = leaf.WriteTo(buffer);
         var leftover = Node.ReadFrom(encoded, out var nodeType, out var actual, out _, out _);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(nodeType, Is.EqualTo(Node.Type.Leaf));
-        Assert.That(actual.Equals(leaf));
+        leftover.Length.Should().Be(0);
+        nodeType.Should().Be(Node.Type.Leaf);
+        actual.Equals(leaf).Should().BeTrue();
     }
 
     [Test]
@@ -243,9 +243,9 @@ public class NodeTests
         var encoded = extension.WriteTo(buffer);
         var leftover = Node.ReadFrom(encoded, out var nodeType, out _, out var actual, out _);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(nodeType, Is.EqualTo(Node.Type.Extension));
-        Assert.That(actual.Equals(extension));
+        leftover.Length.Should().Be(0);
+        nodeType.Should().Be(Node.Type.Extension);
+        actual.Equals(extension).Should().BeTrue();
     }
 
     [Test]
@@ -260,9 +260,9 @@ public class NodeTests
         var encoded = branch.WriteTo(buffer);
         var leftover = Node.ReadFrom(encoded, out var nodeType, out _, out _, out var actual);
 
-        Assert.That(leftover.Length, Is.Zero);
-        Assert.That(nodeType, Is.EqualTo(Node.Type.Branch));
-        Assert.That(actual.Equals(branch));
+        leftover.Length.Should().Be(0);
+        nodeType.Should().Be(Node.Type.Branch);
+        actual.Equals(branch).Should().BeTrue();
     }
 
     [Test]
@@ -286,9 +286,9 @@ public class NodeTests
         readLeftover = Node.ReadFrom(readLeftover, out _, out _, out var actualExtension, out _);
         _ = Node.ReadFrom(readLeftover, out _, out _, out _, out var actualBranch);
 
-        Assert.That(actualLeaf.Equals(leaf));
-        Assert.That(actualExtension.Equals(extension));
-        Assert.That(actualBranch.Equals(branch));
+        actualLeaf.Equals(leaf).Should().BeTrue();
+        actualExtension.Equals(extension).Should().BeTrue();
+        actualBranch.Equals(branch).Should().BeTrue();
     }
 
     [Test]

--- a/src/Paprika.Tests/Merkle/NodeTests.cs
+++ b/src/Paprika.Tests/Merkle/NodeTests.cs
@@ -9,31 +9,28 @@ namespace Paprika.Tests.Merkle;
 public class NodeTests
 {
     [Test]
-    [TestCase(Node.Type.Branch, true, 0b0000)]
-    [TestCase(Node.Type.Branch, false, 0b0101)]
-    [TestCase(Node.Type.Leaf, true, 0b0000)]
-    [TestCase(Node.Type.Leaf, false, 0b0000)]
-    [TestCase(Node.Type.Extension, true, 0b0000)]
-    [TestCase(Node.Type.Extension, false, 0b0000)]
-    public void Header_properties(Node.Type nodeType, bool isDirty, byte metadata)
+    [TestCase(Node.Type.Branch, 0b0000)]
+    [TestCase(Node.Type.Branch, 0b0101)]
+    [TestCase(Node.Type.Leaf, 0b0000)]
+    [TestCase(Node.Type.Extension, 0b0000)]
+    public void Header_properties(Node.Type nodeType, byte metadata)
     {
-        var header = new Node.Header(nodeType, isDirty, metadata);
+        var header = new Node.Header(nodeType, metadata);
 
         Assert.That(header.NodeType, Is.EqualTo(nodeType));
-        Assert.That(header.IsDirty, Is.EqualTo(isDirty));
         Assert.That(header.Metadata, Is.EqualTo(metadata));
     }
 
     [Test]
-    [TestCase(Node.Type.Leaf, false, 0b0000)]
-    [TestCase(Node.Type.Extension, false, 0b0000)]
-    [TestCase(Node.Type.Branch, false, 0b0000)]
-    [TestCase(Node.Type.Leaf, true, 0b0000)]
-    [TestCase(Node.Type.Extension, true, 0b0000)]
-    [TestCase(Node.Type.Branch, true, 0b0001)]
-    public void Node_header_read_write(Node.Type nodeType, bool isDirty, byte metadata)
+    [TestCase(Node.Type.Leaf, 0b0000)]
+    [TestCase(Node.Type.Leaf, 0b0001)]
+    [TestCase(Node.Type.Extension, 0b0000)]
+    [TestCase(Node.Type.Extension, 0b0001)]
+    [TestCase(Node.Type.Branch, 0b0000)]
+    [TestCase(Node.Type.Branch, 0b0001)]
+    public void Node_header_read_write(Node.Type nodeType, byte metadata)
     {
-        var header = new Node.Header(nodeType, isDirty, metadata);
+        var header = new Node.Header(nodeType, metadata);
         Span<byte> buffer = stackalloc byte[Node.Header.Size];
 
         var encoded = header.WriteTo(buffer);
@@ -50,7 +47,6 @@ public class NodeTests
         var branch = new Node.Branch(new NibbleSet.Readonly(nibbles), Values.Key0);
 
         Assert.That(branch.Header.NodeType, Is.EqualTo(Node.Type.Branch));
-        Assert.That(branch.Header.IsDirty, Is.True);
         Assert.That(branch.Keccak, Is.EqualTo(Values.Key0));
     }
 
@@ -194,7 +190,6 @@ public class NodeTests
 
         var extension = new Node.Extension(path);
 
-        Assert.That(extension.Header.IsDirty, Is.True);
         Assert.That(extension.Header.NodeType, Is.EqualTo(Node.Type.Extension));
         Assert.That(extension.Path.Equals(path), $"Expected {path.ToString()}, got {extension.Path.ToString()}");
     }
@@ -274,7 +269,7 @@ public class NodeTests
     public void Node_read_sequential()
     {
         var nibblePath = NibblePath.FromKey(new byte[] { 0x1, 0x2, 0x4, 0x5 });
-        const ushort nibbleBitSet = (ushort)0b0000_0011;
+        const ushort nibbleBitSet = 0b0000_0011;
         var keccak = Values.Key0;
 
         var leaf = new Node.Leaf(nibblePath);

--- a/src/Paprika/Merkle/NibbleSet.cs
+++ b/src/Paprika/Merkle/NibbleSet.cs
@@ -83,6 +83,7 @@ public struct NibbleSet
 
     public readonly struct Readonly : IEquatable<Readonly>
     {
+        private const int AllSetValue = 0b1111_1111_1111_1111;
         private readonly ushort _value;
 
         public Readonly(ushort value)
@@ -92,7 +93,7 @@ public struct NibbleSet
 
         public bool this[byte nibble] => new NibbleSet(_value)[nibble];
 
-        public bool AllSet => _value == 0b1111_1111_1111_1111;
+        public bool AllSet => _value == AllSetValue;
 
         public int SetCount => new NibbleSet(_value).SetCount;
         public byte SmallestNibbleSet => new NibbleSet(_value).SmallestNibbleSet;

--- a/src/Paprika/Merkle/Node.cs
+++ b/src/Paprika/Merkle/Node.cs
@@ -96,10 +96,7 @@ public static partial class Node
 
         public static Header Peek(ReadOnlySpan<byte> source) => new(source[0]);
 
-        public bool Equals(in Header other)
-        {
-            return _header.Equals(other._header);
-        }
+        public bool Equals(in Header other) => _header.Equals(other._header);
 
         public override string ToString() =>
             $"{nameof(Header)} {{ " +

--- a/src/Paprika/Merkle/Node.cs
+++ b/src/Paprika/Merkle/Node.cs
@@ -53,29 +53,22 @@ public static partial class Node
     {
         public const int Size = sizeof(byte);
 
-        private const byte IsDirtyMask = 0b0001;
-        private const int DirtyMaskShift = 0;
-        private const byte Dirty = 0b0001;
-        private const byte NotDirty = 0b0000;
+        private const byte NodeTypeMask = 0b0000_0011;
+        private const int NodeTypeMaskShift = 0;
 
-        private const byte NodeTypeMask = 0b0110;
-        private const int NodeTypeMaskShift = 1;
-
-        private const byte MetadataMask = 0b1111_0000;
-        private const int MetadataMaskShift = 4;
+        private const byte MetadataMask = 0b1111_1100;
+        private const int MetadataMaskShift = 2;
 
         [FieldOffset(0)]
         private readonly byte _header;
 
-        public bool IsDirty => (_header & IsDirtyMask) >> DirtyMaskShift == Dirty;
         public Type NodeType => (Type)((_header & NodeTypeMask) >> NodeTypeMaskShift);
         public byte Metadata => (byte)((_header & MetadataMask) >> MetadataMaskShift);
 
-        public Header(Type nodeType, bool isDirty = true, byte metadata = 0b0000)
+        public Header(Type nodeType, byte metadata = 0b0000)
         {
             _header = (byte)(metadata << MetadataMaskShift);
             _header |= (byte)((byte)nodeType << NodeTypeMaskShift);
-            _header |= isDirty ? Dirty : NotDirty;
         }
 
         private Header(byte header)
@@ -110,7 +103,6 @@ public static partial class Node
 
         public override string ToString() =>
             $"{nameof(Header)} {{ " +
-            $"{nameof(IsDirty)}: {IsDirty}, " +
             $"{nameof(Type)}: {NodeType}, " +
             $"{nameof(Metadata)}: 0b{Convert.ToString(Metadata, 2).PadLeft(4, '0')}" +
             $" }}";
@@ -133,7 +125,7 @@ public static partial class Node
         public Leaf(NibblePath path)
         {
             // leaves shall never be marked as dirty or not. This information will be held by branch
-            Header = new Header(Type.Leaf, false);
+            Header = new Header(Type.Leaf);
             Path = path;
         }
 


### PR DESCRIPTION
A few amendments in `Merkle` nodes:

1. `IsDirty` removed as no longer needed
2. fluent assertions used for tests
3. minors