### PR TITLE
Make Rlp.LengthOfLength branchless

### DIFF
--- a/src/Paprika/RLP/Rlp.cs
+++ b/src/Paprika/RLP/Rlp.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 using Nethermind.Int256;
 using Paprika.Utils;
 
@@ -52,21 +54,7 @@ public static class Rlp
 
     public static int LengthOfLength(int value)
     {
-        if (value < 1 << 8)
-        {
-            return 1;
-        }
-
-        if (value < 1 << 16)
-        {
-            return 2;
-        }
-
-        if (value < 1 << 24)
-        {
-            return 3;
-        }
-
-        return MaxLengthOfLength;
+        int bits = 32 - BitOperations.LeadingZeroCount((uint)value | 1);
+        return (bits + 7) / 8;
     }
 }


### PR DESCRIPTION
Make `Rlp.LengthOfLength` branchless

Extracted from https://github.com/NethermindEth/nethermind/pull/6729. 

[SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgDkBXfGKASzFwG4BYAKGIDMlAEzkAwuQDefcrMpDqScqwB2GcgBkYKgOYYAFgHkAZlt0GAFKvUA3bABsGMAJQy503nK/K15YKwxccgBecgFROHIAIQDDAAcWbAxWCBVcGi1sABNVHQAtFggxCAY1CwsGa2c7RxhyQnIqZx5Pb1liAHZyC39A8gBqcg7ncgB6cgAOFq8AXz4ZoA)