### PR TITLE
Precommit has a separate budget

### DIFF
--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -96,7 +96,11 @@ public static class Program
             // add finality and 10 just to make it a bit slower
             var gate = new SingleAsyncGate(FinalizeEvery + 10);
 
-            await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(5), new CacheBudget.Options(5_000, 8), 1000, reporter.Observe))
+            var cacheBudgetStateAndStorage = new CacheBudget.Options(2_000, 16);
+            var cacheBudgetPreCommit = new CacheBudget.Options(2_000, 16);
+
+            await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(5),
+                             cacheBudgetStateAndStorage, cacheBudgetPreCommit, 1000, reporter.Observe))
             {
                 blockchain.Flushed += (_, e) => gate.Signal(e.blockNumber);
 
@@ -213,6 +217,8 @@ public static class Program
         const double alpha = 1.5; // Shape parameter
 
         var u = random.NextDouble(); // Uniformly distributed number between 0 and 1
-        return (int)(maxValue * Math.Pow(u, 1.0 / alpha)); // Inverse of the CDF (Cumulative Distribution Function) for Pareto
+        return
+            (int)(maxValue *
+                  Math.Pow(u, 1.0 / alpha)); // Inverse of the CDF (Cumulative Distribution Function) for Pareto
     }
 }

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -162,7 +162,7 @@ public static class Program
             //IPreCommitBehavior preCommit = null;
 
             await using (var blockchain =
-                         new Blockchain(db, preCommit, config.FlushEvery, default, 1000, reporter.Observe))
+                         new Blockchain(db, preCommit, config.FlushEvery, default, default, 1000, reporter.Observe))
             {
                 counter = Writer(config, blockchain, bigStorageAccount, random, layout[writing]);
             }

--- a/src/Paprika/Chain/IPersistenceStatsProvider.cs
+++ b/src/Paprika/Chain/IPersistenceStatsProvider.cs
@@ -1,0 +1,12 @@
+﻿namespace Paprika.Chain;
+
+/// <summary>
+/// Provides statistics about persistence aspects.
+/// </summary>
+public interface IPersistenceStatsProvider
+{
+    /// <summary>
+    /// Db reads performed by this component since it's start of the lifetime.
+    /// </summary>
+    public int DbReads { get; }
+}


### PR DESCRIPTION
This commit introduces a separate budget for precommit so that Merkle, if it reads leafs or extensions that are not modified for, firstly, marking path as dirty and then when computing, it has a chance to hit the db once. Otherwise, all the budget is most likely to be consumed by getting storage and state. From now on, there are two separate budgets:

```sharp
var cacheBudgetStateAndStorage = new CacheBudget.Options(2_000, 16);
var cacheBudgetPreCommit = new CacheBudget.Options(2_000, 16);

await using (var blockchain = new Blockchain(..., cacheBudgetStateAndStorage, cacheBudgetPreCommit, ....))
{
}
```