### PR TITLE
Inline fanout

### DIFF
--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -97,7 +97,7 @@ public class PagedDbTests
         const int accounts = 512 * 1024;
         const int size = 10_000;
 
-        using var db = PagedDb.NativeMemoryDb(128 * Mb, 2);
+        using var db = PagedDb.NativeMemoryDb(512 * Mb, 2);
 
         var value = new byte[1] { 13 };
 
@@ -144,7 +144,7 @@ public class PagedDbTests
     {
         const int size = 256 * 256;
 
-        using var db = PagedDb.NativeMemoryDb(16 * Mb, 2);
+        using var db = PagedDb.NativeMemoryDb(512 * Mb, 2);
 
         var value = new byte[4];
 

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -9,14 +9,9 @@ namespace Paprika.Store;
 [StructLayout(LayoutKind.Explicit, Size = Size)]
 public struct AbandonedList
 {
-    /// <summary>
-    /// The total amount of data needed for the <see cref="RootPage"/> data.
-    /// </summary>
-    public const int SpaceForRootPage = 64;
-
     private const int EntriesStart = DbAddress.Size + sizeof(uint);
 
-    private const int Size = Page.PageSize - PageHeader.Size - SpaceForRootPage - EntriesStart;
+    private const int Size = Page.PageSize - PageHeader.Size - RootPage.Payload.AbandonedStart - EntriesStart;
     private const int EntrySize = sizeof(uint) + DbAddress.Size;
     private const int MaxCount = Size / EntrySize;
 

--- a/src/Paprika/Store/FanOutList.cs
+++ b/src/Paprika/Store/FanOutList.cs
@@ -1,0 +1,78 @@
+﻿using System.Runtime.InteropServices;
+using Paprika.Data;
+
+namespace Paprika.Store;
+
+public static class FanOutList
+{
+    public const int Size = FanOut * DbAddress.Size;
+
+    /// <summary>
+    /// The number of buckets to fan out to.
+    /// </summary>
+    public const int FanOut = 256;
+}
+
+/// <summary>
+/// Provides a convenient data structure for <see cref="RootPage"/>, to preserve a fan out of
+/// <see cref="FanOut"/> pages underneath. 
+/// </summary>
+/// <remarks>
+/// The main idea is to limit the depth of the tree by 1 or two and use the space in <see cref="RootPage"/> more.
+/// </remarks>
+public readonly ref struct FanOutList<TPage, TPageType>(Span<DbAddress> addresses)
+    where TPage : struct, IPageWithData<TPage>
+    where TPageType : IPageTypeProvider
+{
+    private readonly Span<DbAddress> _addresses = addresses;
+    private const int ConsumedNibbles = 2;
+
+    public bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
+    {
+        var index = GetIndex(key);
+
+        var addr = _addresses[index];
+        if (addr.IsNull)
+        {
+            result = default;
+            return false;
+        }
+
+        return TPage.Wrap(batch.GetAt(addr)).TryGet(key.SliceFrom(ConsumedNibbles), batch, out result);
+    }
+
+    private static int GetIndex(scoped in NibblePath key) => (key.GetAt(0) << NibblePath.NibbleShift) + key.GetAt(1);
+
+    public void Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        var index = GetIndex(key);
+        var sliced = key.SliceFrom(ConsumedNibbles);
+
+        ref var addr = ref _addresses[index];
+
+        if (addr.IsNull)
+        {
+            var newPage = batch.GetNewPage(out addr, true);
+            newPage.Header.PageType = TPageType.Type;
+            newPage.Header.Level = 0;
+
+            TPage.Wrap(newPage).Set(sliced, data, batch);
+            return;
+        }
+
+        // The page exists, update
+        var updated = TPage.Wrap(batch.GetAt(addr)).Set(sliced, data, batch);
+        addr = batch.GetAddress(updated);
+    }
+
+    public void Report(IReporter reporter, IPageResolver resolver, int level)
+    {
+        foreach (var bucket in _addresses)
+        {
+            if (!bucket.IsNull)
+            {
+                new DataPage(resolver.GetAt(bucket)).Report(reporter, resolver, level + 1);
+            }
+        }
+    }
+}

--- a/src/Paprika/Store/FanOutPage.cs
+++ b/src/Paprika/Store/FanOutPage.cs
@@ -75,7 +75,7 @@ public readonly unsafe struct FanOutPage(Page page) : IPageWithData<FanOutPage>
         if (addr.IsNull)
         {
             var newPage = batch.GetNewPage(out addr, true);
-            newPage.Header.PageType = PageType.Standard;
+            newPage.Header.PageType = Header.PageType;
             newPage.Header.Level = 2;
 
             new DataPage(newPage).Set(sliced, data, batch);

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -21,6 +21,8 @@ public interface IPageWithData<TPage> : IPage
 {
     static abstract TPage Wrap(Page page);
 
+    bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result);
+
     Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch);
 }
 
@@ -76,31 +78,6 @@ public struct PageHeader
     /// Internal metadata of the given page.
     /// </summary>
     [FieldOffset(7)] public byte Metadata;
-}
-
-public enum PageType : byte
-{
-    None = 0,
-
-    /// <summary>
-    /// A standard Paprika page with a fan-out of 16.
-    /// </summary>
-    Standard = 1,
-
-    /// <summary>
-    /// A page that is a Standard page but holds the account identity mappin.
-    /// </summary>
-    Identity = 2,
-
-    /// <summary>
-    /// Represents <see cref="AbandonedPage"/>
-    /// </summary>
-    Abandoned = 3,
-
-    /// <summary>
-    /// The leaf page that represents a part of the page.
-    /// </summary>
-    Leaf = 4,
 }
 
 /// <summary>

--- a/src/Paprika/Store/PageType.cs
+++ b/src/Paprika/Store/PageType.cs
@@ -1,0 +1,41 @@
+﻿namespace Paprika.Store;
+
+public enum PageType : byte
+{
+    None = 0,
+
+    /// <summary>
+    /// A standard Paprika page with a fan-out of 16.
+    /// </summary>
+    Standard = 1,
+
+    /// <summary>
+    /// A page that is a Standard page but holds the account identity mappin.
+    /// </summary>
+    Identity = 2,
+
+    /// <summary>
+    /// Represents <see cref="AbandonedPage"/>
+    /// </summary>
+    Abandoned = 3,
+
+    /// <summary>
+    /// The leaf page that represents a part of the page.
+    /// </summary>
+    Leaf = 4,
+}
+
+public interface IPageTypeProvider
+{
+    public static abstract PageType Type { get; }
+}
+
+public readonly struct StandardType : IPageTypeProvider
+{
+    public static PageType Type => PageType.Standard;
+}
+
+public readonly struct IdentityType : IPageTypeProvider
+{
+    public static PageType Type => PageType.Identity;
+}

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -384,10 +384,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
                 new DataPage(GetAt(root.Data.StateRoot)).Report(state, this, 1);
             }
 
-            if (root.Data.StorageRoot.IsNull == false)
-            {
-                new FanOutPage(GetAt(root.Data.StorageRoot)).Report(storage, this, 1);
-            }
+            root.Data.Storage.Report(state, this, 1);
         }
 
         public uint BatchId => root.Header.BatchId;

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -64,7 +64,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         [FieldOffset(DbAddress.Size * 2 + sizeof(uint) + Metadata.Size + FanOutList.Size)]
         private DbAddress IdsPayload;
 
-        public FanOutList<DataPage, IdentityType> Ids => new(MemoryMarshal.CreateSpan(ref IdsPayload, FanOutList.FanOut));
+        public FanOutList<FanOutPage, IdentityType> Ids => new(MemoryMarshal.CreateSpan(ref IdsPayload, FanOutList.FanOut));
 
         public const int AbandonedStart =
             DbAddress.Size * 2 + sizeof(uint) + Metadata.Size + FanOutList.Size * 2;

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -27,8 +27,6 @@ public readonly unsafe struct RootPage(Page root) : IPage
     {
         private const int Size = Page.PageSize - PageHeader.Size;
 
-        private const int MetadataStart = 4 * DbAddress.Size + sizeof(uint);
-
         /// <summary>
         /// The address of the next free page. This should be used rarely as pages should be reused
         /// with <see cref="AbandonedPage"/>.
@@ -36,32 +34,45 @@ public readonly unsafe struct RootPage(Page root) : IPage
         [FieldOffset(0)] public DbAddress NextFreePage;
 
         /// <summary>
-        /// The first of the data pages.
-        /// </summary>
-        [FieldOffset(DbAddress.Size)] public DbAddress StateRoot;
-
-        /// <summary>
-        /// The first of the data pages.
-        /// </summary>
-        [FieldOffset(DbAddress.Size * 2)] public DbAddress StorageRoot;
-
-        /// <summary>
-        /// The root of the id pages.
-        /// </summary>
-        [FieldOffset(DbAddress.Size * 3)] public DbAddress IdRoot;
-
-        /// <summary>
         /// The account counter
         /// </summary>
-        [FieldOffset(DbAddress.Size * 4)] public uint AccountCounter;
+        [FieldOffset(DbAddress.Size)] public uint AccountCounter;
 
-        [FieldOffset(MetadataStart)] public Metadata Metadata;
+        /// <summary>
+        /// The first of the data pages.
+        /// </summary>
+        [FieldOffset(DbAddress.Size + sizeof(uint))]
+        public DbAddress StateRoot;
+
+        /// <summary>
+        /// Metadata of this root
+        /// </summary>
+        [FieldOffset(DbAddress.Size * 2 + sizeof(uint))]
+        public Metadata Metadata;
+
+        /// <summary>
+        /// Storage.
+        /// </summary>
+        [FieldOffset(DbAddress.Size * 2 + sizeof(uint) + Metadata.Size)]
+        private DbAddress StoragePayload;
+
+        public FanOutList<DataPage, StandardType> Storage => new(MemoryMarshal.CreateSpan(ref StoragePayload, FanOutList.FanOut));
+
+        /// <summary>
+        /// Identifiers
+        /// </summary>
+        [FieldOffset(DbAddress.Size * 2 + sizeof(uint) + Metadata.Size + FanOutList.Size)]
+        private DbAddress IdsPayload;
+
+        public FanOutList<DataPage, IdentityType> Ids => new(MemoryMarshal.CreateSpan(ref IdsPayload, FanOutList.FanOut));
+
+        public const int AbandonedStart =
+            DbAddress.Size * 2 + sizeof(uint) + Metadata.Size + FanOutList.Size * 2;
 
         /// <summary>
         /// The start of the abandoned pages.
         /// </summary>
-        [FieldOffset(AbandonedList.SpaceForRootPage)]
-        public AbandonedList AbandonedList;
+        [FieldOffset(AbandonedStart)] public AbandonedList AbandonedList;
 
         public DbAddress GetNextFreePage()
         {
@@ -96,14 +107,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
             return new DataPage(batch.GetAt(Data.StateRoot)).TryGet(encoded, batch, out result);
         }
 
-        if (Data.StorageRoot.IsNull || Data.IdRoot.IsNull)
-        {
-            result = default;
-            return false;
-        }
-
-        var ids = new FanOutPage(batch.GetAt(Data.IdRoot));
-        if (ids.TryGet(key.Path, batch, out var id) == false)
+        if (Data.Ids.TryGet(key.Path, batch, out var id) == false)
         {
             result = default;
             return false;
@@ -112,7 +116,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         var encodedStorage = Encode(key.StoragePath, stackalloc byte[key.Path.MaxByteLength], key.Type);
         var path = NibblePath.FromKey(id).Append(encodedStorage, stackalloc byte[StorageKeySize]);
 
-        return new FanOutPage(batch.GetAt(Data.StorageRoot)).TryGet(path, batch, out result);
+        return Data.Storage.TryGet(path, batch, out result);
     }
 
     /// <summary>
@@ -169,7 +173,8 @@ public readonly unsafe struct RootPage(Page root) : IPage
         if (lastNibble <= maxPacked)
         {
             // We can pack better
-            destination[raw.Length - 1] = (byte)(lastButOneNibble | (lastNibble << packedShift) | evenPacked | typeFlag);
+            destination[raw.Length - 1] =
+                (byte)(lastButOneNibble | (lastNibble << packedShift) | evenPacked | typeFlag);
             return NibblePath.FromKey(destination[..raw.Length]);
         }
 
@@ -196,11 +201,8 @@ public readonly unsafe struct RootPage(Page root) : IPage
             }
             else
             {
-                // full extraction of key possible, get it
-                var ids = new FanOutPage(batch.TryGetPageAlloc(ref Data.IdRoot, PageType.Identity));
-
                 // try fetch existing first
-                if (ids.TryGet(key.Path, batch, out var existingId) == false)
+                if (Data.Ids.TryGet(key.Path, batch, out var existingId) == false)
                 {
                     Data.AccountCounter++;
                     BinaryPrimitives.WriteUInt32LittleEndian(idSpan, Data.AccountCounter);
@@ -209,7 +211,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
                     batch.IdCache[key.Path.UnsafeAsKeccak] = Data.AccountCounter;
 
                     // update root
-                    Data.IdRoot = batch.GetAddress(ids.Set(key.Path, idSpan, batch));
+                    Data.Ids.Set(key.Path, idSpan, batch);
 
                     id = NibblePath.FromKey(idSpan);
                 }
@@ -224,17 +226,14 @@ public readonly unsafe struct RootPage(Page root) : IPage
             var encoded = Encode(key.StoragePath, stackalloc byte[key.Path.MaxByteLength], key.Type);
             var path = id.Append(encoded, stackalloc byte[StorageKeySize]);
 
-            SetAtRoot<FanOutPage>(batch, path, rawData, ref Data.StorageRoot);
+            Data.Storage.Set(path, rawData, batch);
         }
     }
 
     public void Destroy(IBatchContext batch, in NibblePath account)
     {
-        // Get the id page
-        var ids = new FanOutPage(batch.TryGetPageAlloc(ref Data.IdRoot, PageType.Identity));
-
         // Destroy the Id entry about it
-        Data.IdRoot = batch.GetAddress(ids.Set(account, ReadOnlySpan<byte>.Empty, batch));
+        Data.Ids.Set(account, ReadOnlySpan<byte>.Empty, batch);
 
         // Destroy the account entry
         SetAtRoot<DataPage>(batch, Encode(account, stackalloc byte[account.MaxByteLength], DataType.Account),
@@ -260,7 +259,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
 [StructLayout(LayoutKind.Explicit, Size = Size, Pack = 1)]
 public struct Metadata
 {
-    private const int Size = BlockNumberSize + Keccak.Size;
+    public const int Size = BlockNumberSize + Keccak.Size;
     private const int BlockNumberSize = sizeof(uint);
 
     [FieldOffset(0)] public readonly uint BlockNumber;


### PR DESCRIPTION
This PR moves the fanout of 256 to the `RootPage` using a newly introduced `FanOutList`. This saves one hop. One more is saved by using `FanOutPage` for ids so that `256`*`256` fanout for accounts. This saves 2 searches across `DataPages`