### PR TITLE
Caching commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,6 +404,7 @@ FodyWeavers.xsd
 
 # Paprika files
 src/Paprika.Runner/db
+src/Paprika.Runner.Pareto/db
 src/Tree.Runner/db
 
 /db

--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -89,7 +89,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior(1, 1, false);
+            using var preCommit = new ComputeMerkleBehavior(1, 1, true);
 
             var blockHash = Keccak.EmptyTreeHash;
             var finalization = new Queue<Keccak>();

--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -89,7 +89,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior(1, 1, true);
+            using var preCommit = new ComputeMerkleBehavior(1, 1, false);
 
             var blockHash = Keccak.EmptyTreeHash;
             var finalization = new Queue<Keccak>();

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -69,7 +69,7 @@ public class RootHashFuzzyTests
         var generator = Build(test);
 
         using var db = PagedDb.NativeMemoryDb(16 * 1024 * 1024, 2);
-        var merkle = new ComputeMerkleBehavior(2, 2);
+        var merkle = new ComputeMerkleBehavior(2, 2, false);
         await using var blockchain = new Blockchain(db, merkle);
 
         var rootHash = generator.Run(blockchain, commitEvery);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -21,7 +21,7 @@ namespace Paprika.Chain;
 public class Blockchain : IAsyncDisposable
 {
     // allocate 1024 pages (4MB) at once
-    private readonly BufferPool _pool = new(1024);
+    private readonly BufferPool _pool = new(1024, true, "Blockchain");
 
     private readonly object _blockLock = new();
     private readonly Dictionary<uint, List<BlockState>> _blocksByNumber = new();
@@ -441,11 +441,6 @@ public class Blockchain : IAsyncDisposable
 
         private bool _committed;
         private Keccak? _hash;
-
-        // precommit caches
-        private PooledSpanDictionary? _commitCache;
-        private ReaderWriterLockSlim _commitLock = new();
-
         private readonly CacheBudget _cacheBudget;
 
         private void CreateDictionaries()
@@ -576,16 +571,7 @@ public class Blockchain : IAsyncDisposable
         {
             if (_hash == null)
             {
-                _commitCache = new PooledSpanDictionary(Pool, true, true);
-                try
-                {
-                    _hash = _blockchain._preCommit.BeforeCommit(this, _cacheBudget);
-                }
-                finally
-                {
-                    _commitCache.Dispose();
-                    _commitCache = null;
-                }
+                _hash = _blockchain._preCommit.BeforeCommit(this, _cacheBudget);
             }
         }
 
@@ -761,49 +747,7 @@ public class Blockchain : IAsyncDisposable
                 throw new Exception("This blocks has already been committed");
         }
 
-        ReadOnlySpanOwnerWithMetadata<byte> ICommit.Get(scoped in Key key)
-        {
-            Debug.Assert(_committed == false,
-                "The block is committed and it cleaned up some of its dependencies. It cannot provide data for Get method");
-
-            // Precompute hash and pre-encode key
-            var hash = GetHash(key);
-            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
-
-            if (key.Type != DataType.Merkle)
-            {
-                // for other types than Merkle do not use this
-                return TryGet(key, keyWritten, hash);
-            }
-
-            // Check if it was written locally already
-            var local = TryGetLocal(key, keyWritten, hash, out var succeeded);
-            if (succeeded)
-                return local.WithDepth(0);
-
-            // Try to find in cache now
-            _commitLock.EnterReadLock();
-            if (_commitCache!.TryGet(keyWritten, hash, out var result))
-            {
-                _commitLock.ExitReadLock();
-                return new ReadOnlySpanOwner<byte>(result, null).WithDepth(0);
-            }
-            _commitLock.ExitReadLock();
-
-            var previous = TryGet(key, keyWritten, hash);
-
-            if (previous.IsDbQuery)
-            {
-                // on db query, cache locally
-                _commitLock.EnterWriteLock();
-                _commitCache.Set(keyWritten, hash, previous.Span);
-                _commitLock.ExitWriteLock();
-
-                // TODO: consider returning cached so nothing else needs to deal with db results
-            }
-
-            return previous;
-        }
+        ReadOnlySpanOwnerWithMetadata<byte> ICommit.Get(scoped in Key key) => Get(key);
 
         void ICommit.Set(in Key key, in ReadOnlySpan<byte> payload) => SetImpl(key, payload, _preCommit);
 
@@ -1237,7 +1181,7 @@ public class Blockchain : IAsyncDisposable
             $"{nameof(BlockNumber)}: {BlockNumber}";
     }
 
-    private static int GetHash(in Key key) => key.GetHashCode();
+    public static int GetHash(in Key key) => key.GetHashCode();
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Paprika/Chain/BufferPool.cs
+++ b/src/Paprika/Chain/BufferPool.cs
@@ -24,12 +24,14 @@ public class BufferPool : IDisposable
     // metrics
     private readonly Meter _meter;
 
-    public BufferPool(int buffersInOneSlab, bool assertCountOnDispose = true)
+    public BufferPool(int buffersInOneSlab, bool assertCountOnDispose = true, string name = "")
     {
         _buffersInOneSlab = buffersInOneSlab;
         _assertCountOnDispose = assertCountOnDispose;
 
-        _meter = new Meter("Paprika.Chain.BufferPool");
+        var baseName = "Paprika.Chain.BufferPool";
+
+        _meter = new Meter(string.IsNullOrEmpty(name) ? baseName : baseName + "-" + name);
         _allocatedMB = _meter.CreateAtomicObservableGauge("Total buffers' size", "MB",
             "The amount of MB allocated in the pool");
     }

--- a/src/Paprika/Chain/CommitExtensions.cs
+++ b/src/Paprika/Chain/CommitExtensions.cs
@@ -1,0 +1,111 @@
+﻿using System.Runtime.CompilerServices;
+using Paprika.Crypto;
+using Paprika.Data;
+using Paprika.Utils;
+
+namespace Paprika.Chain;
+
+public static class CommitExtensions
+{
+    /// <summary>
+    /// Creates a commit that caches specified reads so that data once reached,
+    /// if they satisfy <paramref name="shouldCacheResult"/>, are cached locally.
+    ///
+    /// Writes are write through, but they are stored locally for faster compute as well.
+    /// </summary>
+    /// <returns>The wrapped commit.</returns>
+    public static IChildCommit WriteThroughCache(this IChildCommit original, ShouldCacheKey shouldCacheKey,
+        ShouldCacheResult<byte> shouldCacheResult, BufferPool pool)
+    {
+        return new ReadCachingCommit(original, shouldCacheKey, shouldCacheResult, pool);
+    }
+
+    private class ReadCachingCommit : IChildCommit
+    {
+        private readonly IChildCommit _commit;
+        private readonly ShouldCacheKey _shouldCacheKey;
+        private readonly ShouldCacheResult<byte> _shouldCacheResult;
+        private readonly PooledSpanDictionary _cache;
+
+        public ReadCachingCommit(IChildCommit commit, ShouldCacheKey shouldCacheKey,
+            ShouldCacheResult<byte> shouldCacheResult, BufferPool pool)
+        {
+            _commit = commit;
+            _shouldCacheKey = shouldCacheKey;
+            _shouldCacheResult = shouldCacheResult;
+            _cache = new PooledSpanDictionary(pool, true, false);
+        }
+
+        public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
+        {
+            if (_shouldCacheKey(key) == false)
+            {
+                return _commit.Get(key);
+            }
+
+            var hash = Hash(key);
+            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
+
+            if (_cache.TryGet(keyWritten, hash, out var cached))
+            {
+                // return cached
+                return new ReadOnlySpanOwner<byte>(cached, null).WithDepth(0);
+            }
+
+            var result = _commit.Get(key);
+
+            if (_shouldCacheResult(result))
+            {
+                _cache.Set(keyWritten, hash, result.Span);
+            }
+
+            return result;
+        }
+
+        [SkipLocalsInit]
+        public void Set(in Key key, in ReadOnlySpan<byte> payload)
+        {
+            // write locally
+            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
+            _cache.Set(keyWritten, Hash(key), payload);
+
+            // write in the wrapped
+            _commit.Set(key, payload);
+        }
+
+        [SkipLocalsInit]
+        public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
+        {
+            // write locally
+            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
+            _cache.Set(keyWritten, Hash(key), payload0, payload1);
+
+            // write in the wrapped
+            _commit.Set(key, payload0, payload1);
+        }
+
+        private static int Hash(in Key key) => Blockchain.GetHash(key);
+
+        public IChildCommit GetChild() => throw new NotImplementedException("Caching commit has no children");
+
+        public IReadOnlyDictionary<Keccak, int> Stats => _commit.Stats;
+
+        public void Dispose()
+        {
+            _cache.Dispose();
+            _commit.Dispose();
+        }
+
+        public void Commit() => _commit.Commit();
+    }
+}
+
+/// <summary>
+/// The predicate whether the key should be cached.
+/// </summary>
+public delegate bool ShouldCacheKey(in Key key);
+
+/// <summary>
+/// The predicate whether the result should be cached.
+/// </summary>
+public delegate bool ShouldCacheResult<T>(in ReadOnlySpanOwnerWithMetadata<T> result);

--- a/src/Paprika/Chain/CommitExtensions.cs
+++ b/src/Paprika/Chain/CommitExtensions.cs
@@ -65,9 +65,12 @@ public static class CommitExtensions
         [SkipLocalsInit]
         public void Set(in Key key, in ReadOnlySpan<byte> payload)
         {
-            // write locally
-            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
-            _cache.Set(keyWritten, Hash(key), payload);
+            if (_shouldCacheKey(key))
+            {
+                // write locally
+                var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
+                _cache.Set(keyWritten, Hash(key), payload);
+            }
 
             // write in the wrapped
             _commit.Set(key, payload);
@@ -76,9 +79,12 @@ public static class CommitExtensions
         [SkipLocalsInit]
         public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1)
         {
-            // write locally
-            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
-            _cache.Set(keyWritten, Hash(key), payload0, payload1);
+            if (_shouldCacheKey(key))
+            {
+                // write locally
+                var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
+                _cache.Set(keyWritten, Hash(key), payload0, payload1);
+            }
 
             // write in the wrapped
             _commit.Set(key, payload0, payload1);

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -79,6 +79,18 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         return false;
     }
 
+    public bool TryGet(scoped ReadOnlySpan<byte> key, ushort shortHash, out ReadOnlySpan<byte> result)
+    {
+        if (_dict.TryGetValue(BuildKeyTemp(key, shortHash), out var value))
+        {
+            result = GetAt(value);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
     public bool Contains(scoped ReadOnlySpan<byte> key, ushort shortHash)
     {
         return _dict.ContainsKey(BuildKeyTemp(key, shortHash));
@@ -122,7 +134,7 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
         refValue = BuildValue(data0, data1);
     }
 
-    public void Remove(Span<byte> key, int hash)
+    public void Remove(ReadOnlySpan<byte> key, int hash)
     {
         if (_dict.Count == 0)
             return;

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -217,8 +217,8 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     {
         var sum = commit.Stats.Sum(pair => pair.Value);
 
-        // rough estimate of work is to have a budget same budget per core
-        var batchBudget = sum / Environment.ProcessorCount;
+        // make 2 more batches than CPU count to allow some balancing
+        var batchBudget = sum / (Environment.ProcessorCount * 2);
 
         var list = new List<HashSet<Keccak>>();
         var current = new HashSet<Keccak>();


### PR DESCRIPTION
This PR follows up some traces after #205 that resulted in showing that caching provides a lot but RWL is hit heavily with them. It's addressed by creating wrappers that can be used to cache data locally, especially this that are read twice. It's done for:

1. Merkle keys of Storage
2. Merkle keys of State