### PR TITLE
Xor filter and hashing improvements

### DIFF
--- a/src/Paprika.Tests/Utils/Xor8Tests.cs
+++ b/src/Paprika.Tests/Utils/Xor8Tests.cs
@@ -1,0 +1,43 @@
+﻿using System.Runtime.InteropServices;
+using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Utils;
+
+namespace Paprika.Tests.Utils;
+
+public class Xor8Tests
+{
+    [TestCase(10000)]
+    public void Empty(int count)
+    {
+        var filter = new Xor8(Array.Empty<ulong>());
+
+        const double falsePositiveRatio = 0.1;
+        var found = 0;
+
+        for (var i = 0; i < count; i++)
+        {
+            var key = unchecked((ulong)TestContext.CurrentContext.Random.NextInt64());
+            if (filter.MayContain(key))
+            {
+                found++;
+            }
+        }
+
+        ((double)found / count).Should().BeLessThan(falsePositiveRatio);
+    }
+
+    [TestCase(10_000)]
+    public void Test(int count)
+    {
+        var keys = new ulong[count];
+        TestContext.CurrentContext.Random.NextBytes(MemoryMarshal.Cast<ulong, byte>(keys));
+
+        var filter = new Xor8(keys);
+
+        foreach (var key in keys)
+        {
+            filter.MayContain(key).Should().BeTrue();
+        }
+    }
+}

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -1068,35 +1068,7 @@ public class Blockchain : IAsyncDisposable
 
     private static ulong GetHash(in Key key)
     {
-        var hash = (ulong)key.Type;
-
-        if (key.Path.Length == NibblePath.KeccakNibbleCount)
-        {
-            // either account, storage, or Merkle for storage
-            hash ^= key.Path.UnsafeAsKeccak.GetHashCodeUlong();
-
-            return hash ^ ProbeHash(key.StoragePath);
-        }
-
-        return hash ^ ProbeHash(key.Path);
-
-        static ulong ProbeHash(in NibblePath path)
-        {
-            if (path.Length == 0)
-                return 0;
-
-            var max = path.Length - 1;
-
-            // use only 32 bit here to not over-flood with GetAt
-            return (ulong)path.GetAt(0) ^
-                   ((ulong)path.GetAt(max / 8) << 4) ^
-                   ((ulong)path.GetAt(max * 2 / 8) << 8) ^
-                   ((ulong)path.GetAt(max * 3 / 8) << 12) ^
-                   ((ulong)path.GetAt(max * 4 / 8) << 16) ^
-                   ((ulong)path.GetAt(max * 5 / 8) << 20) ^
-                   ((ulong)path.GetAt(max * 6 / 8) << 24) ^
-                   ((ulong)path.GetAt(max * 7 / 8) << 28);
-        }
+        return unchecked((uint)key.GetHashCode());
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -505,6 +505,8 @@ public class Blockchain : IAsyncDisposable
 
         public void Reset()
         {
+            EnsureNotCommitted();
+
             _hash = ParentHash;
             _bloom.Clear();
             _destroyed = null;
@@ -614,10 +616,18 @@ public class Blockchain : IAsyncDisposable
             // clean precalculated hash
             _hash = null;
 
+            EnsureNotCommitted();
+
             var hash = GetHash(key);
             _bloom.Add(hash);
 
             dict.Set(key.WriteTo(stackalloc byte[key.MaxByteLength]), hash, payload);
+        }
+
+        private void EnsureNotCommitted()
+        {
+            if (_committed)
+                throw new Exception("This blocks has already been committed");
         }
 
         private void SetImpl(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1,

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -392,7 +392,7 @@ public class Blockchain : IAsyncDisposable
         /// <summary>
         /// A simple bloom filter to assert whether the given key was set in a given block, used to speed up getting the keys.
         /// </summary>
-        private HashSet<ulong>? _bloom;
+        private HashSet<int>? _bloom;
 
         /// <summary>
         /// A faster filter constructed on block commit.
@@ -439,7 +439,7 @@ public class Blockchain : IAsyncDisposable
             ParentHash = parentStateRoot;
 
             // rent pages for the bloom
-            _bloom = new HashSet<ulong>();
+            _bloom = new HashSet<int>();
             _destroyed = null;
 
             _hash = ParentHash;
@@ -768,7 +768,7 @@ public class Blockchain : IAsyncDisposable
         /// A recursive search through the block and its parent until null is found at the end of the weekly referenced
         /// chain.
         /// </summary>
-        private ReadOnlySpanOwner<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, ulong bloom,
+        private ReadOnlySpanOwner<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, int bloom,
             out bool succeeded)
         {
             var owner = TryGetLocal(key, keyWritten, bloom, out succeeded);
@@ -800,9 +800,9 @@ public class Blockchain : IAsyncDisposable
         /// Tries to get the key only from this block, acquiring no lease as it assumes that the lease is taken.
         /// </summary>
         public ReadOnlySpanOwner<byte> TryGetLocal(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten,
-            ulong bloom, out bool succeeded)
+            int bloom, out bool succeeded)
         {
-            var mayHave = _committed ? _xor!.MayContain(bloom) : _bloom!.Contains(bloom);
+            var mayHave = _committed ? _xor!.MayContain(unchecked((ulong)bloom)) : _bloom!.Contains(bloom);
 
             // check if the change is in the block
             if (!mayHave)
@@ -1026,7 +1026,7 @@ public class Blockchain : IAsyncDisposable
         /// A recursive search through the block and its parent until null is found at the end of the weekly referenced
         /// chain.
         /// </summary>
-        private ReadOnlySpanOwner<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, ulong bloom,
+        private ReadOnlySpanOwner<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, int bloom,
             out bool succeeded)
         {
             // walk all the blocks locally
@@ -1066,10 +1066,7 @@ public class Blockchain : IAsyncDisposable
             $"{nameof(BlockNumber)}: {BlockNumber}";
     }
 
-    private static ulong GetHash(in Key key)
-    {
-        return unchecked((uint)key.GetHashCode());
-    }
+    private static int GetHash(in Key key) => key.GetHashCode();
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -66,7 +66,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         AllocateNewPage();
     }
 
-    public bool TryGet(scoped ReadOnlySpan<byte> key, int hash, out ReadOnlySpan<byte> result)
+    public bool TryGet(scoped ReadOnlySpan<byte> key, ulong hash, out ReadOnlySpan<byte> result)
     {
         var mixed = Mix(hash);
         if (_dict.TryGetValue(BuildKeyTemp(key, mixed), out var value))
@@ -79,11 +79,11 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         return false;
     }
 
-    public void Set(scoped ReadOnlySpan<byte> key, int hash, ReadOnlySpan<byte> data) =>
+    public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data) =>
         Set(key, hash, data, ReadOnlySpan<byte>.Empty);
 
 
-    public void Set(scoped ReadOnlySpan<byte> key, int hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1)
+    public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1)
     {
         var mixed = Mix(hash);
 
@@ -117,7 +117,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         refValue = BuildValue(data0, data1);
     }
 
-    public void Destroy(scoped ReadOnlySpan<byte> key, int hash)
+    public void Destroy(scoped ReadOnlySpan<byte> key, ulong hash)
     {
         var mixed = Mix(hash);
         var tempKey = BuildKeyTemp(key, mixed);
@@ -200,7 +200,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
     private ValueSpan BuildValue(ReadOnlySpan<byte> value0, ReadOnlySpan<byte> value1) =>
         new(Write(value0, value1), (ushort)(value0.Length + value1.Length));
 
-    private static ushort Mix(int hash) => unchecked((ushort)((hash >> 16) ^ hash));
+    private static ushort Mix(ulong hash) => unchecked((ushort)((hash >> 48) ^ (hash >> 32) ^ (hash >> 16) ^ hash));
 
     private ReadOnlySpan<byte> GetAt(KeySpan key)
     {
@@ -341,6 +341,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
                     }
                     else
                         text.WriteLine($"Merkle, Storage [{S(key.Path)}, {key.StoragePath.ToString()}] (updated)");
+
                     break;
                 case DataType.CompressedAccount:
                     throw new Exception("Should not use compressed accounts");

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -66,7 +66,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         AllocateNewPage();
     }
 
-    public bool TryGet(scoped ReadOnlySpan<byte> key, ulong hash, out ReadOnlySpan<byte> result)
+    public bool TryGet(scoped ReadOnlySpan<byte> key, int hash, out ReadOnlySpan<byte> result)
     {
         var mixed = Mix(hash);
         if (_dict.TryGetValue(BuildKeyTemp(key, mixed), out var value))
@@ -79,11 +79,11 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         return false;
     }
 
-    public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data) =>
+    public void Set(scoped ReadOnlySpan<byte> key, int hash, ReadOnlySpan<byte> data) =>
         Set(key, hash, data, ReadOnlySpan<byte>.Empty);
 
 
-    public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1)
+    public void Set(scoped ReadOnlySpan<byte> key, int hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1)
     {
         var mixed = Mix(hash);
 
@@ -117,7 +117,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         refValue = BuildValue(data0, data1);
     }
 
-    public void Destroy(scoped ReadOnlySpan<byte> key, ulong hash)
+    public void Destroy(scoped ReadOnlySpan<byte> key, int hash)
     {
         var mixed = Mix(hash);
         var tempKey = BuildKeyTemp(key, mixed);
@@ -200,7 +200,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
     private ValueSpan BuildValue(ReadOnlySpan<byte> value0, ReadOnlySpan<byte> value1) =>
         new(Write(value0, value1), (ushort)(value0.Length + value1.Length));
 
-    private static ushort Mix(ulong hash) => unchecked((ushort)((hash >> 48) ^ (hash >> 32) ^ (hash >> 16) ^ hash));
+    private static ushort Mix(int hash) => unchecked((ushort)((hash >> 16) ^ hash));
 
     private ReadOnlySpan<byte> GetAt(KeySpan key)
     {

--- a/src/Paprika/Crypto/Keccak.cs
+++ b/src/Paprika/Crypto/Keccak.cs
@@ -116,6 +116,19 @@ public readonly struct Keccak : IEquatable<Keccak>
         return (int)v0 ^ (int)(v0 >> 32);
     }
 
+    public ulong GetHashCodeUlong()
+    {
+        var v0 = As<Vector256<byte>, ulong>(ref AsRef(in Bytes));
+        var v1 = Add(ref As<Vector256<byte>, ulong>(ref AsRef(in Bytes)), 1);
+        var v2 = Add(ref As<Vector256<byte>, ulong>(ref AsRef(in Bytes)), 2);
+        var v3 = Add(ref As<Vector256<byte>, ulong>(ref AsRef(in Bytes)), 3);
+        v0 ^= v1;
+        v2 ^= v3;
+        v0 ^= v2;
+
+        return v0;
+    }
+
     public override string ToString() => ToString(true);
 
     public string ToString(bool withZeroX) => Span.ToHexString(withZeroX);

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using Paprika.Crypto;
 using Paprika.Store;
@@ -96,14 +97,7 @@ public readonly ref partial struct Key
     [SkipLocalsInit]
     public override int GetHashCode()
     {
-        Span<byte> span = stackalloc byte[NibblePath.FullKeccakByteLength];
-
-        var hash = new HashCode();
-        hash.AddBytes(Path.WriteTo(span));
-        hash.AddBytes(StoragePath.WriteTo(span));
-        hash.Add((int)Type);
-
-        return hash.ToHashCode();
+        return unchecked((int)XxHash32.HashToUInt32(WriteTo(stackalloc byte[MaxByteLength])));
     }
 
     public override string ToString()

--- a/src/Paprika/Utils/Xor8.cs
+++ b/src/Paprika/Utils/Xor8.cs
@@ -1,0 +1,214 @@
+﻿using System.Numerics;
+
+namespace Paprika.Utils;
+
+/**
+ * The xor filter, a new algorithm that can replace a Bloom filter.
+ *
+ * It needs 1.23 log(1/fpp) bits per key. It is related to the BDZ algorithm [1]
+ * (a minimal perfect hash function algorithm).
+ *
+ * [1] paper: Simple and Space-Efficient Minimal Perfect Hash Functions -
+ * http://cmph.sourceforge.net/papers/wads07.pdf
+ */
+public class Xor8
+{
+    private const int BitsPerFingerprint = 8;
+    private const int Hashes = 3;
+    private const int Offset = 32;
+    private const int FactorTimes100 = 123;
+
+    private readonly int _blockLength;
+    private readonly ulong _seed;
+    private readonly byte[] _fingerprints;
+
+    private static int GetArrayLength(int size) => (int)(Offset + (long)FactorTimes100 * size / 100);
+
+    public Xor8(ulong[] keys)
+    {
+        var size = keys.Length;
+        var arrayLength = GetArrayLength(size);
+
+        _blockLength = arrayLength / Hashes;
+        var m = arrayLength;
+        var reverseOrder = new ulong[size];
+        var reverseH = new byte[size];
+        int reverseOrderPos;
+        ulong seed;
+    MainLoop:
+        do
+        {
+            seed = Hash.RandomSeed();
+            reverseOrderPos = 0;
+            var t2Count = new byte[m];
+            var t2 = new ulong[m];
+            foreach (var k in keys)
+            {
+                for (var hi = 0; hi < Hashes; hi++)
+                {
+                    var h = GetHash(k, seed, hi);
+                    t2[h] ^= k;
+                    if (t2Count[h] > 120)
+                    {
+                        // probably something wrong with the hash function
+                        goto MainLoop;
+                    }
+
+                    t2Count[h]++;
+                }
+            }
+
+            int[][] alone = new int[Hashes][];
+            for (var i = 0; i < Hashes; i++)
+            {
+                alone[i] = new int[_blockLength];
+            }
+
+            var alonePos = new int[Hashes];
+
+            for (var nextAlone = 0; nextAlone < Hashes; nextAlone++)
+            {
+                for (var i = 0; i < _blockLength; i++)
+                {
+                    if (t2Count[nextAlone * _blockLength + i] == 1)
+                    {
+                        alone[nextAlone][alonePos[nextAlone]++] = nextAlone * _blockLength + i;
+                    }
+                }
+            }
+
+            var found = -1;
+            while (true)
+            {
+                var i = -1;
+                for (var hi = 0; hi < Hashes; hi++)
+                {
+                    if (alonePos[hi] > 0)
+                    {
+                        i = alone[hi][--alonePos[hi]];
+                        found = hi;
+                        break;
+                    }
+                }
+
+                if (i == -1)
+                {
+                    // no entry found
+                    break;
+                }
+
+                if (t2Count[i] <= 0)
+                {
+                    continue;
+                }
+
+                var k = t2[i];
+                if (t2Count[i] != 1)
+                {
+                    throw new Exception("Assertion error");
+                }
+
+                --t2Count[i];
+                for (var hi = 0; hi < Hashes; hi++)
+                {
+                    if (hi != found)
+                    {
+                        var h = GetHash(k, seed, hi);
+                        int newCount = --t2Count[h];
+                        if (newCount == 1)
+                        {
+                            alone[hi][alonePos[hi]++] = h;
+                        }
+
+                        t2[h] ^= k;
+                    }
+                }
+
+                reverseOrder[reverseOrderPos] = k;
+                reverseH[reverseOrderPos] = (byte)found;
+                reverseOrderPos++;
+            }
+        } while (reverseOrderPos != size);
+
+        _seed = seed;
+
+        var fp = new byte[m];
+        for (var i = reverseOrderPos - 1; i >= 0; i--)
+        {
+            var k = reverseOrder[i];
+            int found = reverseH[i];
+            var change = -1;
+            var hash = Hash.Hash64(k, seed);
+            var xor = Fingerprint(hash);
+            for (var hi = 0; hi < Hashes; hi++)
+            {
+                var h = GetHash(k, seed, hi);
+                if (found == hi)
+                {
+                    change = h;
+                }
+                else
+                {
+                    xor ^= fp[h];
+                }
+            }
+
+            fp[change] = (byte)xor;
+        }
+
+        _fingerprints = new byte[m];
+        fp.CopyTo(_fingerprints, 0);
+    }
+
+    public bool MayContain(ulong key)
+    {
+        var hash = Hash.Hash64(key, _seed);
+        var f = Fingerprint(hash);
+        var r0 = (uint)hash;
+        var r1 = (uint)BitOperations.RotateLeft(hash, 21);
+        var r2 = (uint)BitOperations.RotateLeft(hash, 42);
+        var h0 = Hash.Reduce(r0, _blockLength);
+        var h1 = Hash.Reduce(r1, _blockLength) + _blockLength;
+        var h2 = Hash.Reduce(r2, _blockLength) + 2 * _blockLength;
+        f ^= _fingerprints[h0] ^ _fingerprints[h1] ^ _fingerprints[h2];
+        return (f & 0xff) == 0;
+    }
+
+    private int GetHash(ulong key, ulong seed, int index)
+    {
+        var r = BitOperations.RotateLeft(Hash.Hash64(key, seed), 21 * index);
+        r = Hash.Reduce((uint)r, _blockLength);
+        r = r + (ulong)(index * _blockLength);
+        return (int)r;
+    }
+
+    private static int Fingerprint(ulong hash) => (int)(hash & ((1 << BitsPerFingerprint) - 1));
+}
+
+public class Hash
+{
+    public static ulong Hash64(ulong x, ulong seed)
+    {
+        x += seed;
+        x = (x ^ (x >>> 33)) * 0xff51afd7ed558ccdL;
+        x = (x ^ (x >>> 33)) * 0xc4ceb9fe1a85ec53L;
+        x = x ^ (x >>> 33);
+        return x;
+    }
+
+    public static ulong RandomSeed() => unchecked((ulong)Random.Shared.NextInt64());
+
+    /**
+     * Shrink the hash to a value 0..n. Kind of like modulo, but using
+     * multiplication and shift, which are faster to compute.
+     *
+     * @param hash the hash
+     * @param n the maximum of the result
+     * @return the reduced value
+     */
+    public static uint Reduce(uint hash, int n)
+    {
+        // http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+        return (uint)(((hash & 0xffffffffL) * (n & 0xffffffffL)) >>> 32);
+    }
+}

--- a/src/Paprika/Utils/Xor8.cs
+++ b/src/Paprika/Utils/Xor8.cs
@@ -35,7 +35,7 @@ public class Xor8
     {
         // TODO: remove all array allocations, use ArrayPool<ulong> more and/or buffer pool, potentially combine chunks of memory together
 
-        
+
         var size = keys.Count;
         var arrayLength = GetArrayLength(size);
 
@@ -54,10 +54,10 @@ public class Xor8
         {
             seed = Hash.RandomSeed();
             reverseOrderPos = 0;
-            
+
             Array.Clear(t2Count);
             Array.Clear(t2);
-            
+
             foreach (var k in keys)
             {
                 for (var hi = 0; hi < Hashes; hi++)

--- a/src/Paprika/Utils/Xor8.cs
+++ b/src/Paprika/Utils/Xor8.cs
@@ -26,9 +26,9 @@ public class Xor8
 
     private static int GetArrayLength(int size) => (int)(Offset + (long)FactorTimes100 * size / 100);
 
-    public Xor8(ulong[] keys)
+    public Xor8(IReadOnlyCollection<ulong> keys)
     {
-        var size = keys.Length;
+        var size = keys.Count;
         var arrayLength = GetArrayLength(size);
 
         _blockLength = arrayLength / Hashes;

--- a/src/Paprika/Utils/Xor8.cs
+++ b/src/Paprika/Utils/Xor8.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers;
+using System.Collections;
 using System.Numerics;
 
 namespace Paprika.Utils;
@@ -25,6 +26,10 @@ public class Xor8
     private readonly byte[] _fingerprints;
 
     private static int GetArrayLength(int size) => (int)(Offset + (long)FactorTimes100 * size / 100);
+
+    public Xor8(IReadOnlyCollection<int> keys) : this(new ReadonlyUlong(keys))
+    {
+    }
 
     public Xor8(IReadOnlyCollection<ulong> keys)
     {
@@ -221,4 +226,26 @@ public class Xor8
             return (uint)(((hash & 0xffffffffL) * (n & 0xffffffffL)) >>> 32);
         }
     }
+}
+
+file class ReadonlyUlong : IReadOnlyCollection<ulong>
+{
+    private readonly IReadOnlyCollection<int> _ints;
+
+    public ReadonlyUlong(IReadOnlyCollection<int> ints)
+    {
+        _ints = ints;
+    }
+
+    public IEnumerator<ulong> GetEnumerator()
+    {
+        foreach (var i in _ints)
+        {
+            yield return unchecked((ulong)i);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public int Count => _ints.Count;
 }

--- a/src/Paprika/Utils/Xor8.cs
+++ b/src/Paprika/Utils/Xor8.cs
@@ -183,32 +183,33 @@ public class Xor8
     }
 
     private static int Fingerprint(ulong hash) => (int)(hash & ((1 << BitsPerFingerprint) - 1));
+
+    private static class Hash
+    {
+        public static ulong Hash64(ulong x, ulong seed)
+        {
+            x += seed;
+            x = (x ^ (x >>> 33)) * 0xff51afd7ed558ccdL;
+            x = (x ^ (x >>> 33)) * 0xc4ceb9fe1a85ec53L;
+            x = x ^ (x >>> 33);
+            return x;
+        }
+
+        public static ulong RandomSeed() => unchecked((ulong)Random.Shared.NextInt64());
+
+        /**
+         * Shrink the hash to a value 0..n. Kind of like modulo, but using
+         * multiplication and shift, which are faster to compute.
+         *
+         * @param hash the hash
+         * @param n the maximum of the result
+         * @return the reduced value
+         */
+        public static uint Reduce(uint hash, int n)
+        {
+            // http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+            return (uint)(((hash & 0xffffffffL) * (n & 0xffffffffL)) >>> 32);
+        }
+    }
 }
 
-public class Hash
-{
-    public static ulong Hash64(ulong x, ulong seed)
-    {
-        x += seed;
-        x = (x ^ (x >>> 33)) * 0xff51afd7ed558ccdL;
-        x = (x ^ (x >>> 33)) * 0xc4ceb9fe1a85ec53L;
-        x = x ^ (x >>> 33);
-        return x;
-    }
-
-    public static ulong RandomSeed() => unchecked((ulong)Random.Shared.NextInt64());
-
-    /**
-     * Shrink the hash to a value 0..n. Kind of like modulo, but using
-     * multiplication and shift, which are faster to compute.
-     *
-     * @param hash the hash
-     * @param n the maximum of the result
-     * @return the reduced value
-     */
-    public static uint Reduce(uint hash, int n)
-    {
-        // http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-        return (uint)(((hash & 0xffffffffL) * (n & 0xffffffffL)) >>> 32);
-    }
-}


### PR DESCRIPTION
This PR introduces [XorFilter](https://github.com/FastFilter/fastfilter_java) port, to Paprika. As profiling showed, over 70% of the time of retrieving data was spent in the `FindItemIndex`. With the synthetic load and a much larger numer of false positives this PR gets **50% better throughput** 🤯 

## Profiling

### Before

#### Paprika.Runner

![image](https://github.com/NethermindEth/Paprika/assets/519707/cf577233-7755-489b-8759-8f5fa323371c)

#### Nethermind - Sepolia

![image](https://github.com/NethermindEth/Paprika/assets/519707/98f0de6c-033e-40a4-a369-a4cc0202f623)

![image](https://github.com/NethermindEth/Paprika/assets/519707/78a1b401-56cb-42ba-82c1-167fb3338212)

### After

#### Paprika.Runner

![image](https://github.com/NethermindEth/Paprika/assets/519707/f1f3c0af-1f3d-4d66-b2cf-c82c150e9649)

