### PR TITLE
Batches refactored

### DIFF
--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -78,7 +78,7 @@ public class RootHashFuzzyTests
         blockchain.Finalize(rootHash);
         await flush;
 
-        var state = blockchain.StartReadOnly(rootHash);
+        using var state = blockchain.StartReadOnly(rootHash);
         var recalculated = merkle.CalculateStateRootHash(state);
 
         rootHash.Should().Be(generator.RootHashAsKeccak);

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -94,6 +94,10 @@ public readonly ref partial struct Key
 
     public bool IsAccountCompressed => ((Type & DataType.CompressedAccount) == DataType.CompressedAccount);
 
+    public bool IsState => Type == DataType.Account ||
+                           (Type == DataType.Merkle && Path.Length < NibblePath.KeccakNibbleCount);
+
+
     [SkipLocalsInit]
     public override int GetHashCode()
     {

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -59,4 +59,20 @@ abstract class BatchContextBase : IBatchContext
         page.Header.BatchId = BatchId;
         page.Header.PaprikaVersion = PageHeader.CurrentVersion;
     }
+
+    public Page TryGetPageAlloc(ref DbAddress addr, PageType pageType)
+    {
+        Page page;
+        if (addr.IsNull)
+        {
+            page = GetNewPage(out addr, true);
+            page.Header.PageType = pageType;
+        }
+        else
+        {
+            page = GetAt(addr);
+        }
+
+        return page;
+    }
 }

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -39,6 +39,14 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// Assigns the batch identifier to a given page, marking it writable by this batch.
     /// </summary>
     void AssignBatchId(Page page);
+
+    /// <summary>
+    /// Tries to get the page and if it does not exist, allocates one.
+    /// </summary>
+    /// <param name="addr">The address to check.</param>
+    /// <param name="pageType">The page type to assign.</param>
+    /// <returns>The page either allocated or get.</returns>
+    Page TryGetPageAlloc(ref DbAddress addr, PageType pageType);
 }
 
 public interface IReadOnlyBatchContext : IPageResolver


### PR DESCRIPTION
This PR pushes all the methods operating on the root to the `RootPage` where they can be used by both `ReadOnlyBatch` and non-readonly `Batch`. It should help with maintenance as it removes copying of root values to the readonly and simply delegates without copying (TryGet was copied before).