### PR TITLE
Durability fix

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -140,7 +140,7 @@ public class Blockchain : IAsyncDisposable
                     _flusherBlockApplicationInMs.Record((int)application.ElapsedMilliseconds);
 
                     // commit but no flush here, it's too heavy, the flush will come later
-                    await batch.Commit(CommitOptions.DangerNoFlush);
+                    await batch.Commit(CommitOptions.FlushDataOnly);
 
                     // inform blocks about flushing
                     lock (_blockLock)

--- a/src/Paprika/IBatch.cs
+++ b/src/Paprika/IBatch.cs
@@ -34,7 +34,8 @@ public enum CommitOptions
     /// Flushes db only once, ensuring that the data are stored properly.
     /// The root is stored ephemerally, waiting for the next commit to be truly stored.
     ///
-    /// This guarantees ATOMIC (from ACID) but not DURABLE.  
+    /// This guarantees ATOMIC (from ACID) but not DURABLE as the last root may not be flushed properly.
+    /// It will be during the next flush.
     /// </summary>
     FlushDataOnly,
 


### PR DESCRIPTION
This PR ensures that after each batch applied, there's a single flush that ensure that ACI from ACID is preserved. The durability may or may not, but eventually all the root pages are persisted as well so it's ok to have it that way. One more flush is outside of the loop so for a batch of blocks, each will get one flush + at the end there' will be one more to flush the root. 