### PR TITLE
Provide metatada about query retrieval

### DIFF
--- a/src/Paprika.Tests/Merkle/Commit.cs
+++ b/src/Paprika.Tests/Merkle/Commit.cs
@@ -72,23 +72,23 @@ public class Commit : ICommit
         Assert.Fail(sb.ToString());
     }
 
-    ReadOnlySpanOwner<byte> ICommit.Get(scoped in Key key)
+    ReadOnlySpanOwnerWithMetadata<byte> ICommit.Get(scoped in Key key)
     {
         var k = GetKey(key);
 
         if (_after.TryGetValue(k, out var value))
         {
-            return new ReadOnlySpanOwner<byte>(value, null);
+            return new ReadOnlySpanOwner<byte>(value, null).WithDepth(0);
         }
 
         if (_before.TryGetValue(k, out value))
         {
-            return new ReadOnlySpanOwner<byte>(value, null);
+            return new ReadOnlySpanOwner<byte>(value, null).WithDepth(0);
         }
 
         if (_history.TryGetValue(k, out value))
         {
-            return new ReadOnlySpanOwner<byte>(value, null);
+            return new ReadOnlySpanOwner<byte>(value, null).WithDepth(0);
         }
 
         return default;
@@ -156,10 +156,10 @@ public class Commit : ICommit
 
         public void Dispose() => _data.Clear();
 
-        public ReadOnlySpanOwner<byte> Get(scoped in Key key)
+        public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
         {
             return _data.TryGetValue(GetKey(key), out var value)
-                ? new ReadOnlySpanOwner<byte>(value, null)
+                ? new ReadOnlySpanOwner<byte>(value, null).WithDepth(0)
                 : _commit.Get(key);
         }
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -657,7 +657,7 @@ public class Blockchain : IAsyncDisposable
             dict.Set(key.WriteTo(stackalloc byte[key.MaxByteLength]), hash, payload0, payload1);
         }
 
-        ReadOnlySpanOwner<byte> ICommit.Get(scoped in Key key) => Get(key);
+        ReadOnlySpanOwnerWithMetadata<byte> ICommit.Get(scoped in Key key) => Get(key);
 
         void ICommit.Set(in Key key, in ReadOnlySpan<byte> payload) => SetImpl(key, payload, _preCommit);
 
@@ -719,14 +719,14 @@ public class Blockchain : IAsyncDisposable
                 _parent = parent;
             }
 
-            public ReadOnlySpanOwner<byte> Get(scoped in Key key)
+            public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
             {
                 var hash = GetHash(key);
                 var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
 
                 if (_dict.TryGet(keyWritten, hash, out var result))
                 {
-                    return new ReadOnlySpanOwner<byte>(result, null);
+                    return new ReadOnlySpanOwnerWithMetadata<byte>(new ReadOnlySpanOwner<byte>(result, null), 0);
                 }
 
                 return _parent.Get(key);
@@ -766,7 +766,7 @@ public class Blockchain : IAsyncDisposable
             public override string ToString() => _dict.ToString();
         }
 
-        private ReadOnlySpanOwner<byte> Get(scoped in Key key)
+        private ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
         {
             Debug.Assert(_committed == false,
                 "The block is committed and it cleaned up some of its dependencies. It cannot provide data for Get method");
@@ -784,19 +784,23 @@ public class Blockchain : IAsyncDisposable
         /// A recursive search through the block and its parent until null is found at the end of the weekly referenced
         /// chain.
         /// </summary>
-        private ReadOnlySpanOwner<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, int bloom,
+        private ReadOnlySpanOwnerWithMetadata<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, int bloom,
             out bool succeeded)
         {
             var owner = TryGetLocal(key, keyWritten, bloom, out succeeded);
             if (succeeded)
-                return owner;
+                return owner.WithDepth(0);
+
+            ushort depth = 1;
 
             // walk all the blocks locally
             foreach (var ancestor in _ancestors)
             {
                 owner = ancestor.TryGetLocal(key, keyWritten, bloom, out succeeded);
                 if (succeeded)
-                    return owner;
+                    return owner.WithDepth(depth);
+
+                depth++;
             }
 
             if (_batch.TryGet(key, out var span))
@@ -804,7 +808,7 @@ public class Blockchain : IAsyncDisposable
                 // return leased batch
                 succeeded = true;
                 _batch.AcquireLease();
-                return new ReadOnlySpanOwner<byte>(span, _batch);
+                return new ReadOnlySpanOwner<byte>(span, _batch).FromDatabase();
             }
 
             // report as succeeded operation. The value is not there but it was walked through.
@@ -1027,7 +1031,7 @@ public class Blockchain : IAsyncDisposable
         }
 
 
-        public ReadOnlySpanOwner<byte> Get(scoped in Key key)
+        public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
         {
             var hash = GetHash(key);
             var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
@@ -1042,15 +1046,17 @@ public class Blockchain : IAsyncDisposable
         /// A recursive search through the block and its parent until null is found at the end of the weekly referenced
         /// chain.
         /// </summary>
-        private ReadOnlySpanOwner<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, int bloom,
+        private ReadOnlySpanOwnerWithMetadata<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, int bloom,
             out bool succeeded)
         {
+            ushort depth = 1;
+
             // walk all the blocks locally
             foreach (var ancestor in _ancestors)
             {
                 var owner = ancestor.TryGetLocal(key, keyWritten, bloom, out succeeded);
                 if (succeeded)
-                    return owner;
+                    return owner.WithDepth(1);
             }
 
             if (_batch.TryGet(key, out var span))
@@ -1058,7 +1064,7 @@ public class Blockchain : IAsyncDisposable
                 // return leased batch
                 succeeded = true;
                 _batch.AcquireLease();
-                return new ReadOnlySpanOwner<byte>(span, _batch);
+                return new ReadOnlySpanOwner<byte>(span, _batch).FromDatabase();
             }
 
             // report as succeeded operation. The value is not there but it was walked through.

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -37,12 +37,12 @@ public interface IPreCommitBehavior
 public interface ICommit
 {
     /// <summary>
-    /// Tries to retrieve the result stored under the given key only from this commit.
+    /// Tries to retrieve the result stored under the given key.
     /// </summary>
     /// <remarks>
-    /// If successful, returns a result as an owner. Must be disposed properly.
+    /// Returns a result as an owner that must be disposed properly (using var owner = Get)
     /// </remarks>
-    public ReadOnlySpanOwner<byte> Get(scoped in Key key);
+    public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key);
 
     /// <summary>
     /// Sets the value under the given key.
@@ -81,7 +81,7 @@ public interface IReadOnlyCommit
     /// <remarks>
     /// If successful, returns a result as an owner. Must be disposed properly.
     /// </remarks>
-    public ReadOnlySpanOwner<byte> Get(scoped in Key key);
+    public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key);
 }
 
 public interface IChildCommit : ICommit, IDisposable
@@ -96,3 +96,51 @@ public interface IChildCommit : ICommit, IDisposable
 /// A delegate to be called on the each key that that the commit contains.
 /// </summary>
 public delegate void CommitAction(in Key key, ReadOnlySpan<byte> value);
+
+/// <summary>
+/// Provides the same capability as <see cref="ReadOnlySpanOwner{T}"/> but with the additional metadata.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public readonly ref struct ReadOnlySpanOwnerWithMetadata<T>
+{
+    public const ushort DatabaseQueryDepth = ushort.MaxValue;
+
+    /// <summary>
+    /// Provides the depths of the query to retrieve the value.
+    ///
+    /// 0 is for the current commit.
+    /// 1-N is for blocks
+    /// <see cref="DatabaseQueryDepth"/> is for a query hitting the db transaction. 
+    /// </summary>
+    public ushort QueryDepth { get; }
+    private readonly ReadOnlySpanOwner<T> _owner;
+
+    public ReadOnlySpanOwnerWithMetadata(ReadOnlySpanOwner<T> owner, ushort queryDepth)
+    {
+        QueryDepth = queryDepth;
+        _owner = owner;
+    }
+
+    public ReadOnlySpan<T> Span => _owner.Span;
+
+    public bool IsEmpty => _owner.IsEmpty;
+
+    /// <summary>
+    /// Disposes the owner provided as <see cref="IDisposable"/> once.
+    /// </summary>
+    public void Dispose() => _owner.Dispose();
+
+    /// <summary>
+    /// Answers whether this span is owned and provided by <paramref name="owner"/>.
+    /// </summary>
+    public bool IsOwnedBy(object owner) => _owner.IsOwnedBy(owner);
+}
+
+public static class ReadOnlySpanOwnerExtensions
+{
+    public static ReadOnlySpanOwnerWithMetadata<T> WithDepth<T>(this ReadOnlySpanOwner<T> owner, ushort depth) =>
+        new(owner, depth);
+
+    public static ReadOnlySpanOwnerWithMetadata<T> FromDatabase<T>(this ReadOnlySpanOwner<T> owner) =>
+        new(owner, ReadOnlySpanOwnerWithMetadata<T>.DatabaseQueryDepth);
+}

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -113,6 +113,9 @@ public readonly ref struct ReadOnlySpanOwnerWithMetadata<T>
     /// <see cref="DatabaseQueryDepth"/> is for a query hitting the db transaction. 
     /// </summary>
     public ushort QueryDepth { get; }
+
+    public bool IsDbQuery => QueryDepth == DatabaseQueryDepth;
+
     private readonly ReadOnlySpanOwner<T> _owner;
 
     public ReadOnlySpanOwnerWithMetadata(ReadOnlySpanOwner<T> owner, ushort queryDepth)

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -116,7 +116,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             _allowChildCommits = allowChildCommits;
         }
 
-        public ReadOnlySpanOwner<byte> Get(scoped in Key key) => _readOnly.Get(key);
+        public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key) => _readOnly.Get(key);
 
         public void Set(in Key key, in ReadOnlySpan<byte> payload)
         {
@@ -607,7 +607,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
         public void SetPrefix(in Keccak keccak) => _keccak = keccak;
 
-        public ReadOnlySpanOwner<byte> Get(scoped in Key key) => _commit.Get(Build(key));
+        public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key) => _commit.Get(Build(key));
 
         public void Set(in Key key, in ReadOnlySpan<byte> payload) => _commit.Set(Build(key), in payload);
 
@@ -637,7 +637,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                 _commit = commit;
             }
 
-            public ReadOnlySpanOwner<byte> Get(scoped in Key key) => _commit.Get(_parent.Build(key));
+            public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key) => _commit.Get(_parent.Build(key));
 
             public void Set(in Key key, in ReadOnlySpan<byte> payload) => _commit.Set(_parent.Build(key), payload);
 


### PR DESCRIPTION
This PR introduces additional metadata returned whenever data are retrieved from `ICommit`. This should enable various components, like `Merkle` to reason whether it's worth to write retrieved value again to make it more recent. By more recent I mean:

1. closer to the head - the value is written in the current block and then moved with each advancement to the past
2. closer in the database - Paprika DB uses a B-epsilon prefix tree with an embedded LRU behavior

If the metadata are used to write more often, the database will get more reads. This might help though in a long run as the data will be more accessible in the blocks that are in memory and more close to the root in the database.


```csharp
using var owner = commit.Get(key);

if (owner.IsEmpty)
{
   return;
}

if (owner.IsDbQuery)
{
   // getting the value required querying the database, do something so that it does not happen that often
}

```