### PR TITLE
Faster Xor filter

### DIFF
--- a/src/Paprika.Benchmarks/XorBenchmarks.cs
+++ b/src/Paprika.Benchmarks/XorBenchmarks.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Paprika.Utils;
+
+namespace Paprika.Benchmarks;
+
+[DisassemblyDiagnoser(maxDepth: 2)]
+public class XorBenchmarks
+{
+    private const int Size = 2000;
+    private ulong[] _keys;
+    private Xor8 _xor8;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(13);
+
+        _keys = new ulong[Size];
+        random.NextBytes(MemoryMarshal.Cast<ulong, byte>(_keys));
+        _xor8 = new Xor8(_keys);
+    }
+
+    [Benchmark]
+    public bool MayContain()
+    {
+        var accumulator = false;
+        for (var i = 0; i < _keys!.Length; i++)
+        {
+            accumulator ^= _xor8.MayContain(_keys[i]);
+        }
+
+        return accumulator;
+    }
+}


### PR DESCRIPTION
This PR greatly (by over 40%) speeds up the querying of the `Xor8` filter that is used heavily by Paprika. It does it by:

1. skipping length checks on the array (direct ref access)
2. aggressively inlining the hashing function

A bechmark is added to support the claims.

`SkipLocalsInit` and `AggressiveOptimizations` were tested but they provide no gain.

### Benchmarks

```

BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.2715/22H2/2022Update/SunValley2)
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK 7.0.114
  [Host]     : .NET 7.0.14 (7.0.1423.51910), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.14 (7.0.1423.51910), X64 RyuJIT AVX2


```
|     Method |     Mean |    Error |   StdDev |   Median | Code Size |
|----------- |---------:|---------:|---------:|---------:|----------:|
| MayContain (before) | 12.71 μs | 0.925 μs | 2.728 μs | 14.36 μs |     366 B |
| MayContain (after) | 7.161 μs | 0.0835 μs | 0.0781 μs |    | 300 B |
