### PR TITLE
Fan out page and Encode 

### DIFF
--- a/src/Paprika.Tests/Data/NibblePathTests.cs
+++ b/src/Paprika.Tests/Data/NibblePathTests.cs
@@ -295,7 +295,7 @@ public class NibblePathTests
 
         NibblePath.FromKey(expected).SliceFrom(1).Equals(appended);
     }
-    
+
     [TestCaseSource(nameof(GetRawNibbles))]
     public void Raw_nibbles(byte[] nibbles)
     {
@@ -320,7 +320,7 @@ public class NibblePathTests
             1, 2, 3, 4, 5, 6, 7, 8, 9, 0xA, 0xB, 0xC, 0xD, 0xE,
             1, 2, 3, 4, 5, 6, 7, 8, 9, 0xA, 0xB, 0xC, 0xD, 0xE,
         };
-        
+
         yield return new TestCaseData(@long.AsSpan()[..^1].ToArray()).SetName("Long - odd");
         yield return new TestCaseData(@long).SetName("Long - even");
     }

--- a/src/Paprika.Tests/Store/DbAddressTests.cs
+++ b/src/Paprika.Tests/Store/DbAddressTests.cs
@@ -16,13 +16,4 @@ public class DbAddressTests
         Equals(a1, a1).Should().BeTrue();
         Equals(a1, a2).Should().BeFalse();
     }
-
-    [Test]
-    public void FileOffset_overflow()
-    {
-        long page = Page.PageCount - 1;
-        var address = DbAddress.Page((uint)page);
-
-        address.FileOffset.Should().Be(page * Page.PageSize);
-    }
 }

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -57,7 +57,7 @@ public readonly ref struct NibblePath
         var count = key.Length * NibblePerByte;
         return new NibblePath(key, nibbleFrom, count - nibbleFrom);
     }
-    
+
     /// <summary>
     /// Creates a nibble path from raw nibbles (a byte per nibble), using the <paramref name="workingSet"/> as the memory to use.
     /// </summary>

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -20,7 +20,7 @@ namespace Paprika.Store;
 public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
 {
     public static DataPage Wrap(Page page) => new(page);
-    
+
     private const int BucketCount = 16;
 
     public ref PageHeader Header => ref page.Header;

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -17,8 +17,10 @@ namespace Paprika.Store;
 /// in the parent page, or they are flushed underneath. 
 /// </remarks>
 [method: DebuggerStepThrough]
-public readonly unsafe struct DataPage(Page page) : IPage
+public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
 {
+    public static DataPage Wrap(Page page) => new(page);
+    
     private const int BucketCount = 16;
 
     public ref PageHeader Header => ref page.Header;

--- a/src/Paprika/Store/DbAddress.cs
+++ b/src/Paprika/Store/DbAddress.cs
@@ -38,11 +38,7 @@ public readonly struct DbAddress : IEquatable<DbAddress>
     /// </summary>
     /// <param name="page">The page to go to.</param>
     /// <returns></returns>
-    public static DbAddress Page(uint page)
-    {
-        Debug.Assert(page < Store.Page.PageCount, "The page number breached the PageCount maximum");
-        return new(page);
-    }
+    public static DbAddress Page(uint page) => new(page);
 
     /// <summary>
     /// Gets the next address.
@@ -52,9 +48,6 @@ public readonly struct DbAddress : IEquatable<DbAddress>
     public DbAddress(uint value) => _value = value;
 
     public bool IsNull => _value == NullValue;
-
-    // ReSharper disable once MergeIntoPattern
-    public bool IsValidPageAddress => _value < Store.Page.PageCount;
 
     public static implicit operator uint(DbAddress address) => address._value;
     public static implicit operator int(DbAddress address) => (int)address._value;

--- a/src/Paprika/Store/FanOutPage.cs
+++ b/src/Paprika/Store/FanOutPage.cs
@@ -9,7 +9,7 @@ namespace Paprika.Store;
 public readonly unsafe struct FanOutPage(Page page) : IPageWithData<FanOutPage>
 {
     public static FanOutPage Wrap(Page page) => new(page);
-    
+
     private const int ConsumedNibbles = 2;
 
     public ref PageHeader Header => ref page.Header;
@@ -62,15 +62,15 @@ public readonly unsafe struct FanOutPage(Page page) : IPageWithData<FanOutPage>
 
         var index = GetIndex(key);
         var sliced = key.SliceFrom(ConsumedNibbles);
-        
+
         ref var addr = ref Data.Addresses[index];
-        
+
         if (addr.IsNull)
         {
             var newPage = batch.GetNewPage(out addr, true);
             newPage.Header.PageType = Header.PageType;
             newPage.Header.Level = 0;
-            
+
             new DataPage(newPage).Set(sliced, data, batch);
             return page;
         }

--- a/src/Paprika/Store/FanOutPage.cs
+++ b/src/Paprika/Store/FanOutPage.cs
@@ -1,0 +1,80 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Paprika.Data;
+
+namespace Paprika.Store;
+
+[method: DebuggerStepThrough]
+public readonly unsafe struct FanOutPage(Page page) : IPage
+{
+    private const int ConsumedNibbles = 2;
+
+    public ref PageHeader Header => ref page.Header;
+
+    private ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
+
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    private struct Payload
+    {
+        public const int Size = 256 * DbAddress.Size;
+
+        /// <summary>
+        /// The first item of map of frames to allow ref to it.
+        /// </summary>
+        [FieldOffset(0)] private DbAddress Address;
+
+        public Span<DbAddress> Addresses => MemoryMarshal.CreateSpan(ref Address, Size);
+    }
+
+    public bool TryGet(scoped in NibblePath key, IPageResolver batch, out ReadOnlySpan<byte> result)
+    {
+        if (key.Length < ConsumedNibbles)
+        {
+            result = default;
+            return false;
+        }
+
+        var index = GetIndex(key);
+
+        var addr = Data.Addresses[index];
+        if (addr.IsNull)
+        {
+            result = default;
+            return false;
+        }
+
+        return new DataPage(batch.GetAt(addr)).TryGet(key.SliceFrom(ConsumedNibbles), batch, out result);
+    }
+
+    private static int GetIndex(in NibblePath key) => (key.GetAt(0) << NibblePath.NibbleShift) + key.GetAt(1);
+
+    public Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        if (Header.BatchId != batch.BatchId)
+        {
+            // the page is from another batch, meaning, it's readonly. Copy
+            var writable = batch.GetWritableCopy(page);
+            return new FanOutPage(writable).Set(key, data, batch);
+        }
+
+        var index = GetIndex(key);
+        var sliced = key.SliceFrom(ConsumedNibbles);
+        
+        ref var addr = ref Data.Addresses[index];
+        
+        if (addr.IsNull)
+        {
+            var newPage = batch.GetNewPage(out addr, true);
+            newPage.Header.PageType = Header.PageType;
+            newPage.Header.Level = 0;
+            
+            new DataPage(newPage).Set(sliced, data, batch);
+            return page;
+        }
+
+        // update after set
+        addr = batch.GetAddress(new DataPage(batch.GetAt(addr)).Set(sliced, data, batch));
+        return page;
+    }
+}

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -16,6 +16,14 @@ public interface IPage
 {
 }
 
+public interface IPageWithData<TPage> : IPage
+    where TPage : struct, IPageWithData<TPage>
+{
+    static abstract TPage Wrap(Page page);
+
+    Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch);
+}
+
 /// <summary>
 /// Convenient methods for transforming page types.
 /// </summary>
@@ -122,5 +130,6 @@ public readonly unsafe struct Page : IPage, IEquatable<Page>
 
     public override int GetHashCode() => unchecked((int)(long)_ptr);
 
-    public static Page DevOnlyNativeAlloc() => new((byte*)NativeMemory.AlignedAlloc((UIntPtr)PageSize, (UIntPtr)PageSize));
+    public static Page DevOnlyNativeAlloc() =>
+        new((byte*)NativeMemory.AlignedAlloc((UIntPtr)PageSize, (UIntPtr)PageSize));
 }

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -100,8 +100,6 @@ public enum PageType : byte
 /// </summary>
 public readonly unsafe struct Page : IPage, IEquatable<Page>
 {
-    public const int PageCount = 0x1000_0000; // 64GB addressable
-    public const int PageAddressMask = PageCount - 1;
     public const int PageSize = 4 * 1024;
 
     private readonly byte* _ptr;

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -18,8 +18,6 @@ public abstract unsafe class PointerPageManager : IPageManager
             throw new IndexOutOfRangeException("The database breached its size! The returned page is invalid");
         }
 
-        Debug.Assert(address.IsValidPageAddress, "The address page is invalid and breaches max page count");
-
         return new Page((byte*)Ptr + address.FileOffset);
     }
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -457,18 +457,18 @@ public class PagedDb : IPageResolver, IDb, IDisposable
     {
         const byte oddEnd = 0x01;
         const byte evenEnd = 0x00;
-        
+
         Debug.Assert(path.IsOdd == false, "Encoded paths should not be odd. They always start at 0");
 
         if (path.IsEmpty)
             return path;
 
         var raw = path.RawSpan;
-        
+
         if (path.Length % 2 == 1)
         {
             // Odd case
-            
+
             raw.CopyTo(destination);
             ref var last = ref destination[raw.Length - 1];
             last &= 0xF0;
@@ -606,7 +606,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
         }
 
         private void SetAtRoot<TPage>(in NibblePath path, in ReadOnlySpan<byte> rawData, ref DbAddress root)
-            where TPage: struct, IPageWithData<TPage>
+            where TPage : struct, IPageWithData<TPage>
         {
             var data = TryGetPageAlloc(ref root, PageType.Standard);
             var updated = TPage.Wrap(data).Set(path, rawData, this);

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -414,7 +414,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            var ids = new DataPage(GetAt(_rootIdPage));
+            var ids = new FanOutPage(GetAt(_rootIdPage));
             if (ids.TryGet(key.Path, this, out var id) == false)
             {
                 result = default;
@@ -536,7 +536,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 return false;
             }
 
-            var ids = new DataPage(GetAt(_root.Data.IdRoot));
+            var ids = new FanOutPage(GetAt(_root.Data.IdRoot));
             if (ids.TryGet(key.Path, this, out var id) == false)
             {
                 result = default;
@@ -565,7 +565,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             else
             {
                 // full extraction of key possible, get it
-                var ids = new DataPage(TryGetPageAlloc(ref _root.Data.IdRoot, PageType.Identity));
+                var ids = new FanOutPage(TryGetPageAlloc(ref _root.Data.IdRoot, PageType.Identity));
 
                 Span<byte> newId = stackalloc byte[sizeof(uint)];
                 // try fetch existing first
@@ -600,7 +600,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             _db.ReportWrite();
 
             // Get the id page
-            var ids = new DataPage(TryGetPageAlloc(ref _root.Data.IdRoot, PageType.Identity));
+            var ids = new FanOutPage(TryGetPageAlloc(ref _root.Data.IdRoot, PageType.Identity));
 
             // Write empty data so that it is a delete
             _root.Data.IdRoot = GetAddress(ids.Set(account, ReadOnlySpan<byte>.Empty, this));
@@ -746,8 +746,6 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             // process abandoned
             while (_abandoned.TryDequeue(out var page))
             {
-                Debug.Assert(page.IsValidPageAddress, "Only valid pages should be reused");
-
                 first = first.EnqueueAbandoned(this, _db.GetAddress(first.AsPage()), page);
             }
 

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -1,9 +1,7 @@
 ﻿using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
 using Paprika.Crypto;
-using Paprika.Data;
 
 namespace Paprika.Store;
 
@@ -11,15 +9,11 @@ namespace Paprika.Store;
 /// Root page is a page that contains all the needed metadata from the point of view of the database.
 /// It also includes the blockchain information like block hash or block number
 /// </summary>
-public readonly unsafe struct RootPage : IPage
+public readonly unsafe struct RootPage(Page root) : IPage
 {
-    private readonly Page _page;
+    public ref PageHeader Header => ref root.Header;
 
-    public RootPage(Page root) => _page = root;
-
-    public ref PageHeader Header => ref _page.Header;
-
-    public ref Payload Data => ref Unsafe.AsRef<Payload>(_page.Payload);
+    public ref Payload Data => ref Unsafe.AsRef<Payload>(root.Payload);
 
     /// <summary>
     /// Represents the data of the page.

--- a/src/Paprika/Utils/Printer.cs
+++ b/src/Paprika/Utils/Printer.cs
@@ -99,7 +99,7 @@ public class Printer : IPageVisitor
 
     public void On(DataPage page, DbAddress addr)
     {
-        var nextPages = page.Data.Buckets.ToArray().Where(a => a.IsNull == false && a.IsValidPageAddress).ToArray();
+        var nextPages = page.Data.Buckets.ToArray().Where(a => a.IsNull == false).ToArray();
         var p = new[]
         {
             (Type, "DataPage"),


### PR DESCRIPTION
This PR introduces the following changes, to reduce the tree height, make lookups faster and compress the database a bit:

1. A new `FanOutPage` is introduced that provides no buffering for writes. It just consumes 1 byte from the key and does the pass over to the lower levels.
2. `FanOutPage` is used as the root for the `Identity` tree, so that accounts should be mapped to their ids in a faster way
3. `FanOutPage` is used as the root for the `Storage` tree, so that storage cells should be retrieved in a faster way
4. `Encode` method is changed, as now, with two trees `Storage` and `State` being separated, there's no ambiguous way of encoding. This means that:
   5. for an empty path, it now returns an empty `Span<byte>` (saves 1 byte)
   5. for a path with an odd length, it adds the last nibble only (saves 1 byte)
   5. for a path with an even length, it still adds one byte (no change)