### PR TITLE
Different path encoding

### DIFF
--- a/src/Paprika.Tests/Store/RootPageTests.cs
+++ b/src/Paprika.Tests/Store/RootPageTests.cs
@@ -1,0 +1,73 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Paprika.Crypto;
+using Paprika.Data;
+using static Paprika.Store.RootPage;
+
+namespace Paprika.Tests.Store;
+
+public class RootPageTests
+{
+    [Test]
+    public void Encode_length()
+    {
+        const byte merkle = 0x02;
+        const byte odd = 0x01;
+
+        var path = NibblePath.Parse("01234567");
+
+        var n0 = path.GetAt(0);
+        var n0Shifted = (byte)(n0 << NibblePath.NibbleShift);
+
+        var n1 = path.GetAt(1);
+
+        var n2 = path.GetAt(2);
+        var n2Shifted = (byte)(n2 << NibblePath.NibbleShift);
+
+        var n3 = path.GetAt(3);
+
+        var n4 = path.GetAt(4);
+        var n4Shifted = (byte)(n4 << NibblePath.NibbleShift);
+
+        // length: 0
+        Check(NibblePath.Empty, DataType.Merkle, []);
+
+        // length: 1
+        Check(path.SliceTo(1), DataType.Merkle, [(byte)(n0Shifted | merkle | odd)]);
+        Check(path.SliceTo(1), DataType.Account, [(byte)(n0Shifted | odd)]);
+        Check(path.SliceTo(1), DataType.StorageCell, [(byte)(n0Shifted | odd)]);
+
+        // length: 2
+        Check(path.SliceTo(2), DataType.Merkle, [(byte)(n0Shifted | n1), merkle]);
+        Check(path.SliceTo(2), DataType.Account, [(byte)(n0Shifted | n1), 0]);
+        Check(path.SliceTo(2), DataType.StorageCell, [(byte)(n0Shifted | n1), 0]);
+
+        // length: 3
+        Check(path.SliceTo(3), DataType.Merkle, [(byte)(n0Shifted | n1), (byte)(n2Shifted | merkle | odd)]);
+        Check(path.SliceTo(3), DataType.Account, [(byte)(n0Shifted | n1), (byte)(n2Shifted | odd)]);
+        Check(path.SliceTo(3), DataType.StorageCell, [(byte)(n0Shifted | n1), (byte)(n2Shifted | odd)]);
+
+        // length: 4
+        Check(path.SliceTo(4), DataType.Merkle, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), merkle]);
+        Check(path.SliceTo(4), DataType.Account, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), 0]);
+        Check(path.SliceTo(4), DataType.StorageCell, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), 0]);
+
+        // length: 5
+        Check(path.SliceTo(5), DataType.Merkle, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | merkle | odd)]);
+        Check(path.SliceTo(5), DataType.Account, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | odd)]);
+        Check(path.SliceTo(5), DataType.StorageCell, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | odd)]);
+
+        return;
+
+        static void Check(in NibblePath path, DataType type, params byte[] expected)
+        {
+            var actual = Encode(path, stackalloc byte[64], type);
+            (actual.Length % 2).Should().Be(0, "Only even lengths");
+            if (actual.RawSpan.SequenceEqual(expected) == false)
+            {
+                Assert.Fail(
+                    $"Mismatch, expected was: {expected.AsSpan().ToHexString(false)} while actual {actual.RawSpan.ToHexString(false)}");
+            }
+        }
+    }
+}

--- a/src/Paprika.Tests/Store/RootPageTests.cs
+++ b/src/Paprika.Tests/Store/RootPageTests.cs
@@ -11,10 +11,13 @@ public class RootPageTests
     [Test]
     public void Encode_length()
     {
+        const byte packed = 0x04;
         const byte merkle = 0x02;
         const byte odd = 0x01;
+        const byte packedShift = 3;
 
-        var path = NibblePath.Parse("01234567");
+        // Path constructed that nibbles[1] & nibbles[3] are prone to packing them
+        var path = NibblePath.Parse("A1204567");
 
         var n0 = path.GetAt(0);
         var n0Shifted = (byte)(n0 << NibblePath.NibbleShift);
@@ -37,25 +40,30 @@ public class RootPageTests
         Check(path.SliceTo(1), DataType.Account, [(byte)(n0Shifted | odd)]);
         Check(path.SliceTo(1), DataType.StorageCell, [(byte)(n0Shifted | odd)]);
 
-        // length: 2
-        Check(path.SliceTo(2), DataType.Merkle, [(byte)(n0Shifted | n1), merkle]);
-        Check(path.SliceTo(2), DataType.Account, [(byte)(n0Shifted | n1), 0]);
-        Check(path.SliceTo(2), DataType.StorageCell, [(byte)(n0Shifted | n1), 0]);
+        // length: 2, packed
+        var n1Packed = n1 << packedShift | packed;
+        Check(path.SliceTo(2), DataType.Merkle, [(byte)(n0Shifted | n1Packed | merkle)]);
+        Check(path.SliceTo(2), DataType.Account, [(byte)(n0Shifted | n1Packed)]);
+        Check(path.SliceTo(2), DataType.StorageCell, [(byte)(n0Shifted | n1Packed)]);
 
         // length: 3
         Check(path.SliceTo(3), DataType.Merkle, [(byte)(n0Shifted | n1), (byte)(n2Shifted | merkle | odd)]);
         Check(path.SliceTo(3), DataType.Account, [(byte)(n0Shifted | n1), (byte)(n2Shifted | odd)]);
         Check(path.SliceTo(3), DataType.StorageCell, [(byte)(n0Shifted | n1), (byte)(n2Shifted | odd)]);
 
-        // length: 4
-        Check(path.SliceTo(4), DataType.Merkle, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), merkle]);
-        Check(path.SliceTo(4), DataType.Account, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), 0]);
-        Check(path.SliceTo(4), DataType.StorageCell, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), 0]);
+        // length: 4, packed
+        var n3Packed = n3 << packedShift | packed;
+        Check(path.SliceTo(4), DataType.Merkle, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3Packed | merkle)]);
+        Check(path.SliceTo(4), DataType.Account, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3Packed)]);
+        Check(path.SliceTo(4), DataType.StorageCell, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3Packed)]);
 
         // length: 5
-        Check(path.SliceTo(5), DataType.Merkle, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | merkle | odd)]);
-        Check(path.SliceTo(5), DataType.Account, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | odd)]);
-        Check(path.SliceTo(5), DataType.StorageCell, [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | odd)]);
+        Check(path.SliceTo(5), DataType.Merkle,
+            [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | merkle | odd)]);
+        Check(path.SliceTo(5), DataType.Account,
+            [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | odd)]);
+        Check(path.SliceTo(5), DataType.StorageCell,
+            [(byte)(n0Shifted | n1), (byte)(n2Shifted | n3), (byte)(n4Shifted | odd)]);
 
         return;
 

--- a/src/Paprika.Tests/Store/RootPageTests.cs
+++ b/src/Paprika.Tests/Store/RootPageTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Buffers.Binary;
-using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;
 using Paprika.Crypto;

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -401,8 +401,6 @@ public class PooledSpanDictionary : IEqualityComparer<PooledSpanDictionary.KeySp
                         text.WriteLine($"Merkle, Storage [{S(key.Path)}, {key.StoragePath.ToString()}] (updated)");
 
                     break;
-                case DataType.CompressedAccount:
-                    throw new Exception("Should not use compressed accounts");
                 default:
                     throw new ArgumentOutOfRangeException($"The type {key.Type} is not handled");
             }

--- a/src/Paprika/Crypto/SpanExtensions.cs
+++ b/src/Paprika/Crypto/SpanExtensions.cs
@@ -7,6 +7,11 @@ namespace Paprika.Crypto;
 
 public static class SpanExtensions
 {
+    public static string ToHexString(this in Span<byte> span, bool withZeroX)
+    {
+        return ToHexString(span, withZeroX, false, false);
+    }
+
     public static string ToHexString(this in ReadOnlySpan<byte> span, bool withZeroX)
     {
         return ToHexString(span, withZeroX, false, false);

--- a/src/Paprika/Data/DataType.cs
+++ b/src/Paprika/Data/DataType.cs
@@ -21,9 +21,4 @@ public enum DataType : byte
     /// [key, 2] The Merkle entry, either with storage or not
     /// </summary>
     Merkle = 2,
-
-    /// <summary>
-    /// The account compressed with the identity tree.
-    /// </summary>
-    CompressedAccount = 4,
 }

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -92,8 +92,6 @@ public readonly ref partial struct Key
         return leftover;
     }
 
-    public bool IsAccountCompressed => ((Type & DataType.CompressedAccount) == DataType.CompressedAccount);
-
     public bool IsState => Type == DataType.Account ||
                            (Type == DataType.Merkle && Path.Length < NibblePath.KeccakNibbleCount);
 

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -125,7 +125,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
     /// To ensure that <see cref="DataType.Merkle"/> and <see cref="DataType.Account"/>/<see cref="DataType.StorageCell"/>
     /// of the same length can coexist, the merkle marker is added as well.
     /// </summary>
-    private static NibblePath Encode(in NibblePath path, in Span<byte> destination, DataType type)
+    public static NibblePath Encode(in NibblePath path, in Span<byte> destination, DataType type)
     {
         var typeFlag = (byte)(type & DataType.Merkle);
 

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -169,7 +169,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         if (lastNibble <= maxPacked)
         {
             // We can pack better
-            destination[raw.Length - 1] = (byte)(lastButOneNibble | (lastByte << packedShift) | evenPacked | typeFlag);
+            destination[raw.Length - 1] = (byte)(lastButOneNibble | (lastNibble << packedShift) | evenPacked | typeFlag);
             return NibblePath.FromKey(destination[..raw.Length]);
         }
 

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -132,6 +132,15 @@ public readonly unsafe struct RootPage(Page root) : IPage
         const byte oddEnd = 0x01;
         const byte evenEnd = 0x00;
 
+        // 2 lower bits are used, for odd|even and merkle.
+        // We can use 1 more bit for differentiation for even lengths.
+        // This leaves 1 bit to extract potential value. This means that it can compress 2 / 16,
+        // meaning 1/8 of even paths.
+
+        const byte evenPacked = 0x04;
+        const byte packedShift = 3;
+        const byte maxPacked = 1;
+
         Debug.Assert(path.IsOdd == false, "Encoded paths should not be odd. They always start at 0");
 
         if (path.IsEmpty)
@@ -153,6 +162,17 @@ public readonly unsafe struct RootPage(Page root) : IPage
 
         // Even case
         raw.CopyTo(destination);
+        var lastByte = raw[^1];
+        var lastNibble = lastByte & NibblePath.NibbleMask;
+        var lastButOneNibble = lastByte & (NibblePath.NibbleMask << NibblePath.NibbleShift);
+
+        if (lastNibble <= maxPacked)
+        {
+            // We can pack better
+            destination[raw.Length - 1] = (byte)(lastButOneNibble | (lastByte << packedShift) | evenPacked | typeFlag);
+            return NibblePath.FromKey(destination[..raw.Length]);
+        }
+
         destination[raw.Length] = (byte)(evenEnd | typeFlag);
         return NibblePath.FromKey(destination[..(raw.Length + 1)]);
     }
@@ -227,7 +247,8 @@ public readonly unsafe struct RootPage(Page root) : IPage
         // It should not be hard. Walk down by the mapped path, then remove all the pages underneath.
     }
 
-    private static void SetAtRoot<TPage>(IBatchContext batch, in NibblePath path, in ReadOnlySpan<byte> rawData, ref DbAddress root)
+    private static void SetAtRoot<TPage>(IBatchContext batch, in NibblePath path, in ReadOnlySpan<byte> rawData,
+        ref DbAddress root)
         where TPage : struct, IPageWithData<TPage>
     {
         var data = batch.TryGetPageAlloc(ref root, PageType.Standard);


### PR DESCRIPTION
This PR firstly introduces a test for path encoding. Then, it changes how the even paths are encoded. For non-empty even length paths, if they end with `0` or `1` they can skip the suffix byte. This gives 1/8 of all the even paths. The odd-length paths are not affected. This might be not the biggest gain ever but... all the Storage Keccaks and Accounts' addresses Keccaks are even in length, so this should get a 1/8 of all of their entries.

Before the change:

1. ` ` -> ` `
2. `0` -> `0x01` (odd flag at the end)
3. `21` -> `0x2100` (zero byte added to differentiate)
4. `23` -> `0x2300` (zero byte added to differentiate)

After the change

1. ` ` -> ` `
2. `0` -> `0x01` (odd flag at the end)
3. `21` -> `0x2C` (as `1 << 3 + 4 = 0xC`, where `3` is a shift and `4` is a special flag of the last byte that is set only when the even packed is used)
4. `23` -> `0x2300` (zero byte added to differentiate)

This means that every even path, if it ends with a nibble `0` or `1`

### Results

Benchmarking the mainnet shows a reduction of size by 1%.