### PR TITLE
Cache ids in batch

### DIFF
--- a/src/Paprika.Tests/Store/BasePageTests.cs
+++ b/src/Paprika.Tests/Store/BasePageTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Paprika.Crypto;
 using Paprika.Store;
 
 namespace Paprika.Tests.Store;
@@ -21,8 +22,10 @@ public abstract class BasePageTests
         // 0-N is take by metadata pages
         private uint _pageCount = 1U;
 
-        public TestBatchContext(uint batchId) : base(batchId) { }
-
+        public TestBatchContext(uint batchId) : base(batchId)
+        {
+            IdCache = new Dictionary<Keccak, uint>();
+        }
 
         public override Page GetAt(DbAddress address) => _address2Page[address];
 
@@ -51,6 +54,8 @@ public abstract class BasePageTests
         {
             // NOOP
         }
+
+        public override Dictionary<Keccak, uint> IdCache { get; }
 
         public override string ToString() => $"Batch context used {_pageCount} pages to write the data";
 

--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -99,7 +99,7 @@ public class PagedDbTests
 
         using var db = PagedDb.NativeMemoryDb(128 * Mb, 2);
 
-        var value = new byte[1] {13};
+        var value = new byte[1] { 13 };
 
         using var batch = db.BeginNextBatch();
 
@@ -122,7 +122,7 @@ public class PagedDbTests
         static async Task InsertLoadsOfStorages(IDb db, Keccak account)
         {
             var value = new byte[4];
-            
+
             using var batch2 = db.BeginNextBatch();
 
             // Now try to store many

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -1,4 +1,6 @@
-﻿namespace Paprika.Store;
+﻿using Paprika.Crypto;
+
+namespace Paprika.Store;
 
 /// <summary>
 /// The base class for all context implementations.
@@ -46,6 +48,8 @@ abstract class BatchContextBase : IBatchContext
     /// <param name="page">The page to be analyzed and registered for future GC.</param>
 
     public abstract void RegisterForFutureReuse(Page page);
+
+    public abstract Dictionary<Keccak, uint> IdCache { get; }
 
     /// <summary>
     /// Assigns the batch identifier to a given page, marking it writable by this batch.

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -1,4 +1,6 @@
-﻿namespace Paprika.Store;
+﻿using Paprika.Crypto;
+
+namespace Paprika.Store;
 
 public interface IBatchContext : IReadOnlyBatchContext
 {
@@ -29,6 +31,8 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// Abandon this page from this batch on.
     /// </summary>
     void RegisterForFutureReuse(Page page);
+
+    Dictionary<Keccak, uint> IdCache { get; }
 }
 
 public interface IReadOnlyBatchContext : IPageResolver


### PR DESCRIPTION
This PR makes storage heavy batches less heavy on the persistence by caching ids used and assigned in a single batch. Results show drop for applying storage operations by a few %.