### PR TITLE
Finalization handling

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -60,7 +60,8 @@ public class Blockchain : IAsyncDisposable
         {
             _finalizedChannel = Channel.CreateUnbounded<BlockState>(new UnboundedChannelOptions
             {
-                SingleReader = true, SingleWriter = true,
+                SingleReader = true,
+                SingleWriter = true,
             });
         }
         else
@@ -68,7 +69,9 @@ public class Blockchain : IAsyncDisposable
             _finalizedChannel = Channel.CreateBounded<BlockState>(
                 new BoundedChannelOptions(finalizationQueueLimit.Value)
                 {
-                    SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait,
+                    SingleReader = true,
+                    SingleWriter = true,
+                    FullMode = BoundedChannelFullMode.Wait,
                 });
         }
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -282,7 +282,7 @@ public class Blockchain : IAsyncDisposable
 
             ancestor.AcquireLease(); // lease it!
             ancestors.Add(ancestor);
-            parentKeccak = ancestor.ParentHash;
+            parentKeccak = Normalize(ancestor.ParentHash);
         }
 
         return (batch, ancestors.ToArray());


### PR DESCRIPTION
This PR changes the finalization handling and ordering in how a new state is constructed. Previously, it walked through the blocks only then to search for the state. What if the state was already overwritten? 💥 . After this PR, first the state is captured from the database and only then blocks are searched to match the gap.

This is a direct result of `Sepolia` dry runs.