### PR TITLE
Leaf optimization

### DIFF
--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -28,6 +28,8 @@ public readonly ref struct NibblePath
     private readonly ref byte _span;
     private readonly byte _odd;
 
+    public bool IsOdd => _odd == OddBit;
+
     public static NibblePath Empty => default;
 
     /// <summary>

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -13,6 +13,12 @@ public static class CommitExtensions
 {
     public static void SetLeaf(this ICommit commit, in Key key, in NibblePath leafPath)
     {
+        if (leafPath.Length == 0)
+        {
+            // Last level leafs are omitted.
+            return;
+        }
+
         var leaf = new Node.Leaf(leafPath);
         commit.Set(key, leaf.WriteTo(stackalloc byte[leaf.MaxByteLength]));
     }


### PR DESCRIPTION
This PR introduces leaf optimizations for the `Merkle` `Leaf`:

1. Removes the need to store `Leaf`s with empty `Key` (old `TrieNode` terminology)
   1. Leafs with empty `Key` can be reconstructed from the bit set at the nibble branch
   2. This sets the minimum length of the `Key` to 1 as empty are not stored
1. Makes leafs shorter by 1 byte as they pack more into the `Header`. 
   1. This is done by leveraging the fact that Leafs have path at least 1 nibble long
   2. This allows to subtract min from all of them
   3. This means that the longest path to encode will be 63 nibbles
   4. This allows the packing all the length info to the header