### PR TITLE
Importer

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -34,4 +34,4 @@ jobs:
         submodules: true
     - name: Format
       run: |
-        dotnet format whitespace src/ --folder --verify-no-changes
+        dotnet format whitespace src/Paprika.sln --verify-no-changes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src/Nethermind"]
+	path = src/Nethermind
+	url = https://github.com/NethermindEth/nethermind.git
+	branch = new-visitor

--- a/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
@@ -21,8 +21,7 @@ public class SlottedArrayBenchmarks
         while (true)
         {
             BinaryPrimitives.WriteInt32LittleEndian(key, _to);
-            var path = NibblePath.FromKey(key);
-            if (map.TrySet(Key.Account(path), key) == false)
+            if (map.TrySet(key, key) == false)
             {
                 // filled
                 break;
@@ -46,8 +45,7 @@ public class SlottedArrayBenchmarks
         for (int i = 0; i < _to; i++)
         {
             BinaryPrimitives.WriteInt32LittleEndian(key, i);
-            var path = NibblePath.FromKey(key);
-            if (map.TrySet(Key.Account(path), key))
+            if (map.TrySet(key, key))
             {
                 count++;
             }
@@ -68,8 +66,7 @@ public class SlottedArrayBenchmarks
         for (var i = 0; i < _to; i++)
         {
             BinaryPrimitives.WriteInt32LittleEndian(key, i);
-            var path = NibblePath.FromKey(key);
-            if (map.TryGet(Key.Account(path), out var data))
+            if (map.TryGet(key, out var data))
             {
                 result += data.Length;
             }
@@ -90,8 +87,7 @@ public class SlottedArrayBenchmarks
         for (int i = _to; i < _to * 2; i++)
         {
             BinaryPrimitives.WriteInt32LittleEndian(key, i);
-            var path = NibblePath.FromKey(key);
-            if (map.TryGet(Key.Account(path), out _) == false)
+            if (map.TryGet(key, out _) == false)
             {
                 result += 1;
             }

--- a/src/Paprika.Importer/Paprika.Importer.csproj
+++ b/src/Paprika.Importer/Paprika.Importer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
+      <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Paprika.Importer/Paprika.Importer.csproj
+++ b/src/Paprika.Importer/Paprika.Importer.csproj
@@ -10,7 +10,12 @@
     <ItemGroup>
       <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
       <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj" />
+      <ProjectReference Include="..\Paprika.Runner\Paprika.Runner.csproj" />
       <ProjectReference Include="..\Paprika\Paprika.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Spectre.Console" Version="0.47.1-preview.0.23" />
     </ItemGroup>
 
 </Project>

--- a/src/Paprika.Importer/Paprika.Importer.csproj
+++ b/src/Paprika.Importer/Paprika.Importer.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
-      <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj" />
+      <ProjectReference Include="..\Nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
+      <ProjectReference Include="..\Nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj" />
       <ProjectReference Include="..\Paprika.Runner\Paprika.Runner.csproj" />
       <ProjectReference Include="..\Paprika\Paprika.csproj" />
     </ItemGroup>

--- a/src/Paprika.Importer/Paprika.Importer.csproj
+++ b/src/Paprika.Importer/Paprika.Importer.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
       <ProjectReference Include="..\..\..\nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj" />
+      <ProjectReference Include="..\Paprika\Paprika.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Paprika.Importer/PaprikaCopyingVisitor.cs
+++ b/src/Paprika.Importer/PaprikaCopyingVisitor.cs
@@ -1,4 +1,5 @@
-﻿using Nethermind.Core.Crypto;
+﻿using System.IO.Pipelines;
+using Nethermind.Core.Crypto;
 using Nethermind.Trie;
 
 namespace Paprika.Importer;
@@ -6,6 +7,10 @@ namespace Paprika.Importer;
 public class PaprikaCopyingVisitor : ITreeLeafVisitor
 {
     private long accounts;
+
+    public PaprikaCopyingVisitor()
+    {
+    }
 
     public void VisitLeafAccount(in ValueKeccak account, Nethermind.Core.Account value)
     {

--- a/src/Paprika.Importer/PaprikaCopyingVisitor.cs
+++ b/src/Paprika.Importer/PaprikaCopyingVisitor.cs
@@ -1,0 +1,21 @@
+﻿using Nethermind.Core.Crypto;
+using Nethermind.Trie;
+
+namespace Paprika.Importer;
+
+public class PaprikaCopyingVisitor : ITreeLeafVisitor
+{
+    private long accounts;
+
+    public void VisitLeafAccount(in ValueKeccak account, Nethermind.Core.Account value)
+    {
+        Interlocked.Increment(ref accounts);
+    }
+
+    public void VisitLeafStorage(in ValueKeccak account, in ValueKeccak storage, ReadOnlySpan<byte> value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public long Accounts => Volatile.Read(ref accounts);
+}

--- a/src/Paprika.Importer/PaprikaCopyingVisitor.cs
+++ b/src/Paprika.Importer/PaprikaCopyingVisitor.cs
@@ -1,22 +1,33 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie;
 using Paprika.Chain;
+using Paprika.Utils;
 using Keccak = Paprika.Crypto.Keccak;
 
 namespace Paprika.Importer;
 
-public class PaprikaCopyingVisitor : ITreeLeafVisitor
+public class PaprikaCopyingVisitor : ITreeLeafVisitor, IDisposable
 {
     private readonly Blockchain _blockchain;
     private readonly int _batchSize;
+    private readonly int _expectedAccountCount;
     private readonly Channel<(ValueKeccak, Nethermind.Core.Account)> _channel;
-    private long accounts;
 
-    public PaprikaCopyingVisitor(Blockchain blockchain, int batchSize)
+    private readonly Meter _meter;
+    private readonly MetricsExtensions.IAtomicIntGauge _accountsGauge;
+
+    private int _accounts;
+
+    public PaprikaCopyingVisitor(Blockchain blockchain, int batchSize, int expectedAccountCount)
     {
+        _meter = new Meter("Paprika.Importer");
+
+        _accountsGauge = _meter.CreateAtomicObservableGauge("Accounts imported", "%");
+
         _blockchain = blockchain;
 
         var options = new UnboundedChannelOptions
@@ -24,11 +35,19 @@ public class PaprikaCopyingVisitor : ITreeLeafVisitor
         _channel = Channel.CreateUnbounded<(ValueKeccak, Nethermind.Core.Account)>(options);
 
         _batchSize = batchSize;
+        _expectedAccountCount = expectedAccountCount;
     }
 
     public void VisitLeafAccount(in ValueKeccak account, Nethermind.Core.Account value)
     {
-        Interlocked.Increment(ref accounts);
+        var incremented = Interlocked.Increment(ref _accounts);
+
+        // update occasionally
+        if (incremented % 100 == 0)
+        {
+            _accountsGauge.Set(incremented / (_expectedAccountCount / 100));
+        }
+
         Debug.Assert(_channel.Writer.TryWrite((account, value)));
     }
 
@@ -52,16 +71,11 @@ public class PaprikaCopyingVisitor : ITreeLeafVisitor
             {
                 i++;
 
-                Keccak addr = default;
-                item.Item1.BytesAsSpan.CopyTo(addr.BytesAsSpan);
+                var addr = AsPaprika(item.Item1);
                 var v = item.Item2;
 
-                Keccak codeHash = default;
-                v.CodeHash.Bytes.CopyTo(codeHash.BytesAsSpan);
-
-                Keccak storageRoot = default;
-                v.StorageRoot.Bytes.CopyTo(storageRoot.BytesAsSpan);
-
+                var codeHash = AsPaprika(v.CodeHash);
+                var storageRoot = AsPaprika(v.StorageRoot);
                 block.SetAccount(addr, new Account(v.Balance, v.Nonce, codeHash, storageRoot));
             }
 
@@ -75,10 +89,24 @@ public class PaprikaCopyingVisitor : ITreeLeafVisitor
         }
     }
 
+    private static Keccak AsPaprika(Nethermind.Core.Crypto.Keccak keccak)
+    {
+        Unsafe.SkipInit(out Keccak k);
+        keccak.Bytes.CopyTo(k.BytesAsSpan);
+        return k;
+    }
+
+    private static Keccak AsPaprika(Nethermind.Core.Crypto.ValueKeccak keccak)
+    {
+        Unsafe.SkipInit(out Keccak k);
+        keccak.Bytes.CopyTo(k.BytesAsSpan);
+        return k;
+    }
+
     public void VisitLeafStorage(in ValueKeccak account, in ValueKeccak storage, ReadOnlySpan<byte> value)
     {
         throw new NotImplementedException();
     }
 
-    public long Accounts => Volatile.Read(ref accounts);
+    public void Dispose() => _meter.Dispose();
 }

--- a/src/Paprika.Importer/PaprikaCopyingVisitor.cs
+++ b/src/Paprika.Importer/PaprikaCopyingVisitor.cs
@@ -1,20 +1,78 @@
-﻿using System.IO.Pipelines;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Channels;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie;
+using Paprika.Chain;
+using Keccak = Paprika.Crypto.Keccak;
 
 namespace Paprika.Importer;
 
 public class PaprikaCopyingVisitor : ITreeLeafVisitor
 {
+    private readonly Blockchain _blockchain;
+    private readonly int _batchSize;
+    private readonly Channel<(ValueKeccak, Nethermind.Core.Account)> _channel;
     private long accounts;
 
-    public PaprikaCopyingVisitor()
+    public PaprikaCopyingVisitor(Blockchain blockchain, int batchSize)
     {
+        _blockchain = blockchain;
+
+        var options = new UnboundedChannelOptions
+        { SingleReader = true, SingleWriter = true, AllowSynchronousContinuations = false };
+        _channel = Channel.CreateUnbounded<(ValueKeccak, Nethermind.Core.Account)>(options);
+
+        _batchSize = batchSize;
     }
 
     public void VisitLeafAccount(in ValueKeccak account, Nethermind.Core.Account value)
     {
         Interlocked.Increment(ref accounts);
+        Debug.Assert(_channel.Writer.TryWrite((account, value)));
+    }
+
+    public void Finish() => _channel.Writer.Complete();
+
+    public async Task Copy()
+    {
+        var parent = Keccak.Zero;
+        uint number = 1;
+
+        var reader = _channel.Reader;
+
+        while (await reader.WaitToReadAsync())
+        {
+            var i = 0;
+            // dummy, for import only
+            var child = Keccak.Compute(parent.BytesAsSpan);
+            using var block = _blockchain.StartNew(parent, child, number);
+
+            while (i < _batchSize && reader.TryRead(out var item))
+            {
+                i++;
+
+                Keccak addr = default;
+                item.Item1.BytesAsSpan.CopyTo(addr.BytesAsSpan);
+                var v = item.Item2;
+
+                Keccak codeHash = default;
+                v.CodeHash.Bytes.CopyTo(codeHash.BytesAsSpan);
+
+                Keccak storageRoot = default;
+                v.StorageRoot.Bytes.CopyTo(storageRoot.BytesAsSpan);
+
+                block.SetAccount(addr, new Account(v.Balance, v.Nonce, codeHash, storageRoot));
+            }
+
+            // commit & finalize
+            block.Commit();
+            _blockchain.Finalize(child);
+
+            // update
+            number++;
+            parent = child;
+        }
     }
 
     public void VisitLeafStorage(in ValueKeccak account, in ValueKeccak storage, ReadOnlySpan<byte> value)

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -57,7 +57,7 @@ if (Directory.Exists(dataPath))
 }
 
 const long GB = 1024 * 1024 * 1024;
-const long size = 24 * GB;
+const long size = 32 * GB;
 
 Directory.CreateDirectory(dataPath);
 Console.WriteLine($"Using persistent DB on disk, located: {dataPath}");
@@ -69,10 +69,10 @@ var spectre = new CancellationTokenSource();
 
 var sw = Stopwatch.StartNew();
 
-// using var db = PagedDb.MemoryMappedDb(size, 2, dataPath, false);
+//using var db = PagedDb.MemoryMappedDb(size, 2, dataPath, false);
 using var db = PagedDb.NativeMemoryDb(size, 2);
 
-using var preCommit = new ComputeMerkleBehavior(true, 2, 1);
+using var preCommit = new ComputeMerkleBehavior(true, 2, 2);
 await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(10), 100, () => reporter.Observe()))
 {
     const int sepoliaAccountCount = 16146399;

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -78,8 +78,7 @@ await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds
     var visitor = new PaprikaCopyingVisitor(blockchain, 2_000, sepoliaAccountCount);
     Console.WriteLine("Starting...");
 
-    var copyingTask = Task.Run(() => visitor.Copy());
-    var visitorTask = Task.Run(() => trie.Accept(visitor, rootHash, true));
+    var copyingTask = visitor.Copy();
     reportingTask = Task.Run(() => AnsiConsole.Live(reporter.Renderer)
         .StartAsync(async ctx =>
         {
@@ -95,14 +94,7 @@ await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds
             ctx.Refresh();
         }));
 
-    // expected count
-    while (true)
-    {
-        var completed = await Task.WhenAny(Task.Delay(1_000), visitorTask);
-        if (completed == visitorTask)
-            break;
-    }
-
+    trie.Accept(visitor, rootHash, true);
     visitor.Finish();
 
     Console.WriteLine("Awaiting writes to finish...");

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -57,7 +57,7 @@ if (Directory.Exists(dataPath))
 }
 
 const long GB = 1024 * 1024 * 1024;
-const long size = 16 * GB;
+const long size = 24 * GB;
 
 Directory.CreateDirectory(dataPath);
 Console.WriteLine($"Using persistent DB on disk, located: {dataPath}");
@@ -73,11 +73,11 @@ var sw = Stopwatch.StartNew();
 using var db = PagedDb.NativeMemoryDb(size, 2);
 
 using var preCommit = new ComputeMerkleBehavior(true, 2, 1);
-await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(10), 1000, () => reporter.Observe()))
+await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(10), 100, () => reporter.Observe()))
 {
     const int sepoliaAccountCount = 16146399;
 
-    var visitor = new PaprikaCopyingVisitor(blockchain, 10_000, sepoliaAccountCount);
+    var visitor = new PaprikaCopyingVisitor(blockchain, 2_000, sepoliaAccountCount);
     Console.WriteLine("Starting...");
 
     var copyingTask = visitor.Copy();

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -123,7 +123,7 @@ if (dbExists == false)
 }
 
 using var read = db.BeginReadOnlyBatch("Statistics");
-StatisticsForPagedDb.Report(layout[stats], read);
+StatisticsForPagedDb.Report(layout[stats], read, true);
 
 spectre.Cancel();
 await reportingTask;

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -69,13 +69,15 @@ var spectre = new CancellationTokenSource();
 
 var sw = Stopwatch.StartNew();
 
-using var db = PagedDb.MemoryMappedDb(size, 2, dataPath, false);
+// using var db = PagedDb.MemoryMappedDb(size, 2, dataPath, false);
+using var db = PagedDb.NativeMemoryDb(size, 2);
+
 using var preCommit = new ComputeMerkleBehavior(true, 2, 1);
 await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(10), 1000, () => reporter.Observe()))
 {
     const int sepoliaAccountCount = 16146399;
 
-    var visitor = new PaprikaCopyingVisitor(blockchain, 2_000, sepoliaAccountCount);
+    var visitor = new PaprikaCopyingVisitor(blockchain, 10_000, sepoliaAccountCount);
     Console.WriteLine("Starting...");
 
     var copyingTask = visitor.Copy();

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -1,0 +1,24 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using Nethermind.Core.Crypto;
+using Nethermind.Db;
+using Nethermind.Db.Rocks;
+using Nethermind.Db.Rocks.Config;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.Trie.Pruning;
+
+Console.WriteLine("Hello, World!");
+
+var settings = new RocksDbSettings(DbNames.State, DbNames.State);
+
+using var state = new DbOnTheRocks(@"C:\Users\Szymon\ethereum\execution\nethermind_db\sepolia", settings, DbConfig.Default, LimboLogs.Instance);
+using var store = new TrieStore(state, LimboLogs.Instance);
+var trie = new StateTree(store, LimboLogs.Instance);
+
+// https://sepolia.etherscan.io/block/0x77f53fbcafe5d70031154923852b234daa9acddcb7b3212b936b19116d93c15b
+var rootHash = new Keccak("0x4f32764e59eccac237bc6fc78b24f97ad17336906209ab537eedea3240567e7d");
+
+trie.RootHash = rootHash;
+
+Console.WriteLine($"Root: {trie.RootHash}" );

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -123,7 +123,7 @@ if (dbExists == false)
 }
 
 using var read = db.BeginReadOnlyBatch("Statistics");
-StatisticsForPagedDb.Report(layout[stats], read, true);
+StatisticsForPagedDb.Report(layout[stats], read);
 
 spectre.Cancel();
 await reportingTask;

--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -1,5 +1,7 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
+using System.Diagnostics;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Db.Rocks;
@@ -8,8 +10,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.Trie.Pruning;
-
-Console.WriteLine("Hello, World!");
+using Paprika.Importer;
 
 // StandardDbInitializer
 // MemoryHintMan
@@ -19,29 +20,63 @@ const string path = @"C:\Users\Szymon\ethereum\execution\nethermind_db\sepolia";
 var logs = LimboLogs.Instance;
 var cfg = DbConfig.Default;
 
-using var state = new DbOnTheRocks(path, new RocksDbSettings(DbNames.State, DbNames.State), cfg, logs);
-using var blockInfos = new DbOnTheRocks(path, new RocksDbSettings(DbNames.BlockInfos, DbNames.BlockInfos), cfg, logs);
-using var headers = new DbOnTheRocks(path, new RocksDbSettings(DbNames.Headers, DbNames.Headers), cfg, logs);
+using var state = new DbOnTheRocks(path, GetSettings(DbNames.State), cfg, logs).WithEOACompressed();
+using var blockInfos = new DbOnTheRocks(path, GetSettings(DbNames.BlockInfos), cfg, logs);
+using var headers = new DbOnTheRocks(path, GetSettings(DbNames.Headers), cfg, logs);
 using var store = new TrieStore(state, logs);
 
-var headAddressInDb = Keccak.Zero;
-var headData = blockInfos.Get(headAddressInDb);
-ArgumentNullException.ThrowIfNull(headData, "Block info head not found");
+// from BlockTree.cs
+byte[] stateHeadHashDbEntryAddress = new byte[16];
+var persistedNumberData = blockInfos.Get(stateHeadHashDbEntryAddress);
+long? bestPersistedState = persistedNumberData is null ? null : new RlpStream(persistedNumberData).DecodeLong();
 
-var head = new Keccak(headData);
-var headerData = headers.Get(head);
-ArgumentNullException.ThrowIfNull(headerData, "Header of the head");
+ArgumentNullException.ThrowIfNull(bestPersistedState, "Best persisted state not found");
 
-var decoder = new HeaderDecoder();
-var headHeader = decoder.Decode(new RlpStream(headerData));
-ArgumentNullException.ThrowIfNull(headHeader, "Head has no header!");
-ArgumentNullException.ThrowIfNull(headHeader.StateRoot, "Head header! has no StateRoot!");
+var chaininfo = blockInfos.Get(bestPersistedState.Value);
+var chainLevel = Rlp.GetStreamDecoder<ChainLevelInfo>()!.Decode(new RlpStream(chaininfo!));
+
+var main = chainLevel.BlockInfos[0];
+var header = headers.Get(main.BlockHash);
+
+var headerDecoded = Rlp.GetStreamDecoder<BlockHeader>()!.Decode(new RlpStream(header!));
+
+var rootHash = headerDecoded.StateRoot!;
 
 var trie = new StateTree(store, logs)
 {
-    RootHash = headHeader.StateRoot
+    RootHash = rootHash
 };
 
-trie.RootRef!.ResolveNode(store);
+var visitor = new PaprikaCopyingVisitor();
 
-Console.WriteLine($"Root: {trie.RootHash}" );
+Console.WriteLine("Starting visitor...");
+
+var sw = Stopwatch.StartNew();
+
+var run = Task.Run(() => trie.Accept(visitor, rootHash, true));
+
+while (true)
+{
+    var completed = await Task.WhenAny(Task.Delay(1_000), run);
+    if (completed == run)
+        break;
+    Console.WriteLine($"Read accounts: {visitor.Accounts}");
+}
+
+Console.WriteLine($"Root: {rootHash} had {visitor.Accounts} accounts in {sw.Elapsed:g}");
+
+return;
+
+RocksDbSettings GetSettings(string dbName)
+{
+    var dbPath = dbName;
+
+    if (dbName == DbNames.State)
+    {
+        // pruned database, append version 
+        dbPath = Path.Combine(dbName, "0");
+        dbName += "0";
+    }
+
+    return new RocksDbSettings(dbName, dbPath);
+}

--- a/src/Paprika.Runner/StatisticsForPagedDb.cs
+++ b/src/Paprika.Runner/StatisticsForPagedDb.cs
@@ -53,7 +53,6 @@ public static class StatisticsForPagedDb
                     new Layout(
                             new Rows(
                                 new Markup(sb.ToString()),
-                                new Text(""),
                                 new Text("General stats:"),
                                 new Text($"1. Size of this Paprika tree: {mb}MB"),
                                 new Text($"2. Types of pages: {types}"),
@@ -61,7 +60,7 @@ public static class StatisticsForPagedDb
                                 WriteSizePerType(stats.Sizes, "4. Size per entry type:"),
                                 WriteHistogramSizePerType(stats.SizeHistograms, "5. Median of size per entry type:")
                                 ))
-                        .Size(8),
+                        .Size(10),
                     new Layout(levelStats.Expand()));
 
             reportTo.Update(new Panel(report).Header("Paprika tree statistics").Expand());
@@ -92,7 +91,7 @@ public static class StatisticsForPagedDb
 
         return new Markup(sb.ToString());
     }
-    
+
     private static IRenderable WriteHistogramSizePerType(Dictionary<int, IntHistogram> sizes, string prefix)
     {
         var sb = new StringBuilder();
@@ -102,7 +101,7 @@ public static class StatisticsForPagedDb
         {
             var name = StatisticsReporter.GetNameForSize(index);
             var median = histogram.GetValueAtPercentile(50);
-            sb.Append($" {name}: {median:F1} bytes");
+            sb.Append($" {name}: {median} bytes");
         }
 
         return new Markup(sb.ToString());

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -5,6 +5,7 @@ using Nethermind.Int256;
 using NUnit.Framework;
 using Paprika.Chain;
 using Paprika.Crypto;
+using Paprika.Merkle;
 using Paprika.Store;
 using static Paprika.Tests.Values;
 
@@ -110,12 +111,14 @@ public class BlockchainTests
     public async Task BiggerTest()
     {
         const int blockCount = 10;
-        const int perBlock = 1000;
+        const int perBlock = 1_000;
 
-        using var db = PagedDb.NativeMemoryDb(128 * Mb, 2);
+        using var db = PagedDb.NativeMemoryDb(256 * Mb, 2);
         var counter = 0;
 
-        await using (var blockchain = new Blockchain(db))
+        var behavior = new ComputeMerkleBehavior(true, 2, 2);
+
+        await using (var blockchain = new Blockchain(db, behavior))
         {
             var previousBlock = Keccak.Zero;
 
@@ -165,7 +168,7 @@ public class BlockchainTests
             {
                 var key = BuildKey(counter);
 
-                read.ShouldHaveAccount(key, GetAccount(counter));
+                read.ShouldHaveAccount(key, GetAccount(counter), true);
                 read.ShouldHaveStorage(key, key, ((UInt256)counter).ToBigEndian());
 
                 counter++;

--- a/src/Paprika.Tests/Data/SlottedArrayTests.cs
+++ b/src/Paprika.Tests/Data/SlottedArrayTests.cs
@@ -26,7 +26,7 @@ public class SlottedArrayTests
     [Test]
     public void Set_Get_Delete_Get_AnotherSet()
     {
-        Span<byte> span = stackalloc byte[SlottedArray.MinSize];
+        Span<byte> span = stackalloc byte[48];
         var map = new SlottedArray(span);
 
         map.SetAssert(Key.Account(Key0), Data0);
@@ -78,7 +78,7 @@ public class SlottedArrayTests
     public void Defragment_when_no_more_space()
     {
         // by trial and error, found the smallest value that will allow to put these two
-        Span<byte> span = stackalloc byte[40];
+        Span<byte> span = stackalloc byte[88];
         var map = new SlottedArray(span);
 
         map.SetAssert(Key.Account(Key0), Data0);
@@ -99,7 +99,7 @@ public class SlottedArrayTests
     public void Update_in_situ()
     {
         // by trial and error, found the smallest value that will allow to put these two
-        Span<byte> span = stackalloc byte[24];
+        Span<byte> span = stackalloc byte[48];
         var map = new SlottedArray(span);
 
         map.SetAssert(Key.Account(Key1), Data1);
@@ -112,7 +112,7 @@ public class SlottedArrayTests
     public void Update_in_resize()
     {
         // by trial and error, found the smallest value that will allow to put these two
-        Span<byte> span = stackalloc byte[24];
+        Span<byte> span = stackalloc byte[56];
         var map = new SlottedArray(span);
 
         map.SetAssert(Key.Account(Key0), Data0);

--- a/src/Paprika.Tests/Merkle/NodeTests.cs
+++ b/src/Paprika.Tests/Merkle/NodeTests.cs
@@ -150,6 +150,24 @@ public class NodeTests
         encodedNoKeccak.Length.Should().BeLessThan(encodedHasKeccak.Length);
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Branch_all_set(bool keccak)
+    {
+        var branch = new Node.Branch(NibbleSet.Readonly.All, keccak ? Values.Key0 : default);
+
+        Span<byte> buffer = stackalloc byte[branch.MaxByteLength];
+        var encoded = branch.WriteTo(buffer);
+
+        encoded.Length.Should().Be(1 + (keccak ? Keccak.Size : 0), "Full branch should encode to one byte");
+
+        var leftover = Node.Branch.ReadFrom(encoded, out var decoded);
+
+        leftover.Length.Should().Be(0);
+
+        decoded.Equals(branch).Should().BeTrue($"Expected {branch.ToString()}, got {decoded.ToString()}");
+    }
+
     [Test]
     public void Leaf_properties()
     {

--- a/src/Paprika.Tests/Store/BasePageTests.cs
+++ b/src/Paprika.Tests/Store/BasePageTests.cs
@@ -47,7 +47,7 @@ public abstract class BasePageTests
         // for now
         public override bool WasWritten(DbAddress addr) => true;
 
-        protected override void RegisterForFutureReuse(Page page)
+        public override void RegisterForFutureReuse(Page page)
         {
             // NOOP
         }

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -299,6 +299,7 @@ public class DataPageTests : BasePageTests
     }
 
     [Test]
+    [Ignore("This test should be removed or rewritten")]
     public void Small_prefix_tree_with_regular()
     {
         var page = AllocPage();

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -424,7 +424,7 @@ public class DataPageTests : BasePageTests
                 var accountKey = Key.Raw(path, compressedAccount, NibblePath.Empty);
                 var accountStoreKey = StoreKey.Encode(accountKey, store);
 
-                dataPage = new DataPage(dataPage.Set(accountStoreKey, accountValue, batch));
+                dataPage = new DataPage(dataPage.Set(NibblePath.FromKey(accountStoreKey.Payload), accountValue, batch));
             }
 
             // merkle
@@ -432,7 +432,7 @@ public class DataPageTests : BasePageTests
                 var merkleKey = Key.Raw(path, compressedMerkle, NibblePath.Empty);
                 var merkleStoreKey = StoreKey.Encode(merkleKey, store);
 
-                dataPage = new DataPage(dataPage.Set(merkleStoreKey, merkleValue, batch));
+                dataPage = new DataPage(dataPage.Set(NibblePath.FromKey(merkleStoreKey.Payload), merkleValue, batch));
             }
         }
 
@@ -446,7 +446,7 @@ public class DataPageTests : BasePageTests
                 var accountKey = Key.Raw(path, compressedAccount, NibblePath.Empty);
                 var accountStoreKey = StoreKey.Encode(accountKey, store);
 
-                dataPage.TryGet(accountStoreKey, batch, out var value).Should().BeTrue();
+                dataPage.TryGet(NibblePath.FromKey(accountStoreKey.Payload), batch, out var value).Should().BeTrue();
                 value.SequenceEqual(accountValue).Should().BeTrue();
             }
 
@@ -455,7 +455,7 @@ public class DataPageTests : BasePageTests
                 var merkleKey = Key.Raw(path, compressedMerkle, NibblePath.Empty);
                 var merkleStoreKey = StoreKey.Encode(merkleKey, store);
 
-                dataPage.TryGet(merkleStoreKey, batch, out var value).Should().BeTrue();
+                dataPage.TryGet(NibblePath.FromKey(merkleStoreKey.Payload), batch, out var value).Should().BeTrue();
                 value.SequenceEqual(merkleValue).Should().BeTrue();
             }
         }

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -191,7 +191,7 @@ public class DbTests
             var header = page.Header;
 
             header.BatchId.Should().BeGreaterThan(0);
-            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard);
+            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard, PageType.Identity);
             header.PaprikaVersion.Should().Be(1);
         }
     }

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -191,7 +191,7 @@ public class DbTests
             var header = page.Header;
 
             header.BatchId.Should().BeGreaterThan(0);
-            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard, PageType.Identity);
+            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard, PageType.Identity, PageType.Leaf);
             header.PaprikaVersion.Should().Be(1);
         }
     }

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -190,7 +190,7 @@ public class DbTests
             var header = page.Header;
 
             header.BatchId.Should().BeGreaterThan(0);
-            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard, PageType.PrefixPage);
+            header.PageType.Should().BeOneOf(PageType.Abandoned, PageType.Standard);
             header.PaprikaVersion.Should().Be(1);
         }
     }

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -149,7 +149,7 @@ public class DbTests
         const int size = MB64;
         using var db = PagedDb.NativeMemoryDb(size);
 
-        const int count = 100000;
+        const int count = 10_000;
 
         using (var batch = db.BeginNextBatch())
         {
@@ -173,14 +173,15 @@ public class DbTests
             }
         }
 
+        AssertPageMetadataAssigned(db);
+        return;
+
         static Keccak GetStorageAddress(int i)
         {
             var address = Key1A;
             BinaryPrimitives.WriteInt32LittleEndian(address.BytesAsSpan, i);
             return address;
         }
-
-        AssertPageMetadataAssigned(db);
     }
 
     private static void AssertPageMetadataAssigned(PagedDb db)

--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Buffers.Binary;
+using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Data;
+using Paprika.Store;
+
+namespace Paprika.Tests.Store;
+
+public class PagedDbTests
+{
+    private const int Mb = 1024 * 1024;
+    private const int Seed = 17;
+
+    [Test]
+    public async Task BiggerTest()
+    {
+        const int accounts = 10;
+        const int merkleCount = NibblePath.KeccakNibbleCount;
+
+        using var db = PagedDb.NativeMemoryDb(256 * Mb, 2);
+
+        var random = new Random(Seed);
+
+        using var batch = db.BeginNextBatch();
+
+        for (var i = 0; i < accounts; i++)
+        {
+            var keccak = random.NextKeccak();
+
+            // account first & data
+            batch.SetRaw(Key.Account(keccak), GetData());
+            batch.SetRaw(Key.StorageCell(NibblePath.FromKey(keccak), keccak), GetData());
+
+            for (var j = 0; j < merkleCount; j++)
+            {
+                // all the Merkle values
+                batch.SetRaw(Key.Merkle(NibblePath.FromKey(keccak).SliceTo(j)), GetData());
+            }
+        }
+
+        await batch.Commit(CommitOptions.FlushDataAndRoot);
+
+        // reset
+        random = new Random(Seed);
+        _counter = 0;
+
+        Assert();
+        return;
+
+        void Assert()
+        {
+            using var read = db.BeginReadOnlyBatch();
+
+            for (var i = 0; i < accounts; i++)
+            {
+                var keccak = random.NextKeccak();
+
+                read.TryGet(Key.Account(keccak), out var value).Should().BeTrue("The account should exist");
+                value.SequenceEqual(GetData()).Should().BeTrue("The account should have data right");
+
+                read.TryGet(Key.StorageCell(NibblePath.FromKey(keccak), keccak), out value).Should().BeTrue("The storage cell should exist");
+                value.SequenceEqual(GetData()).Should().BeTrue("The storage cell should have data right");
+
+                for (var j = 0; j < merkleCount; j++)
+                {
+                    // all the Merkle values
+                    read.TryGet(Key.Merkle(NibblePath.FromKey(keccak).SliceTo(j)), out value).Should().BeTrue("The Merkle should exist");
+
+                    var actual = value.ToArray();
+                    var expected = GetData();
+
+                    actual.SequenceEqual(expected).Should().BeTrue($"The Merkle @{j} of {i}th account should have data right");
+                }
+            }
+        }
+    }
+
+    private ushort _counter;
+
+    private byte[] GetData()
+    {
+        BinaryPrimitives.WriteUInt16LittleEndian(bytes, _counter);
+        _counter++;
+        return bytes;
+    }
+
+    private static readonly byte[] bytes = new byte[2];
+}

--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -14,7 +14,7 @@ public class PagedDbTests
     [Test]
     public async Task BiggerTest()
     {
-        const int accounts = 10;
+        const int accounts = 1;
         const int merkleCount = NibblePath.KeccakNibbleCount;
 
         using var db = PagedDb.NativeMemoryDb(256 * Mb, 2);

--- a/src/Paprika.Tests/Store/StoreKeyTests.cs
+++ b/src/Paprika.Tests/Store/StoreKeyTests.cs
@@ -15,7 +15,7 @@ public class StoreKeyTests
 
         var key = Key.Merkle(NibblePath.Empty);
 
-        StoreKey.GetByteSize(key).Should().Be(size);
+        StoreKey.GetMaxByteSize(key).Should().Be(size);
         var s = StoreKey.Encode(key, stackalloc byte[size]);
 
         s.Type.Should().Be(DataType.Merkle);
@@ -32,7 +32,7 @@ public class StoreKeyTests
         var path = NibblePath.FromKey(stackalloc byte[1] { nibble << NibblePath.NibbleShift }).SliceTo(1);
         var key = Key.Merkle(path);
 
-        StoreKey.GetByteSize(key).Should().Be(size);
+        StoreKey.GetMaxByteSize(key).Should().Be(size);
         var s = StoreKey.Encode(key, stackalloc byte[size]);
 
         s.Type.Should().Be(key.Type);
@@ -52,7 +52,7 @@ public class StoreKeyTests
         var path = NibblePath.FromKey(stackalloc byte[1] { (byte)payload });
         var key = Key.Merkle(path);
 
-        StoreKey.GetByteSize(key).Should().Be(size);
+        StoreKey.GetMaxByteSize(key).Should().Be(size);
         var s = StoreKey.Encode(key, stackalloc byte[size]);
 
         s.Type.Should().Be(key.Type);
@@ -70,7 +70,7 @@ public class StoreKeyTests
 
         var key = Key.Account(keccak);
 
-        StoreKey.GetByteSize(key).Should().Be(size);
+        StoreKey.GetMaxByteSize(key).Should().Be(size);
         var s = StoreKey.Encode(key, stackalloc byte[size]);
 
         s.Type.Should().Be(key.Type);
@@ -93,7 +93,7 @@ public class StoreKeyTests
         var path = NibblePath.FromKey(stackalloc byte[1] { nibble << NibblePath.NibbleShift }).SliceTo(1);
         var key = Key.Raw(keccak, DataType.Merkle, path);
 
-        StoreKey.GetByteSize(key).Should().Be(size);
+        StoreKey.GetMaxByteSize(key).Should().Be(size);
         var s = StoreKey.Encode(key, stackalloc byte[size]);
 
         s.Type.Should().Be(key.Type);
@@ -114,7 +114,7 @@ public class StoreKeyTests
         var path = NibblePath.FromKey(stackalloc byte[1] { 0xA1 });
         var key = Key.Merkle(path);
 
-        StoreKey.GetByteSize(key).Should().Be(size);
+        StoreKey.GetMaxByteSize(key).Should().Be(size);
         var s = StoreKey.Encode(key, stackalloc byte[size]);
 
         var sliced = s.SliceTwoNibbles();

--- a/src/Paprika.Tests/Store/StoreKeyTests.cs
+++ b/src/Paprika.Tests/Store/StoreKeyTests.cs
@@ -121,4 +121,24 @@ public class StoreKeyTests
 
         sliced.NibbleCount.Should().Be(0);
     }
+
+    [Test]
+    public void Distinct()
+    {
+        var k = Keccak.EmptyTreeHash;
+        var unique = new HashSet<int>();
+
+        Encode(Key.Account(k), unique);
+        Encode(Key.Merkle(NibblePath.FromKey(k)), unique);
+        Encode(Key.Merkle(NibblePath.Empty), unique);
+
+        static void Encode(in Key key, HashSet<int> set)
+        {
+            var encoded = StoreKey.Encode(key, stackalloc byte[StoreKey.MaxByteSize]);
+            var hash = new HashCode();
+            hash.AddBytes(encoded.Payload);
+
+            set.Add(hash.ToHashCode()).Should().BeTrue();
+        }
+    }
 }

--- a/src/Paprika.Tests/Store/StoreKeyTests.cs
+++ b/src/Paprika.Tests/Store/StoreKeyTests.cs
@@ -1,0 +1,124 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Crypto;
+using Paprika.Data;
+using Paprika.Store;
+
+namespace Paprika.Tests.Store;
+
+public class StoreKeyTests
+{
+    [Test]
+    public void Empty()
+    {
+        const int size = 1;
+
+        var key = Key.Merkle(NibblePath.Empty);
+
+        StoreKey.GetByteSize(key).Should().Be(size);
+        var s = StoreKey.Encode(key, stackalloc byte[size]);
+
+        s.Type.Should().Be(DataType.Merkle);
+
+        s.NibbleCount.Should().Be(0);
+    }
+
+    [Test]
+    public void One_nibble()
+    {
+        const int size = 1;
+        const byte nibble = 0x7;
+
+        var path = NibblePath.FromKey(stackalloc byte[1] { nibble << NibblePath.NibbleShift }).SliceTo(1);
+        var key = Key.Merkle(path);
+
+        StoreKey.GetByteSize(key).Should().Be(size);
+        var s = StoreKey.Encode(key, stackalloc byte[size]);
+
+        s.Type.Should().Be(key.Type);
+        s.GetNibbleAt(0).Should().Be(nibble);
+
+        s.NibbleCount.Should().Be(1);
+    }
+
+    [Test]
+    public void Two_nibbles()
+    {
+        const int size = 2;
+        const byte nibble0 = 0x7;
+        const byte nibble1 = 0x9;
+        const int payload = (nibble0 << NibblePath.NibbleShift) | nibble1;
+
+        var path = NibblePath.FromKey(stackalloc byte[1] { (byte)payload });
+        var key = Key.Merkle(path);
+
+        StoreKey.GetByteSize(key).Should().Be(size);
+        var s = StoreKey.Encode(key, stackalloc byte[size]);
+
+        s.Type.Should().Be(key.Type);
+        s.GetNibbleAt(0).Should().Be(nibble0);
+        s.GetNibbleAt(1).Should().Be(nibble1);
+
+        s.NibbleCount.Should().Be(2);
+    }
+
+    [Test]
+    public void Account()
+    {
+        const int size = Keccak.Size + 1;
+        var keccak = NibblePath.FromKey(Values.Key0);
+
+        var key = Key.Account(keccak);
+
+        StoreKey.GetByteSize(key).Should().Be(size);
+        var s = StoreKey.Encode(key, stackalloc byte[size]);
+
+        s.Type.Should().Be(key.Type);
+
+        for (var i = 0; i < NibblePath.KeccakNibbleCount; i++)
+        {
+            s.GetNibbleAt(i).Should().Be(keccak.GetAt(i));
+        }
+
+        s.NibbleCount.Should().Be(NibblePath.KeccakNibbleCount);
+    }
+
+    [Test]
+    public void Merkle_for_storage()
+    {
+        const int size = Keccak.Size + 1;
+        var keccak = NibblePath.FromKey(Values.Key0);
+        const byte nibble = 0x7;
+
+        var path = NibblePath.FromKey(stackalloc byte[1] { nibble << NibblePath.NibbleShift }).SliceTo(1);
+        var key = Key.Raw(keccak, DataType.Merkle, path);
+
+        StoreKey.GetByteSize(key).Should().Be(size);
+        var s = StoreKey.Encode(key, stackalloc byte[size]);
+
+        s.Type.Should().Be(key.Type);
+
+        for (var i = 0; i < NibblePath.KeccakNibbleCount; i++)
+        {
+            s.GetNibbleAt(i).Should().Be(keccak.GetAt(i));
+        }
+
+        s.GetNibbleAt(NibblePath.KeccakNibbleCount).Should().Be(nibble);
+        s.NibbleCount.Should().Be(NibblePath.KeccakNibbleCount + 1);
+    }
+
+    [Test]
+    public void Slice_two_nibbles()
+    {
+        const int size = 2;
+        var path = NibblePath.FromKey(stackalloc byte[1] { 0xA1 });
+        var key = Key.Merkle(path);
+
+        StoreKey.GetByteSize(key).Should().Be(size);
+        var s = StoreKey.Encode(key, stackalloc byte[size]);
+
+        var sliced = s.SliceTwoNibbles();
+
+        sliced.NibbleCount.Should().Be(0);
+    }
+}

--- a/src/Paprika.Tests/Values.cs
+++ b/src/Paprika.Tests/Values.cs
@@ -20,6 +20,10 @@ public static class Values
     public static readonly Keccak Key2 = new(new byte[]
         { 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 });
 
+    public static readonly Keccak Key3 = Keccak.Compute(new byte[] { 234, 34, 23 });
+    public static readonly Keccak Key4 = Keccak.Compute(new byte[] { 1, 2, 3 });
+    public static readonly Keccak Key5 = Keccak.Compute(new byte[] { 35, 234, 33 });
+
     public static readonly UInt256 Balance0 = 13;
     public static readonly UInt256 Balance1 = 17;
     public static readonly UInt256 Balance2 = 19;

--- a/src/Paprika.sln
+++ b/src/Paprika.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Core", "..\..\ne
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nethermind", "Nethermind", "{385A2A10-9F82-42C7-BE2D-7E92CADDF91A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Serialization.Rlp", "..\..\nethermind\src\Nethermind\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj", "{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,10 +58,15 @@ Global
 		{605C27EC-14CD-4757-A480-E59010B1A4CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{605C27EC-14CD-4757-A480-E59010B1A4CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{605C27EC-14CD-4757-A480-E59010B1A4CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{605C27EC-14CD-4757-A480-E59010B1A4CD} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 		{9C7E46A4-E911-4D52-9491-2739BF067944} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 		{38902D34-E95A-48EB-AA30-3731B8B29ED6} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
+		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 	EndGlobalSection
 EndGlobal

--- a/src/Paprika.sln
+++ b/src/Paprika.sln
@@ -8,6 +8,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Runner", "Paprika.R
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Benchmarks", "Paprika.Benchmarks\Paprika.Benchmarks.csproj", "{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Importer", "Paprika.Importer\Paprika.Importer.csproj", "{A31C0261-59FD-4713-A4D5-DC55FA62BB60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Db", "..\..\nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj", "{9C7E46A4-E911-4D52-9491-2739BF067944}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Db.Rocks", "..\..\nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj", "{38902D34-E95A-48EB-AA30-3731B8B29ED6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Core", "..\..\nethermind\src\Nethermind\Nethermind.Core\Nethermind.Core.csproj", "{605C27EC-14CD-4757-A480-E59010B1A4CD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nethermind", "Nethermind", "{385A2A10-9F82-42C7-BE2D-7E92CADDF91A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +40,26 @@ Global
 		{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A31C0261-59FD-4713-A4D5-DC55FA62BB60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A31C0261-59FD-4713-A4D5-DC55FA62BB60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A31C0261-59FD-4713-A4D5-DC55FA62BB60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A31C0261-59FD-4713-A4D5-DC55FA62BB60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C7E46A4-E911-4D52-9491-2739BF067944}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C7E46A4-E911-4D52-9491-2739BF067944}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C7E46A4-E911-4D52-9491-2739BF067944}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C7E46A4-E911-4D52-9491-2739BF067944}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38902D34-E95A-48EB-AA30-3731B8B29ED6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38902D34-E95A-48EB-AA30-3731B8B29ED6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38902D34-E95A-48EB-AA30-3731B8B29ED6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38902D34-E95A-48EB-AA30-3731B8B29ED6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{605C27EC-14CD-4757-A480-E59010B1A4CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{605C27EC-14CD-4757-A480-E59010B1A4CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{605C27EC-14CD-4757-A480-E59010B1A4CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{605C27EC-14CD-4757-A480-E59010B1A4CD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{605C27EC-14CD-4757-A480-E59010B1A4CD} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
+		{9C7E46A4-E911-4D52-9491-2739BF067944} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
+		{38902D34-E95A-48EB-AA30-3731B8B29ED6} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 	EndGlobalSection
 EndGlobal

--- a/src/Paprika.sln
+++ b/src/Paprika.sln
@@ -10,15 +10,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Benchmarks", "Papri
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Importer", "Paprika.Importer\Paprika.Importer.csproj", "{A31C0261-59FD-4713-A4D5-DC55FA62BB60}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Db", "..\..\nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj", "{9C7E46A4-E911-4D52-9491-2739BF067944}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Db", "Nethermind\src\Nethermind\Nethermind.Db\Nethermind.Db.csproj", "{9C7E46A4-E911-4D52-9491-2739BF067944}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Db.Rocks", "..\..\nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj", "{38902D34-E95A-48EB-AA30-3731B8B29ED6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Db.Rocks", "Nethermind\src\Nethermind\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj", "{38902D34-E95A-48EB-AA30-3731B8B29ED6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Core", "..\..\nethermind\src\Nethermind\Nethermind.Core\Nethermind.Core.csproj", "{605C27EC-14CD-4757-A480-E59010B1A4CD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Core", "Nethermind\src\Nethermind\Nethermind.Core\Nethermind.Core.csproj", "{605C27EC-14CD-4757-A480-E59010B1A4CD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nethermind", "Nethermind", "{385A2A10-9F82-42C7-BE2D-7E92CADDF91A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Serialization.Rlp", "..\..\nethermind\src\Nethermind\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj", "{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Serialization.Rlp", "Nethermind\src\Nethermind\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj", "{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Logging", "Nethermind\src\Nethermind\Nethermind.Logging\Nethermind.Logging.csproj", "{BC0D66BE-B693-4015-9F1B-D7A6DE03651F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,11 +64,16 @@ Global
 		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC0D66BE-B693-4015-9F1B-D7A6DE03651F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC0D66BE-B693-4015-9F1B-D7A6DE03651F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC0D66BE-B693-4015-9F1B-D7A6DE03651F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC0D66BE-B693-4015-9F1B-D7A6DE03651F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{605C27EC-14CD-4757-A480-E59010B1A4CD} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 		{9C7E46A4-E911-4D52-9491-2739BF067944} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 		{38902D34-E95A-48EB-AA30-3731B8B29ED6} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 		{C624D4D9-BA2B-4350-BD06-D84EC935D6B3} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
+		{BC0D66BE-B693-4015-9F1B-D7A6DE03651F} = {385A2A10-9F82-42C7-BE2D-7E92CADDF91A}
 	EndGlobalSection
 EndGlobal

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -47,7 +47,11 @@ public readonly struct Account : IEquatable<Account>
 
     public static bool operator !=(Account left, Account right) => !left.Equals(right);
 
-    public override string ToString() => $"{nameof(Nonce)}: {Nonce}, {nameof(Balance)}: {Balance}";
+    public override string ToString() =>
+        $"{nameof(Nonce)}: {Nonce}, " +
+        $"{nameof(Balance)}: {Balance}, " +
+        $"{nameof(CodeHash)}: {CodeHash}" +
+        $"{nameof(StorageRootHash)}: {StorageRootHash}";
 
     public const int MaxByteCount = BigPreambleLength + // preamble 
                                     Serializer.Uint256Size + // balance

--- a/src/Paprika/Data/DataType.cs
+++ b/src/Paprika/Data/DataType.cs
@@ -18,7 +18,7 @@ public enum DataType : byte
     StorageCell = 1,
 
     /// <summary>
-    /// As enums cannot be partial, this is for storing the Merkle.
+    /// [key, 2] The Merkle entry, either with storage or not
     /// </summary>
     Merkle = 2,
 

--- a/src/Paprika/Data/DataType.cs
+++ b/src/Paprika/Data/DataType.cs
@@ -23,9 +23,7 @@ public enum DataType : byte
     Merkle = 2,
 
     /// <summary>
-    /// Special type for <see cref="SlottedArray"/>. 
+    /// The account compressed with the identity tree.
     /// </summary>
-    Deleted = 3,
-
-    Compressed = 4,
+    CompressedAccount = 4,
 }

--- a/src/Paprika/Data/DataType.cs
+++ b/src/Paprika/Data/DataType.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Represents the type of data stored in the <see cref="SlottedArray"/>.
 /// </summary>
+[Flags]
 public enum DataType : byte
 {
     /// <summary>
@@ -25,4 +26,6 @@ public enum DataType : byte
     /// Special type for <see cref="SlottedArray"/>. 
     /// </summary>
     Deleted = 3,
+
+    Compressed = 4,
 }

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -91,6 +91,8 @@ public readonly ref partial struct Key
         return leftover;
     }
 
+    public bool IsAccountCompressed => ((Type & DataType.CompressedAccount) == DataType.CompressedAccount);
+
     [SkipLocalsInit]
     public override int GetHashCode()
     {

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -235,17 +235,8 @@ public readonly ref struct NibblePath
     private static int GetSpanLength(byte length, int odd) => (length + 1 + odd) / 2;
 
     /// <summary>
-    /// Extracts raw span that can be read as the nibble path from the source.
+    /// Gets the raw underlying span behind the path, removing the odd encoding.
     /// </summary>
-    public static ReadOnlySpan<byte> RawExtract(ReadOnlySpan<byte> source)
-    {
-        var b = source[0];
-        var length = (byte)(b >> LengthShift);
-        var odd = b & OddBit;
-
-        return source.Slice(0, GetSpanLength(length, odd) + PreambleLength);
-    }
-
     public ReadOnlySpan<byte> RawSpan
     {
         get
@@ -254,11 +245,6 @@ public readonly ref struct NibblePath
             return MemoryMarshal.CreateSpan(ref _span, lenght);
         }
     }
-
-    private static readonly byte[] Bytes = Enumerable
-        .Range(0, byte.MaxValue + 1).Select(b => (byte)b)
-        .ToArray();
-    public static NibblePath OfByte(byte value) => FromKey(Bytes.AsSpan(value, 1));
 
     public static ReadOnlySpan<byte> ReadFrom(ReadOnlySpan<byte> source, out NibblePath nibblePath)
     {

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -246,6 +246,15 @@ public readonly ref struct NibblePath
         return source.Slice(0, GetSpanLength(length, odd) + PreambleLength);
     }
 
+    public ReadOnlySpan<byte> RawSpan
+    {
+        get
+        {
+            var lenght = GetSpanLength(Length, _odd);
+            return MemoryMarshal.CreateSpan(ref _span, lenght);
+        }
+    }
+
     private static readonly byte[] Bytes = Enumerable
         .Range(0, byte.MaxValue + 1).Select(b => (byte)b)
         .ToArray();

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -174,7 +174,7 @@ public readonly ref struct NibblePath
     /// Sets a <paramref name="value"/> of the nibble at the given <paramref name="nibble"/> location.
     /// This is unsafe. Use only for owned memory. 
     /// </summary>
-    public void UnsafeSetAt(int nibble, byte countOdd, byte value)
+    private void UnsafeSetAt(int nibble, byte countOdd, byte value)
     {
         ref var b = ref GetRefAt(nibble);
         var shift = GetShift(nibble + countOdd);
@@ -245,6 +245,11 @@ public readonly ref struct NibblePath
 
         return source.Slice(0, GetSpanLength(length, odd) + PreambleLength);
     }
+
+    private static readonly byte[] Bytes = Enumerable
+        .Range(0, byte.MaxValue + 1).Select(b => (byte)b)
+        .ToArray();
+    public static NibblePath OfByte(byte value) => FromKey(Bytes.AsSpan(value, 1));
 
     public static ReadOnlySpan<byte> ReadFrom(ReadOnlySpan<byte> source, out NibblePath nibblePath)
     {

--- a/src/Paprika/Data/NibbleSelector.cs
+++ b/src/Paprika/Data/NibbleSelector.cs
@@ -3,4 +3,4 @@
 /// <summary>
 /// Gets a nibble from the key.
 /// </summary>
-public delegate byte NibbleSelector(in ReadOnlySpan<byte> key);
+public delegate byte NibbleSelector(ReadOnlySpan<byte> key);

--- a/src/Paprika/Data/NibbleSelector.cs
+++ b/src/Paprika/Data/NibbleSelector.cs
@@ -1,0 +1,6 @@
+﻿namespace Paprika.Data;
+
+/// <summary>
+/// Gets a nibble from the key.
+/// </summary>
+public delegate byte NibbleSelector(in ReadOnlySpan<byte> key);

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Paprika.Merkle;
 using Paprika.Store;
 using Paprika.Utils;
 
@@ -38,7 +37,7 @@ public readonly ref struct SlottedArray
         _slots = MemoryMarshal.Cast<byte, Slot>(_data);
     }
 
-    public bool TrySet(in Key key, ReadOnlySpan<byte> data, ushort? keyHash = default)
+    public bool TrySet(in ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, ushort? keyHash = default)
     {
         var hash = keyHash ?? Slot.GetHash(key);
 
@@ -55,11 +54,8 @@ public readonly ref struct SlottedArray
             DeleteImpl(index);
         }
 
-        var encodedKey = key.Path.WriteTo(stackalloc byte[key.Path.MaxByteLength]);
-        var encodedStorageKey = key.StoragePath.WriteTo(stackalloc byte[key.StoragePath.MaxByteLength]);
-
         // does not exist yet, calculate total memory needed
-        var total = GetTotalSpaceRequired(encodedKey, encodedStorageKey, data);
+        var total = GetTotalSpaceRequired(key, data);
 
         if (_header.Taken + total + Slot.Size > _data.Length)
         {
@@ -86,15 +82,13 @@ public readonly ref struct SlottedArray
         // write slot
         slot.Hash = hash;
         slot.ItemAddress = (ushort)(_data.Length - _header.High - total);
-        slot.Type = key.Type;
-        slot.PathNotEmpty = !key.Path.IsEmpty;
 
-        // write item: key, additionalKey, data
+        // write item: length_key, key, data
         var dest = _data.Slice(slot.ItemAddress, total);
 
-        encodedKey.CopyTo(dest);
-        encodedStorageKey.CopyTo(dest.Slice(encodedKey.Length));
-        data.CopyTo(dest.Slice(encodedKey.Length + encodedStorageKey.Length));
+        dest[0] = (byte)key.Length;
+        key.CopyTo(dest.Slice(KeyLengthLength));
+        data.CopyTo(dest.Slice(KeyLengthLength + key.Length));
 
         // commit low and high
         _header.Low += Slot.Size;
@@ -109,21 +103,13 @@ public readonly ref struct SlottedArray
 
     public int CapacityLeft => _data.Length - _header.Taken;
 
-    public NibbleEnumerator EnumerateNibble(byte nibble) => new(this, nibble);
+    public Enumerator EnumerateAll() =>
+        new(this);
 
-    public NibbleEnumerator EnumerateAll() => new(this, NibbleEnumerator.AllNibbles);
-
-    public ref struct NibbleEnumerator
+    public ref struct Enumerator
     {
-        public const byte AllNibbles = byte.MaxValue;
-
         /// <summary>The map being enumerated.</summary>
         private readonly SlottedArray _map;
-
-        /// <summary>
-        /// The nibble being enumerated.
-        /// </summary>
-        private readonly byte _nibble;
 
         /// <summary>The next index to yield.</summary>
         private int _index;
@@ -131,10 +117,9 @@ public readonly ref struct SlottedArray
         private readonly byte[] _bytes;
         private Item _current;
 
-        internal NibbleEnumerator(SlottedArray map, byte nibble)
+        internal Enumerator(SlottedArray map)
         {
             _map = map;
-            _nibble = nibble;
             _index = -1;
             _bytes = ArrayPool<byte>.Shared.Rent(128);
         }
@@ -148,10 +133,7 @@ public readonly ref struct SlottedArray
 
             ref var slot = ref _map._slots[index];
 
-            while (index < to &&
-                   (slot.Type == DataType.Deleted || // filter out deleted
-                    (_nibble != AllNibbles &&
-                     (!slot.PathNotEmpty || NibblePath.ReadFirstNibble(_map.GetSlotPayload(ref slot)) != _nibble))))
+            while (index < to && slot.IsDeleted) // filter out deleted
             {
                 // move by 1
                 index += 1;
@@ -175,10 +157,12 @@ public readonly ref struct SlottedArray
             ref var slot = ref _map._slots[_index];
             var span = _map.GetSlotPayload(ref slot);
 
-            var leftover = NibblePath.ReadFrom(span, out NibblePath path);
-            var data = NibblePath.ReadFrom(leftover, out NibblePath storagePath);
+            var keyLenght = span[0];
 
-            return new Item(Key.Raw(path, slot.Type, storagePath), data, _index, slot.Type);
+            var key = span.Slice(KeyLengthLength, keyLenght);
+            var data = span.Slice(KeyLengthLength + keyLenght);
+
+            return new Item(key, data, _index);
         }
 
         public void Dispose()
@@ -190,21 +174,19 @@ public readonly ref struct SlottedArray
         public readonly ref struct Item
         {
             public int Index { get; }
-            public DataType Type { get; }
-            public Key Key { get; }
+            public ReadOnlySpan<byte> Key { get; }
             public ReadOnlySpan<byte> RawData { get; }
 
-            public Item(Key key, ReadOnlySpan<byte> rawData, int index, DataType type)
+            public Item(ReadOnlySpan<byte> key, ReadOnlySpan<byte> rawData, int index)
             {
                 Index = index;
-                Type = type;
                 Key = key;
                 RawData = rawData;
             }
         }
 
         // a shortcut to not allocate, just copy the enumerator
-        public NibbleEnumerator GetEnumerator() => this;
+        public Enumerator GetEnumerator() => this;
     }
 
     public const int BucketCount = 16;
@@ -212,7 +194,7 @@ public readonly ref struct SlottedArray
     /// <summary>
     /// Gets the aggregated sizes per nibble.
     /// </summary>
-    public void GatherSizeStatistics(Span<ushort> buckets)
+    public void GatherSizeStatistics(Span<ushort> buckets, NibbleSelector selector)
     {
         Debug.Assert(buckets.Length == BucketCount);
 
@@ -222,14 +204,14 @@ public readonly ref struct SlottedArray
             ref var slot = ref _slots[i];
 
             // extract only not deleted and these which have at least one nibble
-            if (slot.Type != DataType.Deleted && slot.PathNotEmpty)
+            if (slot.IsDeleted == false)
             {
                 var payload = GetSlotPayload(ref slot);
-                var firstNibble = NibblePath.ReadFirstNibble(payload);
-
-                var index = firstNibble % BucketCount;
-
-                buckets[index] += (ushort)(payload.Length + Slot.Size);
+                var first = selector(payload);
+                if (first < BucketCount)
+                {
+                    buckets[first] += (ushort)(payload.Length + Slot.Size);
+                }
             }
         }
     }
@@ -237,7 +219,7 @@ public readonly ref struct SlottedArray
     /// <summary>
     /// Gets the aggregated count of entries per nibble.
     /// </summary>
-    public void GatherCountStatistics(Span<ushort> buckets)
+    public void GatherCountStatistics(Span<ushort> buckets, NibbleSelector selector)
     {
         Debug.Assert(buckets.Length == BucketCount);
 
@@ -247,29 +229,29 @@ public readonly ref struct SlottedArray
             ref var slot = ref _slots[i];
 
             // extract only not deleted and these which have at least one nibble
-            if (slot.Type != DataType.Deleted && slot.PathNotEmpty)
+            if (slot.IsDeleted == false)
             {
                 var payload = GetSlotPayload(ref slot);
-                var firstNibble = NibblePath.ReadFirstNibble(payload);
-
-                var index = firstNibble % BucketCount;
-
-                buckets[index] += 1;
+                var first = selector(payload);
+                if (first < BucketCount)
+                {
+                    buckets[first] += 1;
+                }
             }
         }
     }
 
-    private static int GetTotalSpaceRequired(ReadOnlySpan<byte> key, ReadOnlySpan<byte> storageKey,
-        ReadOnlySpan<byte> data)
+    private const int KeyLengthLength = 1;
+    private static int GetTotalSpaceRequired(in ReadOnlySpan<byte> key, ReadOnlySpan<byte> data)
     {
-        return key.Length + data.Length + storageKey.Length;
+        return KeyLengthLength + key.Length + data.Length;
     }
 
     /// <summary>
     /// Warning! This does not set any tombstone so the reader won't be informed about a delete,
     /// just will miss the value.
     /// </summary>
-    public bool Delete(in Key key)
+    public bool Delete(in ReadOnlySpan<byte> key)
     {
         if (TryGetImpl(key, Slot.GetHash(key), out _, out var index))
         {
@@ -280,12 +262,12 @@ public readonly ref struct SlottedArray
         return false;
     }
 
-    public void Delete(in NibbleEnumerator.Item item) => DeleteImpl(item.Index);
+    public void Delete(in Enumerator.Item item) => DeleteImpl(item.Index);
 
     private void DeleteImpl(int index)
     {
         // mark as deleted first
-        _slots[index].Type = DataType.Deleted;
+        _slots[index].IsDeleted = true;
         _header.Deleted++;
 
         // always try to compact after delete
@@ -306,7 +288,7 @@ public readonly ref struct SlottedArray
         for (int i = 0; i < count; i++)
         {
             var copyFrom = _slots[i];
-            if (copyFrom.Type != DataType.Deleted)
+            if (copyFrom.IsDeleted == false)
             {
                 var fromSpan = GetSlotPayload(ref _slots[i]);
 
@@ -318,8 +300,6 @@ public readonly ref struct SlottedArray
 
                 copyTo.Hash = copyFrom.Hash;
                 copyTo.ItemAddress = high;
-                copyTo.Type = copyFrom.Type;
-                copyTo.PathNotEmpty = copyFrom.PathNotEmpty;
 
                 copy._header.Low += Slot.Size;
                 copy._header.High = (ushort)(copy._header.High + fromSpan.Length);
@@ -341,7 +321,7 @@ public readonly ref struct SlottedArray
         // start with the last written and perform checks and cleanup till all the deleted are gone
         var index = Count - 1;
 
-        while (index >= 0 && _slots[index].Type == DataType.Deleted)
+        while (index >= 0 && _slots[index].IsDeleted)
         {
             // undo writing low
             _header.Low -= Slot.Size;
@@ -360,7 +340,7 @@ public readonly ref struct SlottedArray
         }
     }
 
-    public bool TryGet(scoped in Key key, out ReadOnlySpan<byte> data)
+    public bool TryGet(in ReadOnlySpan<byte> key, out ReadOnlySpan<byte> data)
     {
         if (TryGetImpl(key, Slot.GetHash(key), out var span, out _))
         {
@@ -374,7 +354,7 @@ public readonly ref struct SlottedArray
 
     [OptimizationOpportunity(OptimizationType.CPU,
         "key encoding is delayed but it might be called twice, here + TrySet")]
-    private bool TryGetImpl(scoped in Key key, ushort hash, out Span<byte> data, out int slotIndex)
+    private bool TryGetImpl(scoped in ReadOnlySpan<byte> key, ushort hash, out Span<byte> data, out int slotIndex)
     {
         var to = _header.Low / Slot.Size;
 
@@ -394,10 +374,6 @@ public readonly ref struct SlottedArray
             return false;
         }
 
-        // encode keys only if there
-        var encodedKey = key.Path.WriteTo(stackalloc byte[key.Path.MaxByteLength]);
-        var encodedStorageKey = key.StoragePath.WriteTo(stackalloc byte[key.StoragePath.MaxByteLength]);
-
         while (index != notFound)
         {
             // move offset to the given position
@@ -408,34 +384,16 @@ public readonly ref struct SlottedArray
                 var i = offset / 2;
 
                 ref var slot = ref _slots[i];
-                if (slot.Type == key.Type)
+                if (slot.IsDeleted == false)
                 {
                     var actual = GetSlotPayload(ref slot);
 
                     // The StartsWith check assumes that all the keys have the same length.
-                    if (actual.StartsWith(encodedKey))
+                    if (actual[0] == key.Length && actual.Slice(KeyLengthLength).StartsWith(key))
                     {
-                        if (key.StoragePath.IsEmpty)
-                        {
-                            // the searched storage path is empty, but need to ensure that it starts right
-                            // the empty path is encoded as "[0]", compare manually
-                            if (actual[encodedKey.Length] == 0)
-                            {
-                                data = actual.Slice(encodedKey.Length + NibblePath.EmptyEncodedLength);
-                                slotIndex = i;
-                                return true;
-                            }
-                        }
-                        else
-
-                        // there's the additional key, assert it
-                        // do it by slicing off first the encoded and then check the additional
-                        if (actual.Slice(encodedKey.Length).StartsWith(encodedStorageKey))
-                        {
-                            data = actual.Slice(encodedKey.Length + encodedStorageKey.Length);
-                            slotIndex = i;
-                            return true;
-                        }
+                        data = actual.Slice(KeyLengthLength + key.Length);
+                        slotIndex = i;
+                        return true;
                     }
                 }
             }
@@ -491,28 +449,15 @@ public readonly ref struct SlottedArray
             set => Raw = (ushort)((Raw & ~AddressMask) | value);
         }
 
-        private const int DataTypeShift = 13;
-        private const ushort DataTypeMask = 0b1110_0000_0000_0000;
+        private const ushort DeletedMask = 0b0010_0000_0000_0000;
 
         /// <summary>
         /// The data type contained in this slot.
         /// </summary>
-        public DataType Type
+        public bool IsDeleted
         {
-            get => (DataType)((Raw & DataTypeMask) >> DataTypeShift);
-            set => Raw = (ushort)((Raw & ~DataTypeMask) | (ushort)((byte)value << DataTypeShift));
-        }
-
-        private const int NotEmptyPathShift = 12;
-        private const ushort NotEmptyPathMask = 1 << NotEmptyPathShift;
-
-        /// <summary>
-        /// Shows whether the path that is encoded is empty or not.
-        /// </summary>
-        public bool PathNotEmpty
-        {
-            get => (Raw & NotEmptyPathMask) == NotEmptyPathMask;
-            set => Raw = (ushort)((Raw & ~NotEmptyPathMask) | (ushort)((value ? 1 : 0) << NotEmptyPathShift));
+            get => (Raw & DeletedMask) == DeletedMask;
+            set => Raw = (ushort)((Raw & ~DeletedMask) | (ushort)(value ? DeletedMask : 0));
         }
 
         [FieldOffset(0)] private ushort Raw;
@@ -530,20 +475,22 @@ public readonly ref struct SlottedArray
         /// <summary>
         /// Builds the hash for the key.
         /// </summary>
-        public static ushort GetHash(in Key key)
+        public static ushort GetHash(in ReadOnlySpan<byte> key)
         {
-            unchecked
+            return key.Length switch
             {
-                // do not use type in the hash, it's compared separately
-                var hashCode = key.Path.GetHashCode() ^ key.StoragePath.GetHashCode();
-                return (ushort)(hashCode ^ (hashCode >> 16));
-            }
+                0 => 0,
+                1 => key[0],
+
+                // The last byte may provide not the best entropy as the last byte for StoreKey may be half empty. Mix it with a middle one.
+                _ => (ushort)((key[0] << 8) | (byte)(key[^1] ^ key[key.Length / 2]))
+            };
         }
 
         public override string ToString()
         {
             return
-                $"{nameof(Type)}: {Type}, {nameof(Hash)}: {Hash}, {nameof(ItemAddress)}: {ItemAddress}";
+                $"{nameof(Hash)}: {Hash}, {nameof(ItemAddress)}: {ItemAddress}";
         }
     }
 

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -191,6 +191,29 @@ public readonly ref struct SlottedArray
         public Enumerator GetEnumerator() => this;
     }
 
+    /// <summary>
+    /// Tries to move as many items as possible from this map to the destination map.
+    /// </summary>
+    /// <remarks>
+    /// Returns how many items were moved.
+    /// </remarks>
+    public int MoveTo(in SlottedArray destination)
+    {
+        var count = 0;
+
+        foreach (var item in EnumerateAll())
+        {
+            // try copy all, even if one is not copyable the other might
+            if (destination.TrySet(item.Key, item.RawData))
+            {
+                count++;
+                Delete(item);
+            }
+        }
+
+        return count;
+    }
+
     public const int BucketCount = 16;
 
     /// <summary>

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -389,11 +389,15 @@ public readonly ref struct SlottedArray
                     var actual = GetSlotPayload(ref slot);
 
                     // The StartsWith check assumes that all the keys have the same length.
-                    if (actual[0] == key.Length && actual.Slice(KeyLengthLength).StartsWith(key))
+                    var length = key.Length;
+                    if (actual[0] == length)
                     {
-                        data = actual.Slice(KeyLengthLength + key.Length);
-                        slotIndex = i;
-                        return true;
+                        if (actual.Slice(KeyLengthLength, length).SequenceEqual(key))
+                        {
+                            data = actual.Slice(KeyLengthLength + length);
+                            slotIndex = i;
+                            return true;
+                        }
                     }
                 }
             }

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -233,7 +233,7 @@ public readonly ref struct SlottedArray
             }
         }
     }
-    
+
     /// <summary>
     /// Gets the aggregated count of entries per nibble.
     /// </summary>

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -232,7 +232,7 @@ public readonly ref struct SlottedArray
             if (slot.IsDeleted == false)
             {
                 var payload = GetSlotPayload(ref slot);
-                var first = selector(payload);
+                var first = selector(payload.Slice(KeyLengthLength));
                 if (first < BucketCount)
                 {
                     buckets[first] += 1;

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -545,7 +545,6 @@ public readonly ref struct SlottedArray
         /// </summary>
         public static ushort GetHash(in Key key)
         {
-            // TODO: ensure this is called once!
             unchecked
             {
                 // do not use type in the hash, it's compared separately

--- a/src/Paprika/Merkle/NibbleSet.cs
+++ b/src/Paprika/Merkle/NibbleSet.cs
@@ -93,6 +93,8 @@ public struct NibbleSet
 
         public bool this[byte nibble] => new NibbleSet(_value)[nibble];
 
+        public static Readonly All => new(AllSetValue);
+
         public bool AllSet => _value == AllSetValue;
 
         public int SetCount => new NibbleSet(_value).SetCount;

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -45,7 +45,7 @@ abstract class BatchContextBase : IBatchContext
     /// </summary>
     /// <param name="page">The page to be analyzed and registered for future GC.</param>
 
-    protected abstract void RegisterForFutureReuse(Page page);
+    public abstract void RegisterForFutureReuse(Page page);
 
     /// <summary>
     /// Assigns the batch identifier to a given page, marking it writable by this batch.

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Buffers;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Paprika.Crypto;
@@ -47,34 +48,10 @@ public readonly unsafe struct DataPage : IPage
             return new DataPage(writable).Set(ctx);
         }
 
-        if (Header.PageType == PageType.PrefixPage && ctx.IsPrefixed == false)
-        {
-            if (TryExtractPrefixed(ctx.Key, out var prefixed))
-            {
-                // prefixes match, just amend the context
-                return Set(new SetContext(prefixed, ctx.Data, ctx.Batch, true));
-            }
-
-            // This page is the top of the prefix tree.
-            // Create a new regular parent page and push this page as a child.
-            // As prefixes are checked with EndsWith, no need to do truncation
-            var parent = ctx.Batch.GetNewPage(out _, true);
-            parent.Header.PageType = PageType.Standard;
-            parent = new DataPage(parent).Set(ctx);
-
-            // read, extract and slice the first nibble
-            NibblePath.ReadFrom(Data.AccountPrefix, out var prefix);
-            var firstNibble = prefix.FirstNibble;
-            prefix.SliceFrom(1).WriteTo(Data.AccountPrefix);
-
-            // point to the first nibble of the sliced path as a child
-            new DataPage(parent).Data.Buckets[firstNibble] = ctx.Batch.GetAddress(this.AsPage());
-            return parent;
-        }
-
         var map = new SlottedArray(Data.DataSpan);
+        var key = TryCompress(ctx.Key);
 
-        var path = ctx.Key.Path;
+        var path = key.Path;
         var isDelete = ctx.Data.IsEmpty;
 
         if (isDelete)
@@ -82,7 +59,7 @@ public readonly unsafe struct DataPage : IPage
             if (path.Length < NibbleCount)
             {
                 // path cannot be held on a lower level so delete in here
-                return DeleteInMap(ctx, map);
+                return DeleteInMap(key, map);
             }
 
             // path is not empty, so it might have a child page underneath with data, let's try
@@ -90,28 +67,34 @@ public readonly unsafe struct DataPage : IPage
             if (childPageAddress.IsNull)
             {
                 // there's no lower level, delete in map
-                return DeleteInMap(ctx, map);
+                return DeleteInMap(key, map);
             }
         }
 
         // try write in map
-        if (map.TrySet(ctx.Key, ctx.Data))
+        if (map.TrySet(key, ctx.Data))
         {
             return _page;
         }
 
-        // There's no more room in this page. We need to make some, but in a way that will not over-allocate pages.
-        // To make it work:
-        // 1. find amongst existing children pages that have some capacity left.
-        // 2. sort them from the most empty to the least empty
-        // 3. loop through them, and flush down the given nibble in a way that will not allocate anything in them
-        // 4. after each spin of the loop, try to write map
-        // 5. if after walking through all of the pages there's still no place, flush down the biggest nibble
-        if (TryFlushDownSoftAndWrite(ctx, map))
+        // The map is full. The plan for this is the following:
+        // 1. try apply the dictionary compression
+        // 2. try to flush down softly
+        // 3. try to flush down with force the biggest nibble
+        if (TryCompressMap(map))
+        {
+            // compression occured, try to write again
+            if (map.TrySet(key, ctx.Data))
+            {
+                return _page;
+            }
+        }
+
+        if (TryFlushDownSoftAndWrite(key, ctx.Data, ctx.Batch, map))
             return _page;
 
         // Flushing down to existing pages didn't make space for this entry, flush the biggest nibble forcefully.
-        var biggestNibble = FindBiggestNibble(map);
+        var biggestNibble = FindMostFrequentNibble(map);
 
         // try get the child page
         ref var address = ref Data.Buckets[biggestNibble];
@@ -119,21 +102,10 @@ public readonly unsafe struct DataPage : IPage
 
         if (address.IsNull)
         {
-            var noOtherChildren = Data.Buckets.IndexOfAnyExcept(DbAddress.Null) == -1;
-            if (noOtherChildren)
-            {
-                // try to create a prefix child only if there are no other children at this page.
-                // If they are, this looks like a regular page
-                if (TryExtractAsPrefixTree(biggestNibble, ctx, map, out address))
-                {
-                    // the page has been extracted, retry set
-                    return Set(ctx);
-                }
-            }
-
             // create child as the same type as the parent
             child = ctx.Batch.GetNewPage(out Data.Buckets[biggestNibble], true);
             child.Header.PageType = Header.PageType;
+            child.Header.Level = (byte)(Header.Level + 1);
         }
         else
         {
@@ -152,8 +124,74 @@ public readonly unsafe struct DataPage : IPage
         return Set(ctx);
     }
 
-    private bool TryFlushDownSoftAndWrite(SetContext ctx, SlottedArray map)
+    private bool TryCompressMap(in SlottedArray map)
     {
+        if (Header.Level < DictionaryCompression.CompressFromLevel)
+            return false;
+
+        if (!Data.Compression.HasMoreSpace)
+            return false;
+
+        var dictionary = new Dictionary<int, int>();
+
+        foreach (var item in map.EnumerateAll())
+        {
+            if (IsCompressible(item.Key))
+            {
+                var hashCode = item.Key.Path.GetHashCode();
+                ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, hashCode, out _);
+                count++;
+            }
+        }
+
+        if (dictionary.Count == 0)
+            return false;
+
+        // find max and compress it away
+        var max = dictionary.Max(kvp => kvp.Value);
+        var maxKey = dictionary.First(kvp => kvp.Value == max).Key;
+
+        // assigned compressed
+        foreach (var item in Map.EnumerateAll())
+        {
+            if (IsCompressible(item.Key))
+            {
+                var hashCode = item.Key.Path.GetHashCode();
+                if (hashCode == maxKey)
+                {
+                    Data.Compression.Assign(item.Key.Path);
+                    break;
+                }
+            }
+        }
+
+        // copy over
+        var size = Data.DataSpan.Length;
+        var array = ArrayPool<byte>.Shared.Rent(size);
+        var bytes = array.AsSpan(0, size);
+        bytes.Clear();
+
+        var copy = new SlottedArray(bytes);
+        foreach (var item in map.EnumerateAll())
+        {
+            copy.TrySet(TryCompress(item.Key), item.RawData);
+        }
+
+        bytes.CopyTo(Data.DataSpan);
+        ArrayPool<byte>.Shared.Return(array);
+
+        return true;
+    }
+
+    private bool TryFlushDownSoftAndWrite(in Key key, in ReadOnlySpan<byte> data, IBatchContext batch, in SlottedArray map)
+    {
+        // There's no more room in this page. We need to make some, but in a way that will not over-allocate pages.
+        // To make it work:
+        // 1. find amongst existing children pages that have some capacity left.
+        // 2. sort them from the most empty to the least empty
+        // 3. loop through them, and flush down the given nibble in a way that will not allocate anything in them
+        // 4. after each spin of the loop, try to write map
+
         // TODO: Change this algorithm into a simple bit-map that is memoized in page.
         // Softly flushed map would memoize whether a page was flushed softly.
         // Here, select only these that were not
@@ -168,7 +206,7 @@ public readonly unsafe struct DataPage : IPage
             var childAddress = Data.Buckets[i];
             if (childAddress.IsNull == false)
             {
-                capacities[i] = (ushort)new DataPage(ctx.Batch.GetAt(childAddress)).Map.CapacityLeft;
+                capacities[i] = (ushort)new DataPage(batch.GetAt(childAddress)).Map.CapacityLeft;
             }
         }
 
@@ -186,14 +224,14 @@ public readonly unsafe struct DataPage : IPage
             ref var childAddress = ref Data.Buckets[nibble];
             Debug.Assert(childAddress.IsNull == false, "Only an existing child should be selected for flush down");
 
-            var page = new DataPage(ctx.Batch.GetAt(childAddress));
-            page = FlushDown(map, nibble, page, ctx.Batch, true);
+            var page = new DataPage(batch.GetAt(childAddress));
+            page = FlushDown(map, nibble, page, batch, true);
 
             // update the child address
-            childAddress = ctx.Batch.GetAddress(page.AsPage());
+            childAddress = batch.GetAddress(page.AsPage());
 
             // try write again to the map
-            if (map.TrySet(ctx.Key, ctx.Data))
+            if (map.TrySet(key, data))
             {
                 return true;
             }
@@ -202,18 +240,13 @@ public readonly unsafe struct DataPage : IPage
         return false;
     }
 
-    private DataPage FlushDown(in SlottedArray map, byte nibble, DataPage destination, IBatchContext batch, bool tryAllocFree)
+    private static DataPage FlushDown(in SlottedArray map, byte nibble, DataPage destination, IBatchContext batch, bool tryAllocFree)
     {
-        const int minimumCapacity = 96;
+        const int minimumCapacity = 128;
 
         foreach (var item in map.EnumerateNibble(nibble))
         {
             var key = item.Key.SliceFrom(NibbleCount);
-            if (tryAllocFree && !destination.MayAcceptKeyInAllocFreeWay(key))
-            {
-                // skip items that will result in creating an additional page for now
-                continue;
-            }
 
             if (tryAllocFree && destination.Map.CapacityLeft < minimumCapacity)
             {
@@ -221,7 +254,7 @@ public readonly unsafe struct DataPage : IPage
                 break;
             }
 
-            var set = new SetContext(key, item.RawData, batch, Header.PageType == PageType.PrefixPage);
+            var set = new SetContext(key, item.RawData, batch);
             destination = new DataPage(destination.Set(set));
 
             // use the special delete for the item that is much faster than map.Delete(item.Key);
@@ -231,20 +264,12 @@ public readonly unsafe struct DataPage : IPage
         return destination;
     }
 
-    /// <summary>
-    /// Checks whether the key can be added to the page and it will not result in an automatic page allocation.
-    /// </summary>
-    private bool MayAcceptKeyInAllocFreeWay(in Key key)
-    {
-        return Header.PageType == PageType.Standard || TryExtractPrefixed(key, out _);
-    }
-
-    private static byte FindBiggestNibble(SlottedArray map)
+    private static byte FindMostFrequentNibble(SlottedArray map)
     {
         const int count = SlottedArray.BucketCount;
 
         Span<ushort> stats = stackalloc ushort[count];
-        map.GatherSizeStatistics(stats);
+        map.GatherCountStatistics(stats);
 
         byte biggestIndex = 0;
         for (byte i = 1; i < count; i++)
@@ -258,9 +283,9 @@ public readonly unsafe struct DataPage : IPage
         return biggestIndex;
     }
 
-    private Page DeleteInMap(SetContext ctx, SlottedArray map)
+    private Page DeleteInMap(in Key key, SlottedArray map)
     {
-        map.Delete(ctx.Key);
+        map.Delete(key);
         if (map.Count == 0 && Data.Buckets.IndexOfAnyExcept(DbAddress.Null) == -1)
         {
             // map is empty, buckets are empty, page is empty
@@ -279,19 +304,12 @@ public readonly unsafe struct DataPage : IPage
     public struct Payload
     {
         private const int Size = Page.PageSize - PageHeader.Size;
-
         private const int BucketSize = BucketCount * DbAddress.Size;
-
-        private const int PrefixSizeLongAligned = 40;
-
-        private const int PrefixSize = NibblePath.FullKeccakByteLength > PrefixSizeLongAligned
-            ? NibblePath.FullKeccakByteLength
-            : PrefixSizeLongAligned;
 
         /// <summary>
         /// The size of the raw byte data held in this page. Must be long aligned.
         /// </summary>
-        private const int DataSize = Size - BucketSize - PrefixSize;
+        private const int DataSize = Size - BucketSize - DictionaryCompression.Size;
 
         private const int DataOffset = Size - DataSize;
 
@@ -302,8 +320,7 @@ public readonly unsafe struct DataPage : IPage
 
         public Span<DbAddress> Buckets => MemoryMarshal.CreateSpan(ref Bucket, BucketCount);
 
-        [FieldOffset(BucketSize)] private byte PrefixStart;
-        public Span<byte> AccountPrefix => MemoryMarshal.CreateSpan(ref PrefixStart, PrefixSize);
+        [FieldOffset(BucketSize)] public DictionaryCompression Compression;
 
         /// <summary>
         /// The first item of map of frames to allow ref to it.
@@ -317,67 +334,131 @@ public readonly unsafe struct DataPage : IPage
     }
 
     /// <summary>
-    /// Tries to match and extract the prefixed key for <see cref="PageType.PrefixPage"/>.
+    /// This structure provides an in-page dictionary compression,
+    /// allowing to store to up to <see cref="MaxPrefixCount"/> nibbles paths extracted.
     /// </summary>
-    private bool TryExtractPrefixed(in Key key, out Key prefixed)
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    public struct DictionaryCompression
     {
-        // This is a prefixed page and the key has the storage path.
-        // This means, that it didn't have it's prefix checked & extracted.
-        NibblePath.ReadFrom(Data.AccountPrefix, out var accountPrefix);
+        public const int CompressFromLevel = 3;
+        public const int MinimalPathLength = 2;
 
-        // If prefix is different, fail
-        if (accountPrefix.Equals(key.Path) == false)
+        public const int Size = MaxPrefixCount * AccountSize + sizeof(long);
+
+        private const int AccountSize = Keccak.Size;
+        private const int MaxPrefixCount = 2;
+
+        [FieldOffset(0)]
+        private byte pathStart;
+
+        private Span<byte> this[byte index] =>
+            MemoryMarshal.CreateSpan(ref Unsafe.Add(ref pathStart, index * AccountSize), AccountSize);
+
+        [FieldOffset(MaxPrefixCount * AccountSize)]
+        private byte Count;
+
+        [FieldOffset(MaxPrefixCount * AccountSize + 1)]
+        private byte NibbleStart;
+
+        private Span<byte> NibblePairs => MemoryMarshal.CreateSpan(ref NibbleStart, AccountSize);
+
+        public bool HasMoreSpace => Count < MaxPrefixCount;
+
+        public byte Assign(in NibblePath path)
         {
-            prefixed = default;
-            return false;
+            if (!HasMoreSpace)
+                throw new Exception("Filled compression");
+
+            var id = Count;
+            Count++;
+            path.WriteTo(this[id]);
+            NibblePairs[id] = GetTwoNibbles(path);
+
+            return id;
         }
 
-        // prefix is right
-        prefixed = Key.Raw(key.StoragePath, key.Type, NibblePath.Empty);
-        return true;
-    }
+        private static byte GetTwoNibbles(in NibblePath path) =>
+            (byte)((path.GetAt(0) << NibblePath.NibbleShift) | path.GetAt(1));
 
-    public bool TryGet(Key key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result) =>
-        TryGet(key, false, batch, out result);
-
-    private bool TryGet(Key key, bool isPrefixed, IPageResolver batch, out ReadOnlySpan<byte> result)
-    {
-        if (Header.PageType == PageType.PrefixPage && !isPrefixed)
+        public bool TryFindCompressed(in NibblePath path, out byte id)
         {
-            if (TryExtractPrefixed(key, out var prefixed) == false)
+            var search = GetTwoNibbles(path);
+
+            for (byte i = 0; i < Count; i++)
             {
-                result = default;
-                return false;
+                if (NibblePairs[i] == search)
+                {
+                    NibblePath.ReadFrom(this[i], out var compressed);
+                    if (compressed.Equals(path))
+                    {
+                        id = i;
+                        return true;
+                    }
+                }
             }
 
-            return TryGet(prefixed, true, batch, out result);
+            id = default;
+            return false;
         }
+    }
+
+
+    public bool TryGet(Key key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result) =>
+        TryGet(key, (IPageResolver)batch, out result);
+
+    private bool TryGet(Key key, IPageResolver batch, out ReadOnlySpan<byte> result)
+    {
+        scoped var k = TryCompress(key);
 
         // read in-page
         var map = Map;
 
         // try regular map
-        if (map.TryGet(key, out result))
+        if (map.TryGet(k, out result))
         {
             return true;
         }
 
         // path longer than 0, try to find in child
-        if (key.Path.Length > 0)
+        if (k.Path.Length > 0)
         {
             // try to go deeper only if the path is long enough
-            var bucket = Data.Buckets[key.Path.FirstNibble];
+            var bucket = Data.Buckets[k.Path.FirstNibble];
 
             // non-null page jump, follow it!
             if (bucket.IsNull == false)
             {
-                return new DataPage(batch.GetAt(bucket)).TryGet(key.SliceFrom(NibbleCount), isPrefixed, batch,
-                    out result);
+                return new DataPage(batch.GetAt(bucket)).TryGet(k.SliceFrom(NibbleCount), batch, out result);
             }
         }
 
         result = default;
         return false;
+    }
+
+    private Key TryCompress(in Key key)
+    {
+        if (Header.Level < DictionaryCompression.CompressFromLevel)
+            return key;
+
+        if (!IsCompressible(key))
+            return key;
+
+        if (!Data.Compression.TryFindCompressed(key.Path, out var id))
+            return key;
+
+        Debug.Assert(Header.Level <= 32);
+        var actual = (byte)(Header.Level << 2 | id);
+
+        return Key.Raw(key.StoragePath, key.Type | DataType.Compressed, NibblePath.OfByte(actual));
+    }
+
+    private static bool IsCompressible(in Key key)
+    {
+        // compress only merkle for storage or storage
+        return key.Path.Length > DictionaryCompression.MinimalPathLength
+               && (key.Type & DataType.Compressed) != DataType.Compressed
+               && key.StoragePath.Length > 0;
     }
 
     private SlottedArray Map => new(Data.DataSpan);
@@ -406,69 +487,5 @@ public readonly unsafe struct DataPage : IPage
         }
 
         reporter.ReportDataUsage(Header.PageType, level, BucketCount - emptyBuckets, slotted.Count, slotted.CapacityLeft);
-    }
-
-    private static bool TryExtractAsPrefixTree(byte nibble, in SetContext ctx, in SlottedArray map,
-        out DbAddress address)
-    {
-        if (ctx.IsPrefixed)
-        {
-            // if this is an already prefixed tree, don't prefix it again
-            address = default;
-            return false;
-        }
-
-        // required as enumerator destroys paths when enumeration moves to the next value
-        Span<byte> accountPathBytes = stackalloc byte[NibblePath.FullKeccakByteLength];
-        var accountPath = NibblePath.Empty;
-
-        var count = 0;
-
-        // assert that all StorageCells have the same prefix
-        foreach (var item in map.EnumerateNibble(nibble))
-        {
-            if (accountPath.Equals(NibblePath.Empty))
-            {
-                // deep copy
-                NibblePath.ReadFrom(item.Key.Path.WriteTo(accountPathBytes), out accountPath);
-            }
-            else if (item.Key.Path.Equals(accountPath) == false)
-            {
-                // If there's at least one item that has a different key, it will be a regular page
-                address = default;
-                return false;
-            }
-
-            count++;
-        }
-
-        // Extract prefix only if all the entries share the prefix. Otherwise, fault with extraction
-        if (count < map.CountPushableDown())
-        {
-            address = default;
-            return false;
-        }
-
-        var prefixPage = ctx.Batch.GetNewPage(out address, true);
-
-        // this is the top page of the massive storage tree
-        prefixPage.Header.PageType = PageType.PrefixPage;
-
-        var dataPage = new DataPage(prefixPage);
-
-        // store prefix but truncated by one nibble as this is the nibble that is extracted
-        accountPath.SliceFrom(1).WriteTo(dataPage.Data.AccountPrefix);
-
-        foreach (var item in map.EnumerateNibble(nibble))
-        {
-            // Extract the prefix and store items under their raw keys of storage.
-            var key = Key.Raw(item.Key.StoragePath, item.Type, NibblePath.Empty);
-            dataPage = new DataPage(dataPage.Set(new SetContext(key, item.RawData, ctx.Batch, true)));
-
-            // fast delete by enumerator item
-            map.Delete(item);
-        }
-
-        return true;
     }
 }

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -2,9 +2,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text.Json.Serialization.Metadata;
 using Paprika.Data;
-using Paprika.Merkle;
 
 namespace Paprika.Store;
 

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -44,7 +44,7 @@ public readonly unsafe struct DataPage : IPage
         return Set(key, ctx.Data, ctx.Batch);
     }
 
-    private Page Set(in StoreKey key, in ReadOnlySpan<byte> data, IBatchContext batch)
+    public Page Set(in StoreKey key, in ReadOnlySpan<byte> data, IBatchContext batch)
     {
         if (Header.BatchId != batch.BatchId)
         {
@@ -296,7 +296,7 @@ public readonly unsafe struct DataPage : IPage
         return TryGet(k, (IPageResolver)batch, out result);
     }
 
-    private bool TryGet(StoreKey key, IPageResolver batch, out ReadOnlySpan<byte> result)
+    public bool TryGet(scoped StoreKey key, IPageResolver batch, out ReadOnlySpan<byte> result)
     {
         // read in-page
         var map = Map;

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -19,7 +19,7 @@ namespace Paprika.Store;
 /// </remarks>
 public readonly unsafe struct DataPage : IPage
 {
-    public const int BucketCount = 16;
+    private const int BucketCount = 16;
 
     private readonly Page _page;
 
@@ -30,7 +30,7 @@ public readonly unsafe struct DataPage : IPage
 
     public ref Payload Data => ref Unsafe.AsRef<Payload>(_page.Payload);
 
-    public const int NibbleCount = 1;
+    private const int NibbleCount = 1;
 
     /// <summary>
     /// Sets values for the given <see cref="SetContext.Key"/>
@@ -214,7 +214,10 @@ public readonly unsafe struct DataPage : IPage
         var start = capacities.IndexOfAnyExcept((ushort)0);
 
         if (start == -1)
+        {
+            // no child pages with non-zero capacities, default
             return false;
+        }
 
         // contains sorted from the smallest to the biggest capacity
         var nibblesWithSomeCapacity = nibbles.Slice(start);

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -24,6 +24,11 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// Checks whether the page was written during this batch.
     /// </summary>
     bool WasWritten(DbAddress addr);
+    
+    /// <summary>
+    /// Abandon this page from this batch on.
+    /// </summary>
+    void RegisterForFutureReuse(Page page);
 }
 
 public interface IReadOnlyBatchContext : IPageResolver

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -24,7 +24,7 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// Checks whether the page was written during this batch.
     /// </summary>
     bool WasWritten(DbAddress addr);
-    
+
     /// <summary>
     /// Abandon this page from this batch on.
     /// </summary>

--- a/src/Paprika/Store/IPageManager.cs
+++ b/src/Paprika/Store/IPageManager.cs
@@ -20,4 +20,9 @@ public interface IPageManager : IDisposable, IPageResolver
     /// Flushes underlying buffers.
     /// </summary>
     void Flush();
+
+    /// <summary>
+    /// Forces to flush the underlying no matter what flags they are
+    /// </summary>
+    void ForceFlush();
 }

--- a/src/Paprika/Store/IReporter.cs
+++ b/src/Paprika/Store/IReporter.cs
@@ -17,7 +17,7 @@ public interface IReporter
     /// </summary>
     void ReportPage(uint ageInBatches, PageType type);
 
-    void ReportItem(in Key key, ReadOnlySpan<byte> rawData);
+    void ReportItem(in StoreKey key, ReadOnlySpan<byte> rawData);
 }
 
 public class StatisticsReporter : IReporter
@@ -53,13 +53,13 @@ public class StatisticsReporter : IReporter
         PageTypes[type] = value + 1;
     }
 
-    public void ReportItem(in Key key, ReadOnlySpan<byte> rawData)
+    public void ReportItem(in StoreKey key, ReadOnlySpan<byte> rawData)
     {
         var index = GetKey(key, rawData);
 
         // total size
         const int slottedArraySlot = 4;
-        var keyEstimatedLength = key.Path.MaxByteLength + key.StoragePath.MaxByteLength + slottedArraySlot;
+        var keyEstimatedLength = key.Payload.Length + slottedArraySlot;
         var total = rawData.Length + keyEstimatedLength;
 
         ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(Sizes, index, out _);
@@ -76,7 +76,7 @@ public class StatisticsReporter : IReporter
     private const int KeyShift = 8;
     private const int KeyDiff = 1;
 
-    private static int GetKey(in Key key, in ReadOnlySpan<byte> data)
+    private static int GetKey(in StoreKey key, in ReadOnlySpan<byte> data)
     {
         var encoded = (int)key.Type;
         if ((key.Type & DataType.Merkle) != DataType.Merkle)

--- a/src/Paprika/Store/IReporter.cs
+++ b/src/Paprika/Store/IReporter.cs
@@ -1,4 +1,5 @@
-﻿using HdrHistogram;
+﻿using System.Runtime.InteropServices;
+using HdrHistogram;
 using Paprika.Data;
 using Paprika.Merkle;
 
@@ -25,9 +26,8 @@ public class StatisticsReporter : IReporter
     public readonly Dictionary<PageType, int> PageTypes = new();
     public int PageCount;
 
-    private const int SizeCount = (int)(DataType.Merkle + (byte)Node.Type.Branch) + 1;
-    public readonly long[] Sizes = new long[SizeCount];
-    public readonly SortedDictionary<int, IntHistogram> SizeHistograms = new();
+    public readonly Dictionary<int, long> Sizes = new();
+    public readonly Dictionary<int, IntHistogram> SizeHistograms = new();
 
     public readonly IntHistogram PageAge = new(uint.MaxValue, 5);
 
@@ -42,16 +42,8 @@ public class StatisticsReporter : IReporter
 
         lvl.ChildCount.RecordValue(filledBuckets);
 
-        if (type == PageType.Standard)
-        {
-            lvl.StandardEntries.RecordValue(entriesPerPage);
-            lvl.StandardCapacityLeft.RecordValue(capacityLeft);
-        }
-        else
-        {
-            lvl.PrefixedEntries.RecordValue(entriesPerPage);
-            lvl.PrefixedCapacityLeft.RecordValue(capacityLeft);
-        }
+        lvl.Entries.RecordValue(entriesPerPage);
+        lvl.CapacityLeft.RecordValue(capacityLeft);
     }
 
     public void ReportPage(uint ageInBatches, PageType type)
@@ -69,7 +61,9 @@ public class StatisticsReporter : IReporter
         const int slottedArraySlot = 4;
         var keyEstimatedLength = key.Path.MaxByteLength + key.StoragePath.MaxByteLength + slottedArraySlot;
         var total = rawData.Length + keyEstimatedLength;
-        Sizes[index] += total;
+        
+        ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(Sizes, index, out _);
+        value += total;
 
         if (!SizeHistograms.TryGetValue(index, out var histogram))
         {
@@ -79,40 +73,40 @@ public class StatisticsReporter : IReporter
         histogram.RecordValue(total);
     }
 
+    private const int KeyShift = 8;
+    private const int KeyDiff = 1;
+    
     private static int GetKey(in Key key, in ReadOnlySpan<byte> data)
     {
-        switch (key.Type)
+        var encoded = (int)key.Type;
+        if ((key.Type & DataType.Merkle) != DataType.Merkle)
         {
-            case DataType.Account:
-                return (int)DataType.Account;
-            case DataType.StorageCell:
-                return (int)DataType.StorageCell;
-            case DataType.Merkle:
-                Node.Header.ReadFrom(data, out var header);
-                return (int)(DataType.Merkle + (byte)header.NodeType);
+            return encoded;
         }
-
-        return 0;
+        
+        Node.Header.ReadFrom(data, out var header);
+        return encoded | (((int)header.NodeType + KeyDiff) << KeyShift);
     }
 
     public static string GetNameForSize(int i)
     {
-        return i switch
+        var type = (DataType)(i & 0xFF);
+        var str = type.ToString().Replace(", ", "-");
+
+        if (i >> KeyShift < KeyDiff)
         {
-            0 => nameof(DataType.Account),
-            1 => nameof(DataType.StorageCell),
-            _ => $"{nameof(DataType.Merkle)}-{((Node.Type)(i - 2)).ToString()}", // merkle
-        };
+            return str;
+        }
+
+        var merkleType = (Node.Type)((i >> KeyShift) - KeyDiff);
+        return $"{str}-{merkleType}";
     }
 
     public class Level
     {
         public readonly IntHistogram ChildCount = new(1000, 5);
 
-        public readonly IntHistogram StandardEntries = new(1000, 5);
-        public readonly IntHistogram StandardCapacityLeft = new(10000, 5);
-
-        public readonly IntHistogram PrefixedEntries = new(1000, 5);
-        public readonly IntHistogram PrefixedCapacityLeft = new(10000, 5);
+        public readonly IntHistogram Entries = new(1000, 5);
+        public readonly IntHistogram CapacityLeft = new(10000, 5);
     }
 }

--- a/src/Paprika/Store/IReporter.cs
+++ b/src/Paprika/Store/IReporter.cs
@@ -61,7 +61,7 @@ public class StatisticsReporter : IReporter
         const int slottedArraySlot = 4;
         var keyEstimatedLength = key.Path.MaxByteLength + key.StoragePath.MaxByteLength + slottedArraySlot;
         var total = rawData.Length + keyEstimatedLength;
-        
+
         ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(Sizes, index, out _);
         value += total;
 
@@ -75,7 +75,7 @@ public class StatisticsReporter : IReporter
 
     private const int KeyShift = 8;
     private const int KeyDiff = 1;
-    
+
     private static int GetKey(in Key key, in ReadOnlySpan<byte> data)
     {
         var encoded = (int)key.Type;
@@ -83,7 +83,7 @@ public class StatisticsReporter : IReporter
         {
             return encoded;
         }
-        
+
         Node.Header.ReadFrom(data, out var header);
         return encoded | (((int)header.NodeType + KeyDiff) << KeyShift);
     }

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -71,7 +71,9 @@ public enum PageType : byte
 
     Standard = 1,
 
-    Abandoned = 2
+    Identity = 2,
+
+    Abandoned = 3,
 }
 
 /// <summary>

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -63,17 +63,33 @@ public struct PageHeader
     /// The depth of the tree.
     /// </summary>
     [FieldOffset(6)] public byte Level;
+
+    /// <summary>
+    /// Internal metadata of the given page.
+    /// </summary>
+    [FieldOffset(7)] public byte Metadata;
 }
 
 public enum PageType : byte
 {
     None = 0,
 
+    /// <summary>
+    /// A standard Paprika page with a fan-out of 16.
+    /// </summary>
     Standard = 1,
 
+    /// <summary>
+    /// A page that is a Standard page but holds the account identity mappin.
+    /// </summary>
     Identity = 2,
 
     Abandoned = 3,
+
+    /// <summary>
+    /// The leaf page that represents a part of the page.
+    /// </summary>
+    Leaf = 4,
 }
 
 /// <summary>

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -58,6 +58,11 @@ public struct PageHeader
     /// The type of the page.
     /// </summary>
     [FieldOffset(5)] public PageType PageType;
+
+    /// <summary>
+    /// The depth of the tree.
+    /// </summary>
+    [FieldOffset(6)] public byte Level;
 }
 
 public enum PageType : byte
@@ -66,12 +71,7 @@ public enum PageType : byte
 
     Standard = 1,
 
-    /// <summary>
-    /// The page is a part of the tree use for massive storage accounts.
-    /// </summary>
-    PrefixPage = 2,
-
-    Abandoned = 3
+    Abandoned = 2
 }
 
 /// <summary>

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -129,7 +129,19 @@ public class MemoryMappedPageManager : PointerPageManager
         }
     }
 
-    public override void Flush() => _file.Flush(_flushToDisk);
+    public override void Flush()
+    {
+        if (_flushToDisk)
+        {
+            _file.Flush(true);
+        }
+    }
+
+    public override void ForceFlush()
+    {
+        _whole.Flush();
+        _file.Flush(true);
+    }
 
     public override void Dispose()
     {

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -20,6 +20,7 @@ public unsafe class NativeMemoryPageManager : PointerPageManager
     protected override void* Ptr => _ptr;
 
     public override void Flush() { }
+    public override void ForceFlush() { }
 
     public override void Dispose() => NativeMemory.AlignedFree(_ptr);
 

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -22,10 +22,11 @@ public unsafe class NativeMemoryPageManager : PointerPageManager
     public override void Flush()
     {
     }
+
     public override void ForceFlush()
     {
     }
-    
+
     public override void Dispose() => NativeMemory.AlignedFree(_ptr);
 
     public override ValueTask FlushPages(ICollection<DbAddress> addresses, CommitOptions options) =>

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Paprika.Data;
 
 namespace Paprika.Store.PageManagers;
 
@@ -38,6 +37,7 @@ public abstract unsafe class PointerPageManager : IPageManager
     public abstract ValueTask FlushRootPage(DbAddress rootPage, CommitOptions options);
 
     public abstract void Flush();
+    public abstract void ForceFlush();
 
     public abstract void Dispose();
 }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -660,7 +660,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
 
         public override bool WasWritten(DbAddress addr) => _written.Contains(addr);
 
-        protected override void RegisterForFutureReuse(Page page)
+        public override void RegisterForFutureReuse(Page page)
         {
             var addr = _db.GetAddress(page);
             _abandoned.Enqueue(addr);

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -46,12 +46,12 @@ public readonly unsafe struct RootPage : IPage
         /// The first of the data pages.
         /// </summary>
         [FieldOffset(DbAddress.Size)] public DbAddress DataRoot;
-        
+
         /// <summary>
         /// The root of the id pages.
         /// </summary>
         [FieldOffset(DbAddress.Size * 2)] public DbAddress IdRoot;
-        
+
         /// <summary>
         /// The account counter
         /// </summary>

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -27,7 +27,7 @@ public readonly unsafe struct RootPage : IPage
     {
         private const int Size = Page.PageSize - PageHeader.Size;
 
-        private const int MetadataStart = DbAddress.Size + DbAddress.Size;
+        private const int MetadataStart = 3 * DbAddress.Size + sizeof(uint);
 
         private const int AbandonedPagesStart = MetadataStart + Metadata.Size;
 
@@ -46,6 +46,16 @@ public readonly unsafe struct RootPage : IPage
         /// The first of the data pages.
         /// </summary>
         [FieldOffset(DbAddress.Size)] public DbAddress DataRoot;
+        
+        /// <summary>
+        /// The root of the id pages.
+        /// </summary>
+        [FieldOffset(DbAddress.Size * 2)] public DbAddress IdRoot;
+        
+        /// <summary>
+        /// The account counter
+        /// </summary>
+        [FieldOffset(DbAddress.Size * 3)] public uint AccountCounter;
 
         [FieldOffset(MetadataStart)]
         public Metadata Metadata;

--- a/src/Paprika/Store/SetContext.cs
+++ b/src/Paprika/Store/SetContext.cs
@@ -10,14 +10,12 @@ public readonly ref struct SetContext
     public readonly Key Key;
     public readonly IBatchContext Batch;
     public readonly ReadOnlySpan<byte> Data;
-    public readonly bool IsPrefixed;
 
-    public SetContext(Key key, ReadOnlySpan<byte> data, IBatchContext batch, bool isPrefixed = false)
+    public SetContext(Key key, ReadOnlySpan<byte> data, IBatchContext batch)
     {
         Key = key;
         Batch = batch;
         Data = data;
-        IsPrefixed = isPrefixed;
     }
 
     /// <summary>

--- a/src/Paprika/Store/StoreKey.cs
+++ b/src/Paprika/Store/StoreKey.cs
@@ -22,14 +22,14 @@ public readonly ref struct StoreKey
     private const byte OddNibblesShift = 3;
 
     public const int MaxByteSize = Keccak.Size + Keccak.Size + 1;
-    
+
     public static int GetMaxByteSize(in Key key)
     {
         if (key.IsAccountCompressed)
         {
             return key.Path.Length / 2 + GetNibblePathLength(key.StoragePath);
         }
-        
+
         return key.Path.Length == NibblePath.KeccakNibbleCount
             ? Keccak.Size + GetNibblePathLength(key.StoragePath)
             : GetNibblePathLength(key.Path);
@@ -64,15 +64,18 @@ public readonly ref struct StoreKey
             var raw = path.RawSpan;
             raw.CopyTo(destination);
 
+            var t = (byte)type;
+            Debug.Assert(t <= TypeMask, "Type should be selectable by mask");
+
             if (path.Length % 2 == 0)
             {
                 // even path, write last byte
-                destination[raw.Length] = (byte)type;
+                destination[raw.Length] = t;
                 return raw.Length + 1;
             }
 
             ref var last = ref destination[raw.Length - 1];
-            last = (byte)((last & LastByteMask) | OddNibbles | (byte)type);
+            last = (byte)((last & LastByteMask) | OddNibbles | t);
             return raw.Length;
         }
     }

--- a/src/Paprika/Store/StoreKey.cs
+++ b/src/Paprika/Store/StoreKey.cs
@@ -1,0 +1,89 @@
+﻿using System.Diagnostics;
+using Paprika.Crypto;
+using Paprika.Data;
+
+namespace Paprika.Store;
+
+public readonly ref struct StoreKey
+{
+    public readonly ReadOnlySpan<byte> Data;
+
+    private StoreKey(ReadOnlySpan<byte> data)
+    {
+        Data = data;
+    }
+
+    private const byte TypeMask = 0b0000_0011;
+    private const byte LastByteMask = 0b1111_0000;
+    private const byte OddNibbles = 0b0000_0100;
+    private const byte OddNibblesShift = 2;
+
+    public static int GetByteSize(in Key key)
+    {
+        return key.Path.Length == NibblePath.KeccakNibbleCount
+            ? Keccak.Size + GetNibblePathLength(key.StoragePath)
+            : GetNibblePathLength(key.Path);
+
+        static int GetNibblePathLength(in NibblePath path)
+        {
+            return path.Length % 2 == 0
+                ? path.Length / 2 + 1 // path is even, requires one more byte                  
+                : (path.Length + 1) / 2;
+        }
+    }
+
+    public static StoreKey Encode(in Key key, Span<byte> destination)
+    {
+        int written;
+        if (key.Path.Length == NibblePath.KeccakNibbleCount)
+        {
+            key.Path.RawSpan.CopyTo(destination);
+            written = Keccak.Size;
+
+            written += Write(key.StoragePath, destination.Slice(Keccak.Size), key.Type);
+            return new StoreKey(destination.Slice(0, written));
+        }
+        else
+        {
+            written = Write(key.Path, destination, key.Type);
+        }
+
+        return new StoreKey(destination.Slice(0, written));
+
+        static int Write(in NibblePath path, Span<byte> destination, DataType type)
+        {
+            var raw = path.RawSpan;
+            raw.CopyTo(destination);
+
+            if (path.Length % 2 == 0)
+            {
+                // even path, write last byte
+                destination[raw.Length] = (byte)type;
+                return raw.Length + 1;
+            }
+
+            ref var last = ref destination[raw.Length - 1];
+            last = (byte)((last & LastByteMask) | OddNibbles | (byte)type);
+            return raw.Length;
+        }
+    }
+
+    public byte GetNibbleAt(int offset)
+    {
+        Debug.Assert(offset < NibbleCount);
+
+        var b = Data[offset / 2];
+        var odd = offset & 1;
+        return (byte)((b >> ((1 - odd) * NibblePath.NibbleShift)) & 0x0F);
+    }
+
+    public int NibbleCount => (Data.Length - 1) * 2 + ((Data[^1] & OddNibbles) >> OddNibblesShift);
+
+    public StoreKey SliceTwoNibbles()
+    {
+        Debug.Assert(NibbleCount >= 2);
+        return new StoreKey(Data[1..]);
+    }
+
+    public DataType Type => (DataType)(Data[^1] & TypeMask);
+}

--- a/src/Paprika/Store/StoreKey.cs
+++ b/src/Paprika/Store/StoreKey.cs
@@ -93,7 +93,7 @@ public readonly ref struct StoreKey
 
     public StoreKey SliceTwoNibbles()
     {
-        Debug.Assert(NibbleCount >= 2);
+        Debug.Assert(Payload.Length > 1, "Trim to zero length of the payload is not allowed");
         return new StoreKey(Payload[1..]);
     }
 

--- a/src/Paprika/Store/StoreKey.cs
+++ b/src/Paprika/Store/StoreKey.cs
@@ -98,4 +98,6 @@ public readonly ref struct StoreKey
     }
 
     public DataType Type => (DataType)(Payload[^1] & TypeMask);
+
+    public override string ToString() => Payload.ToHexString(false);
 }


### PR DESCRIPTION
Introduces and `Importer` that does the import from `RocksDb` of `Nethermind` into Paprika's custom storage. To make it work it introduces the following changes:

1. Moves the concept of the Ethereum aware `Key` away from the `PagedDb`
2. Makes the `SlottedArray` is now based or raw `ReadOnlySpan<byte>` key
3. Introduces `StoreKey` that allows to efficiently encode `Key` into a `Span<byte>` wrapping structure
4. Introduces a mapping of account address to an int as a separate tree in the `PagedDb`. 
   1. This does not decrease the size of the database per se, but as the entries will repeatedly appear for same accounts, should decrease the size of the entry and number of updated pages.
   2. It introduces one additional layer of indirection meaning that the reads and writes will need to read/write through the id tree. It can be amortized later with some caching (this is not done now as it doesn't seem to be needed).
5. Merkle's `Node.Branch` that is full will have its value encoded as one byte instead of 3. This is a small improvement but should provide some space in upper layers of the `PagedDb` tree.
6. `IBatchContext` & co. allows now pages to be `RegisterForFutureReuse`. Whenever a page is no longer needed it can be abandoned with this call without leaking it out.
7. `DataPage` has the biggest change introduced with `Leaf` pages. Whenever the internal map of the page is full but it has no nibble children, it won't have the biggest nibble flushed first. It will use the buckets for addresses to create more pages with maps until they are full. Only once they are full they will be flushed down. This single change reduced the Sepolia size by 40%-50%. Should be observed with `Mainnet`.

Closes #156 
