### PR TITLE
Caching and work redistribution

### DIFF
--- a/src/Paprika.Cli/Program.cs
+++ b/src/Paprika.Cli/Program.cs
@@ -42,7 +42,7 @@ public class ValidateRootHashesSettingsCommand : AsyncCommand<ValidateRootHashes
 
         // configure merkle to memoize none and recalculate all
         const int none = int.MaxValue;
-        var merkle = new ComputeMerkleBehavior(true, none, none, false);
+        var merkle = new ComputeMerkleBehavior(none, none, false);
 
         await using var blockchain = new Blockchain(db, merkle);
         using var batch = blockchain.StartReadOnlyLatestFromDb();

--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -89,7 +89,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior(true, 1, 1, true);
+            using var preCommit = new ComputeMerkleBehavior(1, 1, true);
 
             var blockHash = Keccak.EmptyTreeHash;
             var finalization = new Queue<Keccak>();

--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -89,7 +89,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior(true, 1, 1, true, 100);
+            using var preCommit = new ComputeMerkleBehavior(true, 1, 1, true);
 
             var blockHash = Keccak.EmptyTreeHash;
             var finalization = new Queue<Keccak>();
@@ -97,7 +97,7 @@ public static class Program
             // add finality and 10 just to make it a bit slower
             var gate = new SingleAsyncGate(FinalizeEvery + 10);
 
-            await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(5), 1000, reporter.Observe))
+            await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(5), new CacheBudget.Options(100, 1000), 1000, reporter.Observe))
             {
                 blockchain.Flushed += (_, e) => gate.Signal(e.blockNumber);
 

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -20,7 +20,12 @@ namespace Paprika.Runner;
 /// <summary>
 /// The case for running the runner.
 /// </summary>
-public record Case(uint BlockCount, int AccountsPerBlock, ulong DbFileSize, bool PersistentDb, TimeSpan FlushEvery,
+public record Case(
+    uint BlockCount,
+    int AccountsPerBlock,
+    ulong DbFileSize,
+    bool PersistentDb,
+    TimeSpan FlushEvery,
     bool Fsync,
     bool UseBigStorageAccount)
 {
@@ -35,12 +40,16 @@ public static class Program
 
     private static readonly Case InMemorySmall =
         new(10_000, 1000, 10 * Gb, false, TimeSpan.FromSeconds(5), false, true);
+
     private static readonly Case InMemoryMedium =
         new(50_000, 1000, 32 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+
     private static readonly Case
         InMemoryBig = new(100_000, 1000, 56 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+
     private static readonly Case DiskSmallNoFlush =
         new(50_000, 1000, 11 * Gb, true, TimeSpan.FromSeconds(5), false, false);
+
     private static readonly Case DiskSmallFlushFile =
         new(50_000, 1000, 11 * Gb, true, TimeSpan.FromSeconds(5), true, false);
 
@@ -152,7 +161,8 @@ public static class Program
             using var preCommit = new ComputeMerkleBehavior(true, 2, 1);
             //IPreCommitBehavior preCommit = null;
 
-            await using (var blockchain = new Blockchain(db, preCommit, config.FlushEvery, 1000, reporter.Observe))
+            await using (var blockchain =
+                         new Blockchain(db, preCommit, config.FlushEvery, default, 1000, reporter.Observe))
             {
                 counter = Writer(config, blockchain, bigStorageAccount, random, layout[writing]);
             }
@@ -257,7 +267,8 @@ public static class Program
 
     private static Random BuildRandom() => new(RandomSeed);
 
-    private static int Writer(Case config, Blockchain blockchain, Keccak bigStorageAccount, Random random, Layout reporting)
+    private static int Writer(Case config, Blockchain blockchain, Keccak bigStorageAccount, Random random,
+        Layout reporting)
     {
         var report = new StringBuilder();
         string result = "";
@@ -333,7 +344,8 @@ public static class Program
         var lastBlock = toFinalize.Last();
         blockchain.Finalize(lastBlock);
 
-        report.AppendLine($@"At block {config.BlockCount - 1}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
+        report.AppendLine(
+            $@"At block {config.BlockCount - 1}. This batch of {config.LogEvery} blocks took {writing.Elapsed:h\:mm\:ss\.FF}. RootHash: {result}");
 
         reporting.Update(new Panel(report.ToString()).Header("Writing").Expand());
 

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -158,7 +158,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior(true, 2, 1);
+            using var preCommit = new ComputeMerkleBehavior(2, 1);
             //IPreCommitBehavior preCommit = null;
 
             await using (var blockchain =

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -385,7 +385,7 @@ public class BlockchainTests
 
     private class PreCommit : IPreCommitBehavior
     {
-        public Keccak BeforeCommit(ICommit commit)
+        public Keccak BeforeCommit(ICommit commit, CacheBudget budget)
         {
             var hashCode = RuntimeHelpers.GetHashCode(commit);
             Keccak hash = default;

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -73,7 +73,7 @@ public class BlockchainTests
 
         using var db = PagedDb.NativeMemoryDb(16 * Mb, 2);
 
-        await using var blockchain = new Blockchain(db, new ComputeMerkleBehavior(true, 2, 2));
+        await using var blockchain = new Blockchain(db, new ComputeMerkleBehavior(2, 2));
 
         var block = blockchain.StartNew(Keccak.EmptyTreeHash);
         block.SetAccount(Key0, new Account(1, 1));
@@ -287,7 +287,7 @@ public class BlockchainTests
         using var db = PagedDb.NativeMemoryDb(256 * Mb, 2);
         var counter = 0;
 
-        var behavior = new ComputeMerkleBehavior(true, 2, 2);
+        var behavior = new ComputeMerkleBehavior(2, 2);
 
         await using (var blockchain = new Blockchain(db, behavior))
         {

--- a/src/Paprika.Tests/Chain/PreCommitBehaviorTests.cs
+++ b/src/Paprika.Tests/Chain/PreCommitBehaviorTests.cs
@@ -50,7 +50,7 @@ public class PreCommitBehaviorTests
             _found = new HashSet<Keccak>();
         }
 
-        public Keccak BeforeCommit(ICommit commit)
+        public Keccak BeforeCommit(ICommit commit, CacheBudget budget)
         {
             _found.Clear();
 

--- a/src/Paprika.Tests/Merkle/AdditionalTests.cs
+++ b/src/Paprika.Tests/Merkle/AdditionalTests.cs
@@ -17,7 +17,7 @@ public class AdditionalTests
         const int storageCount = 32 * 1024;
 
         using var db = PagedDb.NativeMemoryDb(4 * 1024 * 1024, 2);
-        var merkle = new ComputeMerkleBehavior(true, 2, 2);
+        var merkle = new ComputeMerkleBehavior(2, 2);
 
         await using var blockchain = new Blockchain(db, merkle);
 

--- a/src/Paprika.Tests/Merkle/DirtyTests.cs
+++ b/src/Paprika.Tests/Merkle/DirtyTests.cs
@@ -298,7 +298,8 @@ public class DirtyTests
 
     private void Assert(Commit commit, Action<ICommit> assert)
     {
-        var merkle = new ComputeMerkleBehavior(false);
+        const int dontMemoize = int.MaxValue;
+        var merkle = new ComputeMerkleBehavior(dontMemoize, dontMemoize, false);
 
         // run merkle before
         merkle.BeforeCommit(commit, CacheBudget.Options.None.Build());
@@ -358,5 +359,14 @@ public static class CommitExtensions
 
     public static void Set(this Commit commit, string path) => commit.Set(NibblePath.Parse(path));
 
-    public static void Set(this Commit commit, in NibblePath path) => commit.Set(Key.Account(path), new byte[] { 0 });
+    public static void Set(this Commit commit, in NibblePath path) => commit.Set(Key.Account(path), SmallestAccount);
+
+    private static readonly byte[] SmallestAccount;
+
+    static CommitExtensions()
+    {
+        var account = new Account(1, 1);
+        var written = account.WriteTo(stackalloc byte[Account.MaxByteCount]);
+        SmallestAccount = written.ToArray();
+    }
 }

--- a/src/Paprika.Tests/Merkle/DirtyTests.cs
+++ b/src/Paprika.Tests/Merkle/DirtyTests.cs
@@ -301,7 +301,7 @@ public class DirtyTests
         var merkle = new ComputeMerkleBehavior(false);
 
         // run merkle before
-        merkle.BeforeCommit(commit);
+        merkle.BeforeCommit(commit, CacheBudget.Options.None.Build());
 
         if (_delete)
         {
@@ -318,7 +318,7 @@ public class DirtyTests
             }
 
             // run Merkle it again to undo the structure
-            merkle.BeforeCommit(commit);
+            merkle.BeforeCommit(commit, CacheBudget.Options.None.Build());
         }
 
         if (!_delete)

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -54,7 +54,7 @@ public class RootHashFuzzyTests
         var generator = Build(test);
 
         using var db = PagedDb.NativeMemoryDb(32 * 1024 * 1024, 2);
-        var merkle = new ComputeMerkleBehavior(true, 2, 2);
+        var merkle = new ComputeMerkleBehavior(2, 2);
         await using var blockchain = new Blockchain(db, merkle);
 
         var rootHash = generator.Run(blockchain, commitEvery);
@@ -69,7 +69,7 @@ public class RootHashFuzzyTests
         var generator = Build(test);
 
         using var db = PagedDb.NativeMemoryDb(16 * 1024 * 1024, 2);
-        var merkle = new ComputeMerkleBehavior(true, 2, 2);
+        var merkle = new ComputeMerkleBehavior(2, 2);
         await using var blockchain = new Blockchain(db, merkle);
 
         var rootHash = generator.Run(blockchain, commitEvery);
@@ -92,7 +92,7 @@ public class RootHashFuzzyTests
         var generator = Build(test);
 
         using var db = PagedDb.NativeMemoryDb(1024 * 1024 * 1024, 2);
-        var merkle = new ComputeMerkleBehavior(true, 2, 2, false);
+        var merkle = new ComputeMerkleBehavior(2, 2, false);
         await using var blockchain = new Blockchain(db, merkle);
 
         // set
@@ -263,7 +263,7 @@ public class RootHashFuzzyTests
 
     private static void AssertRoot(string hex, ICommit commit)
     {
-        var merkle = new ComputeMerkleBehavior(true);
+        var merkle = new ComputeMerkleBehavior();
 
         merkle.BeforeCommit(commit, CacheBudget.Options.None.Build());
 

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -265,7 +265,7 @@ public class RootHashFuzzyTests
     {
         var merkle = new ComputeMerkleBehavior(true);
 
-        merkle.BeforeCommit(commit);
+        merkle.BeforeCommit(commit, CacheBudget.Options.None.Build());
 
         var keccak = new Keccak(Convert.FromHexString(hex));
 

--- a/src/Paprika.Tests/Merkle/RootHashTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashTests.cs
@@ -255,7 +255,7 @@ public class RootHashTests
     {
         var merkle = new ComputeMerkleBehavior();
 
-        merkle.BeforeCommit(commit);
+        merkle.BeforeCommit(commit, CacheBudget.Options.None.Build());
 
         var keccak = new Keccak(Convert.FromHexString(hex));
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -766,9 +766,7 @@ public class Blockchain : IAsyncDisposable
             Debug.Assert(_committed == false,
                 "The block is committed and it cleaned up some of its dependencies. It cannot provide data for Get method");
 
-            return Get(key);
-
-            // Precompute hash and preencode key
+            // Precompute hash and pre-encode key
             var hash = GetHash(key);
             var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -766,6 +766,8 @@ public class Blockchain : IAsyncDisposable
             Debug.Assert(_committed == false,
                 "The block is committed and it cleaned up some of its dependencies. It cannot provide data for Get method");
 
+            return Get(key);
+
             // Precompute hash and preencode key
             var hash = GetHash(key);
             var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -1018,9 +1018,12 @@ public class Blockchain : IAsyncDisposable
 
             foreach (var kvp in dict)
             {
-                Key.ReadFrom(kvp.Key, out var key);
-                var data = preCommit == null ? kvp.Value : preCommit.InspectBeforeApply(key, kvp.Value);
-                batch.SetRaw(key, data);
+                if (!_transient.Contains(kvp.Key, kvp.ShortHash))
+                {
+                    Key.ReadFrom(kvp.Key, out var key);
+                    var data = preCommit == null ? kvp.Value : preCommit.InspectBeforeApply(key, kvp.Value);
+                    batch.SetRaw(key, data);
+                }
             }
         }
 

--- a/src/Paprika/Chain/CacheBudget.cs
+++ b/src/Paprika/Chain/CacheBudget.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics.Contracts;
+
+namespace Paprika.Chain;
+
+/// <summary>
+/// Represents the cache budget per block.
+/// Cache budget consists of transient and db writes.
+/// The first are set only in the block, with no impact on the db.
+/// The second traverse the whole and are later set in the database.
+/// </summary>
+public class CacheBudget
+{
+    public readonly record struct Options(int DbWrites, int TransientWrites)
+    {
+        [Pure]
+        public CacheBudget Build() => new(DbWrites, TransientWrites);
+
+        public static Options None => default;
+    }
+
+    private int _dbWrites;
+    private int _transientWrites;
+
+    private CacheBudget(int dbWrites, int transientWrites)
+    {
+        _dbWrites = dbWrites;
+        _transientWrites = transientWrites;
+    }
+
+    public bool ClaimDbWrite() => Interlocked.Decrement(ref _dbWrites) >= 0;
+
+    public bool IsDbWrite => Volatile.Read(ref _transientWrites) > 0;
+
+    public bool ClaimTransient() => Interlocked.Decrement(ref _transientWrites) >= 0;
+
+    public bool IsTransientAvailable => Volatile.Read(ref _transientWrites) > 0;
+}

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -15,8 +15,9 @@ public interface IPreCommitBehavior
     /// Executed just before commit.
     /// </summary>
     /// <param name="commit">The object representing the commit.</param>
+    /// <param name="budget">The budget for caching capabilities.</param>
     /// <returns>The result of the before commit.</returns>
-    Keccak BeforeCommit(ICommit commit);
+    Keccak BeforeCommit(ICommit commit, CacheBudget budget);
 
     /// <summary>
     /// Inspects the data allowing it to overwrite them if needed, before the commit is applied to the database.

--- a/src/Paprika/Utils/MetricsExtensions.cs
+++ b/src/Paprika/Utils/MetricsExtensions.cs
@@ -1,9 +1,26 @@
-﻿using System.Diagnostics.Metrics;
+﻿using System.Diagnostics;
+using System.Diagnostics.Metrics;
 
 namespace Paprika.Utils;
 
 public static class MetricsExtensions
 {
+    public readonly struct MeasurementScope : IDisposable
+    {
+        private readonly Stopwatch _sw;
+        private readonly Histogram<long> _timer;
+
+        public MeasurementScope(Stopwatch sw, Histogram<long> timer)
+        {
+            _sw = sw;
+            _timer = timer;
+        }
+
+        public void Dispose() => _timer.Record(_sw.ElapsedMilliseconds);
+    }
+
+    public static MeasurementScope Measure(this Histogram<long> timer) => new(Stopwatch.StartNew(), timer);
+
     private class AtomicIntGauge : IAtomicIntGauge
     {
         private int _value;


### PR DESCRIPTION
This PR introduces several improvements over how data are processed in Paprika:

1. the cache budget with two ways of caching items that were retrieved from the database
   1. Transient, that is helpful whenever a storage or an account is retrieved using `GetAccount` and `GetStorage`.
   1. Persistent, that is helpful to apply LRU with the database
1. the commitment cache, that caches all the read that are from db that are returned to the commitment mechanism (Merkle)
1. reorganization of computation of Merkle

### Transient Cache

This is done whenever there's a budget and the data are returned either from the db or beyond 80% of non-finalized blocks. Even with Xor filters it's more beneficial to have them warm and ready. Think of all the proxy addresses written once in a while and others that are frequently read but infrequently written. Transiently cached data do not hit the db.

### Peristent

Values written in the persistent way will go through finalization and will be persisted in the database. Please do mind that currently Paprika db has an LRU behavior so this writes will help with the future read

### Commitment cache

As branches and leafs are read to both, construct the trie and then perform the calculation of the Keccak, they can be read twice. Why not to cache all of them only for the commitment purposes, if they come from db? This is what is done in here

### Merkle reorganized

Coarse-grained tasks for storage to calculate them once and for all, then merge and proceed to the state. Also, Parallel over Parallel is removed here. Better data locality comes for free as well.
