### PR TITLE
Paprika db queries refresh behavior

### DIFF
--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -18,7 +18,7 @@ public static class Program
     private const int MaxReorgDepth = 64;
     private const int FinalizeEvery = 128;
 
-    private const int BlockCount = 500_000;
+    private const int BlockCount = 50_000;
 
     private const int AccountCount = 1_000_000;
     private const int ContractCount = 50_000;
@@ -89,7 +89,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior(true, 1, 1);
+            using var preCommit = new ComputeMerkleBehavior(true, 1, 1, true, 100);
 
             var blockHash = Keccak.EmptyTreeHash;
             var finalization = new Queue<Keccak>();

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -116,6 +116,8 @@ public readonly ref struct ReadOnlySpanOwnerWithMetadata<T>
 
     public bool IsDbQuery => QueryDepth == DatabaseQueryDepth;
 
+    public bool SetAtThisBlock => QueryDepth == 0;
+
     private readonly ReadOnlySpanOwner<T> _owner;
 
     public ReadOnlySpanOwnerWithMetadata(ReadOnlySpanOwner<T> owner, ushort queryDepth)

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -59,7 +59,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     /// <param name="memoizeRlp">Whether the RLP of branches should be memoized in memory (but not stored)
     /// to limit the number of lookups for the children and their Keccak recalculation.
     /// This includes invalidating the memoized RLP whenever a path that it caches is marked as dirty.</param>
-    /// <param name="refreshBudget">How many time per block values that were retrieved from database can be put in front
+    /// <param name="refreshBudget">How many values per block, that were retrieved from database, can be put in front
     /// of it so that they are more fresh.</param>
     public ComputeMerkleBehavior(bool fullMerkle = true,
         int minimumTreeLevelToMemoizeKeccak = DefaultMinimumTreeLevelToMemoizeKeccak,


### PR DESCRIPTION
This PR introduces a new parameter that defines budget for re-setting values that are retrieved from the database. 
Data retrieved from the depth of the database may cost a while to get them. As #202 introduced additional metadata, the information about whether a given value was retrieved from the database or not, can be used to determine whether to bump up the key-value pair. The bump up happens by setting the value again in the current commit It should have the following effects:

1. make the data available for other parts of the Merkle process. For example `MarkPathDirty` can refresh a leaf so that the compute do not re-retrieve it. This should limit the calculation time
2. make the data available for the forthcoming blocks. With a budget of `100` and the depth of the finalization queue at ~90, up to 9,000 values would be kept warm in the memory
3. make the values closer to the root in the database so that it can query them faster

The last effect is based on the LRU behavior of the internal Paprika db. If the database is left is, it can only optimize it in time. If a database is changed, it will suffer from some additional writes.

The entries that have their values re-set:

1. Merkle leaf. If a leaf data came from db, and there's a budget in the commit, set it cause as they are read, they might be re-read in near future.
2. Value that is Merkleized. Same as above.
3. Branch. Update it less often but when it comes from db, try to update.