### PR TITLE
Root hash checking

### DIFF
--- a/src/Paprika.Cli/Paprika.Cli.csproj
+++ b/src/Paprika.Cli/Paprika.Cli.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Spectre.Console.Cli" Version="0.48.1-preview.0.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Paprika\Paprika.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Paprika.Cli/Program.cs
+++ b/src/Paprika.Cli/Program.cs
@@ -1,0 +1,69 @@
+﻿using System.Diagnostics;
+using Paprika.Chain;
+using Paprika.Merkle;
+using Paprika.Store;
+using Paprika.Store.PageManagers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+var app = new CommandApp();
+app.Configure(cfg =>
+{
+    cfg.AddCommand<ValidateRootHashesSettingsCommand>("validate");
+    cfg.SetExceptionHandler(ex =>
+    {
+        AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+        return -99;
+    });
+});
+
+await app.RunAsync(args);
+
+public class ValidateRootHashesSettings : CommandSettings
+{
+    [CommandArgument(0, "<path>")]
+    public string Path { get; set; }
+
+    [CommandArgument(1, "<historyDepth>")]
+    public byte HistoryDepth { get; set; }
+}
+
+public class ValidateRootHashesSettingsCommand : AsyncCommand<ValidateRootHashesSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, ValidateRootHashesSettings settings)
+    {
+        var file = MemoryMappedPageManager.GetPaprikaFilePath(settings.Path);
+        if (File.Exists(file) == false)
+            throw new FileNotFoundException("Paprika file was not found", file);
+
+        var length = new FileInfo(file).Length;
+
+        using var db = PagedDb.MemoryMappedDb((ulong)length, settings.HistoryDepth, settings.Path);
+
+        // configure merkle to memoize none and recalculate all
+        const int none = int.MaxValue;
+        var merkle = new ComputeMerkleBehavior(true, none, none, false);
+
+        await using var blockchain = new Blockchain(db, merkle);
+        using var batch = blockchain.StartReadOnlyLatestFromDb();
+
+        AnsiConsole.MarkupLine("[grey]Calculation in progress...[/]");
+
+        var sw = Stopwatch.StartNew();
+        var hash = merkle.CalculateStateRootHash(batch);
+        var took = sw.Elapsed;
+
+        AnsiConsole.MarkupLine($"[grey]Calculation took: {took}[/]");
+
+        if (hash == batch.Hash)
+        {
+            AnsiConsole.MarkupLine($"[green]Recalculated hash matches the expected {hash.ToString(true)}[/]");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine($"[red] Recalculated hash {hash.ToString(true)} " +
+                                   $"is different than one memoized {batch.Hash.ToString(true)}[/]");
+
+        return -1;
+    }
+}

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -180,7 +180,20 @@ public static class TestExtensions
 
         chain.Flushed += (_, block) =>
         {
-            if (block == blockNumber)
+            if (block.blockNumber == blockNumber)
+                tcs.SetResult();
+        };
+
+        return tcs.Task;
+    }
+
+    public static Task WaitTillFlush(this Blockchain chain, Keccak hash)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        chain.Flushed += (_, block) =>
+        {
+            if (block.blockHash == hash)
                 tcs.SetResult();
         };
 

--- a/src/Paprika.sln
+++ b/src/Paprika.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Runner", "Paprika.R
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Benchmarks", "Paprika.Benchmarks\Paprika.Benchmarks.csproj", "{FFAD2237-381A-4FC5-ACB9-14658C6ADCE9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Cli", "Paprika.Cli\Paprika.Cli.csproj", "{ABF0EAEF-C6CF-4ED4-A340-8A7708C05516}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{BFF87BF1-D687-4EBF-B60C-3B67184A8A7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44B0A996-A65A-4BFE-B9F6-708D5A7E54C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{44B0A996-A65A-4BFE-B9F6-708D5A7E54C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABF0EAEF-C6CF-4ED4-A340-8A7708C05516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABF0EAEF-C6CF-4ED4-A340-8A7708C05516}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABF0EAEF-C6CF-4ED4-A340-8A7708C05516}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABF0EAEF-C6CF-4ED4-A340-8A7708C05516}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -30,7 +30,7 @@ public class MemoryMappedPageManager : PointerPageManager
     public unsafe MemoryMappedPageManager(ulong size, byte historyDepth, string dir,
         PersistenceOptions options = PersistenceOptions.FlushFile) : base(size)
     {
-        Path = System.IO.Path.Combine(dir, PaprikaFileName);
+        Path = GetPaprikaFilePath(dir);
 
         if (!File.Exists(Path))
         {
@@ -62,6 +62,8 @@ public class MemoryMappedPageManager : PointerPageManager
         _whole.SafeMemoryMappedViewHandle.AcquirePointer(ref _ptr);
         _options = options;
     }
+
+    public static string GetPaprikaFilePath(string dir) => System.IO.Path.Combine(dir, PaprikaFileName);
 
     public string Path { get; }
 


### PR DESCRIPTION
This PR enables root hash check, by introducing a new method in the `Merkle` behavior. This method allows to walk through all the values in the database and ignore previously precalculated ones. This gives a state root hash that is calculated bottom-up. 

Additionally, this PR adds a small `CLI` that allows to run the method described above. Maybe, in the future it can be extended with other tools, like the stats analyzer etc.