### PR TITLE
Contract destruction

### DIFF
--- a/src/Paprika.Importer/Program.cs
+++ b/src/Paprika.Importer/Program.cs
@@ -52,7 +52,7 @@ var dataPath = Path.Combine(dir, "db");
 var dbExists = Directory.Exists(dataPath);
 
 const long GB = 1024 * 1024 * 1024;
-var size = (path.Contains("mainnet") ? 256 : 32) * GB;
+var size = (path.Contains("mainnet") ? 256ul : 32ul) * GB;
 
 if (dbExists)
 {

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -50,7 +50,7 @@ public class DbTests
                 var expected = GetValue(i);
 
                 read.ShouldHaveAccount(key, expected);
-                read.ShouldHaveStorage(key, key, expected);
+                read.AssertStorageValue(key, key, expected);
             }
         }
     }
@@ -169,7 +169,7 @@ public class DbTests
             for (int i = 0; i < count; i++)
             {
                 var address = GetStorageAddress(i);
-                read.ShouldHaveStorage(Key0, address, GetValue(i));
+                read.AssertStorageValue(Key0, address, GetValue(i));
             }
         }
 

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -46,6 +46,11 @@ public static class TestExtensions
         }
     }
 
+    public static void AssertNoAccount(this IReadOnlyBatch read, in Keccak key)
+    {
+        read.TryGet(Key.Account(key), out _).Should().BeFalse();
+    }
+
     public static Account GetAccount(this IReadOnlyBatch read, in Keccak key)
     {
         if (!read.TryGet(Key.Account(key), out var value))
@@ -72,11 +77,9 @@ public static class TestExtensions
         }
     }
 
-    public static void ShouldHaveStorage(this IReadOnlyBatch read, in Keccak key, in Keccak storage,
-        ReadOnlySpan<byte> expected)
+    public static void AssertNoStorageAt(this IReadOnlyBatch read, in Keccak key, in Keccak storage)
     {
-        read.TryGet(Key.StorageCell(NibblePath.FromKey(key), storage), out var value).Should().BeTrue();
-        value.SequenceEqual(expected);
+        read.TryGet(Key.StorageCell(NibblePath.FromKey(key), storage), out var value).Should().BeFalse();
     }
 
     public static void SetAccount(this IBatch batch, in Keccak key, ReadOnlySpan<byte> value) =>

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -726,6 +726,14 @@ public class Blockchain : IAsyncDisposable
 
         public void Apply(IBatch batch)
         {
+            if (_destroyed.Count > 0)
+            {
+                foreach (var account in _destroyed)
+                {
+                    batch.Destroy(NibblePath.FromKey(account));
+                }
+            }
+
             Apply(batch, _state);
             Apply(batch, _storage);
             Apply(batch, _preCommit);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -451,7 +451,7 @@ public class Blockchain : IAsyncDisposable
                     Key.ReadFrom(kvp.Key, out var key);
                     if (key.Path.Equals(searched))
                     {
-                        dict.Clean(kvp.Key, GetHash(key));
+                        dict.Destroy(kvp.Key, GetHash(key));
                     }
                 }
             }
@@ -480,7 +480,7 @@ public class Blockchain : IAsyncDisposable
 
             // check the span emptiness
             if (owner.Span.IsEmpty)
-                return default;
+                return new Account(0, 0);
 
             Account.ReadFrom(owner.Span, out var result);
             return result;

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -346,10 +346,14 @@ public class Blockchain : IAsyncDisposable
         public uint BlockNumber { get; }
 
         /// <summary>
-        /// A simple bloom filter to assert whether the given key was set in a given block,
-        /// used to speed up getting the keys.
+        /// A simple bloom filter to assert whether the given key was set in a given block, used to speed up getting the keys.
         /// </summary>
         private readonly HashSet<int> _bloom;
+
+        /// <summary>
+        /// Stores information about contracts that should have their previous incarnations destroyed.
+        /// </summary>
+        private readonly HashSet<Keccak> _destroyed;
 
         private readonly ReadOnlyBatchCountingRefs _batch;
         private Block[] _ancestors;
@@ -390,6 +394,8 @@ public class Blockchain : IAsyncDisposable
             // rent pages for the bloom
             _bloom = new HashSet<int>();
 
+            _destroyed = new HashSet<Keccak>();
+
             // as pre-commit can use parallelism, make the pooled dictionaries concurrent friendly:
             // 1. make the dictionary preserve once written values, which means that it can repeatedly read and set without worrying of ordering operations
             // 2. set dictionary so that it allows concurrent readers
@@ -427,6 +433,29 @@ public class Blockchain : IAsyncDisposable
         }
 
         private BufferPool Pool => _blockchain._pool;
+
+        public void DestroyAccount(in Keccak address)
+        {
+            var searched = NibblePath.FromKey(address);
+
+            Destroy(searched, _state);
+            Destroy(searched, _storage);
+
+            _destroyed.Add(address);
+            return;
+
+            static void Destroy(NibblePath searched, PooledSpanDictionary dict)
+            {
+                foreach (var kvp in dict)
+                {
+                    Key.ReadFrom(kvp.Key, out var key);
+                    if (key.Path.Equals(searched))
+                    {
+                        dict.Clean(kvp.Key, GetHash(key));
+                    }
+                }
+            }
+        }
 
         public Span<byte> GetStorage(in Keccak address, in Keccak storage, Span<byte> destination)
         {

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -621,6 +621,16 @@ public class Blockchain : IAsyncDisposable
             if (succeeded)
                 return owner;
 
+            if (key.Type is DataType.Account or DataType.StorageCell)
+            {
+                if (_destroyed.Contains(key.Path.UnsafeAsKeccak))
+                {
+                    // The key is account or the storage cell that belongs to a history of a destroyed account. Default
+                    succeeded = true;
+                    return default;
+                }
+            }
+
             var expected = BlockNumber - 1;
 
             // walk all the blocks locally

--- a/src/Paprika/Chain/IWorldState.cs
+++ b/src/Paprika/Chain/IWorldState.cs
@@ -11,13 +11,18 @@ public interface IWorldState : IDisposable
 
     uint BlockNumber { get; }
 
-    public Span<byte> GetStorage(in Keccak address, in Keccak storage, Span<byte> destination);
+    void SetAccount(in Keccak address, in Account account);
 
-    public void SetAccount(in Keccak address, in Account account);
+    Account GetAccount(in Keccak address);
 
-    public Account GetAccount(in Keccak address);
+    /// <summary>
+    /// Destroys the given account.
+    /// </summary>
+    void DestroyAccount(in Keccak address);
 
-    public void SetStorage(in Keccak address, in Keccak storage, ReadOnlySpan<byte> value);
+    Span<byte> GetStorage(in Keccak address, in Keccak storage, Span<byte> destination);
+
+    void SetStorage(in Keccak address, in Keccak storage, ReadOnlySpan<byte> value);
 
     /// <summary>
     /// Commits the block to the chain allowing to build upon it.

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Paprika.Crypto;
 using Paprika.Data;
@@ -113,6 +114,17 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         refValue = BuildValue(data0, data1);
     }
 
+    public void Clean(scoped ReadOnlySpan<byte> key, int hash)
+    {
+        var mixed = Mix(hash);
+        var tempKey = BuildKeyTemp(key, mixed);
+
+        ref var entry = ref CollectionsMarshal.GetValueRefOrNullRef(_dict, tempKey);
+        Debug.Assert(Unsafe.IsNullRef(ref entry) == false, "Can be used only to clean the existing entries");
+
+        // empty value span produces an empty span
+        entry = default;
+    }
 
     public Enumerator GetEnumerator() => new(this);
 

--- a/src/Paprika/IBatch.cs
+++ b/src/Paprika/IBatch.cs
@@ -18,6 +18,11 @@ public interface IBatch : IReadOnlyBatch
     void SetRaw(in Key key, ReadOnlySpan<byte> rawData);
 
     /// <summary>
+    /// Marks the given account as destroyed.
+    /// </summary>
+    void Destroy(in NibblePath account);
+
+    /// <summary>
     /// Commits the block returning its root hash.
     /// </summary>
     /// <param name="options">How to commit.</param>

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -500,6 +500,25 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             _root.Data.DataRoot = _db.GetAddress(updated);
         }
 
+        public void Destroy(in NibblePath account)
+        {
+            _db.ReportWrite();
+
+            // Get the id page
+            var ids = new DataPage(TryGetPageAlloc(ref _root.Data.IdRoot, PageType.Identity));
+
+            // Ensure that it exists
+            if (!ids.TryGet(account, this, out _))
+            {
+                return;
+            }
+
+            // Write empty data so that it is a delete
+            _root.Data.IdRoot = GetAddress(ids.Set(account, ReadOnlySpan<byte>.Empty, this));
+
+            // TODO: there' no garbage collection now while it should as data with the given prefix are left dangling
+        }
+
         private Page TryGetPageAlloc(ref DbAddress addr, PageType pageType)
         {
             CheckDisposed();


### PR DESCRIPTION
This PR introduces the semantics of contract destruction. It does it in the following way:

1. When a contract is destroyed:
   1. it has its state cleaned from the block
   1. it is remembered to be destroyed later
1. When applied on the `PageDb`, 
   1. first all contract destructions are applied moving their mapping in `IdTree` to a new number
   2. data are stored using the new mapping
   3. a destruction of the previous state&storage with the given number is scheduled in `PagedDb`

Remark: the garbage collection of destroyed accounts is not done yet.

Closes #117 