### PR TITLE
Dense identifiers for contracts

### DIFF
--- a/src/Paprika.Tests/Store/IdTests.cs
+++ b/src/Paprika.Tests/Store/IdTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Buffers.Binary;
+using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Store;
+
+namespace Paprika.Tests.Store;
+
+public class IdTests
+{
+    [Test]
+    public void Small()
+    {
+        var unique = new HashSet<byte>();
+
+        for (uint i = 0; i < Id.Limit; i++)
+        {
+            var encoded = Id.WriteId(i);
+            encoded.Length.Should().Be(1);
+            unique.Add(encoded[0]).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void Bigger()
+    {
+        var unique = new HashSet<ushort>();
+
+        for (uint i = Id.Limit; i < Id.Limit * 128; i++)
+        {
+            var encoded = Id.WriteId(i);
+            encoded.Length.Should().Be(2);
+            unique.Add(BinaryPrimitives.ReadUInt16LittleEndian(encoded)).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void Big()
+    {
+        var unique = new HashSet<uint>();
+
+        const uint start = 1 * 256 * 256 * 256;
+        for (uint i = start; i < start + 1_000; i++)
+        {
+            var encoded = Id.WriteId(i);
+            encoded.Length.Should().Be(4);
+            unique.Add(BinaryPrimitives.ReadUInt32LittleEndian(encoded)).Should().BeTrue();
+        }
+    }
+}

--- a/src/Paprika/Store/Id.cs
+++ b/src/Paprika/Store/Id.cs
@@ -1,0 +1,40 @@
+﻿using System.Numerics;
+
+namespace Paprika.Store;
+
+/// <summary>
+/// The ID encoding utility.
+/// </summary>
+public static class Id
+{
+    public const int Limit = 1 << Shift;
+
+    private const int IdSize = 4;
+    private const int Shift = 6;
+
+    /// <summary>
+    /// Writes the id in a dense way, reducing the number of bytes needed to encode it.
+    /// The padding does not break it.
+    /// It writes it in a way that can be appended at the end with any payload and it will be unique.
+    /// </summary>
+    public static ReadOnlySpan<byte> WriteId(uint id)
+    {
+        Span<byte> span = stackalloc byte[IdSize];
+
+        // The highest 2 bits are used to encode how many bytes are there. The rest, 6 bits are free to be used.
+        var (extracted, prefix) = Math.DivRem(id, Limit);
+        var bytesCount = (BitOperations.LeadingZeroCount(extracted) + 7) / 8;
+
+        span[0] = (byte)((bytesCount << Shift) | prefix);
+
+        var i = 1;
+        while (extracted != 0)
+        {
+            span[i++] = (byte)(extracted & 0xFF);
+            extracted >>= 8;
+        }
+
+        // TODO: remove allocation
+        return span[..i].ToArray();
+    }
+}


### PR DESCRIPTION
This PR changes the encoding for contract to make them more dense and allow to write first `256 * 256 * 64` contract identifiers on 3 bytes only.