### PR TITLE
PooledSpanDictionary boost

### DIFF
--- a/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
+++ b/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
+++ b/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
@@ -11,7 +11,7 @@ public class PooledSpanDictionaryBenchmarks
     [Benchmark]
     public int Read_write_small()
     {
-        using var dict = new PooledSpanDictionary(_pool, false, true);
+        using var dict = new PooledSpanDictionary(_pool, false);
 
         Span<byte> key = stackalloc byte[2];
 

--- a/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
+++ b/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
@@ -1,0 +1,34 @@
+﻿using BenchmarkDotNet.Attributes;
+using Paprika.Chain;
+
+namespace Paprika.Benchmarks;
+
+[MemoryDiagnoser]
+public class PooledSpanDictionaryBenchmarks
+{
+    private readonly BufferPool _pool = new(1, false);
+
+    [Benchmark]
+    public int Read_write_small()
+    {
+        using var dict = new PooledSpanDictionary(_pool, false, true);
+
+        Span<byte> key = stackalloc byte[2];
+
+        for (byte i = 0; i < 255; i++)
+        {
+            key[0] = i;
+            dict.Set(key, i, key, 1);
+        }
+
+        var count = 0;
+        for (byte i = 0; i < 255; i++)
+        {
+            key[0] = i;
+            dict.TryGet(key, (ulong)i, out var result);
+            count += result[0];
+        }
+
+        return count;
+    }
+}

--- a/src/Paprika.Tests/Categories.cs
+++ b/src/Paprika.Tests/Categories.cs
@@ -6,7 +6,7 @@ public static class Categories
     /// Long running tests that should be skipped by CI when running in default settings.
     /// </summary>
     public const string LongRunning = nameof(LongRunning);
-    
+
     /// <summary>
     /// The test asserts the memory using <see cref="JetBrains.dotMemoryUnit"/> capabilities.
     /// </summary>

--- a/src/Paprika.Tests/Categories.cs
+++ b/src/Paprika.Tests/Categories.cs
@@ -6,4 +6,9 @@ public static class Categories
     /// Long running tests that should be skipped by CI when running in default settings.
     /// </summary>
     public const string LongRunning = nameof(LongRunning);
+    
+    /// <summary>
+    /// The test asserts the memory using <see cref="JetBrains.dotMemoryUnit"/> capabilities.
+    /// </summary>
+    public const string Memory = nameof(Memory);
 }

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
-using System.Text;
 using FluentAssertions;
 using Nethermind.Int256;
 using NUnit.Framework;

--- a/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
+++ b/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
@@ -25,7 +25,7 @@ public class PooledSpanDictionaryTests
         actual.SequenceEqual(value).Should().BeTrue();
 
         dict.Destroy(key, hash);
-        dict.TryGet(key, hash, out var destroyed).Should().BeTrue();
+        dict.TryGet(key, hash, out var destroyed).Should().BeFalse();
         destroyed.IsEmpty.Should().BeTrue();
     }
 
@@ -77,7 +77,7 @@ public class PooledSpanDictionaryTests
         Span<byte> key1 = stackalloc byte[] { 23, 19 };
         const ulong hash1 = 534;
 
-        var onePage = new byte[BufferPool.BufferSize - key0.Length - key1.Length];
+        var onePage = new byte[BufferPool.BufferSize - key0.Length - key1.Length - PooledSpanDictionary.ItemOverhead * 2];
 
         const byte metadata = 1;
 
@@ -91,7 +91,7 @@ public class PooledSpanDictionaryTests
         value1.SequenceEqual(ReadOnlySpan<byte>.Empty);
     }
 
-    public const int Mb = 1024 * 1024;
+    private const int Mb = 1024 * 1024;
 
     [Test]
     [Category(Categories.LongRunning)]

--- a/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
+++ b/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
@@ -141,7 +141,7 @@ public class PooledSpanDictionaryTests
 
         e.MoveNext().Should().BeFalse();
     }
-    
+
     [Test]
     public void Copy_to()
     {
@@ -164,7 +164,7 @@ public class PooledSpanDictionaryTests
         // Copy
         using var copy = new PooledSpanDictionary(pool);
         dict.CopyTo(copy);
-        
+
         // Assert
         dict.TryGet(key, hash, out result).Should().BeTrue();
         result.SequenceEqual(value0).Should().BeTrue();
@@ -222,14 +222,14 @@ public class PooledSpanDictionaryTests
             dict.Set(key, hash, key, GetMetadata(key));
             dict.TryGet(key, hash, out _);
         }
-        
+
         // Test original
         AssertIterate(dict);
 
         // Copy & test copy
         using var copy = new PooledSpanDictionary(pool, false);
         dict.CopyTo(copy);
-        
+
         AssertIterate(copy);
         return;
 

--- a/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
+++ b/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
@@ -36,10 +36,10 @@ public class PooledSpanDictionaryTests
         using var dict = new PooledSpanDictionary(pool, true);
 
         Span<byte> key = stackalloc byte[] { 13, 17 };
-        
+
         Span<byte> value0 = stackalloc byte[] { 211 };
         const byte meta0 = 1;
-        
+
         Span<byte> value1 = stackalloc byte[] { 23 };
         const byte meta1 = 0;
 
@@ -49,21 +49,21 @@ public class PooledSpanDictionaryTests
         dict.Set(key, hash, value0, meta0);
         dict.TryGet(key, hash, out var actual0).Should().BeTrue();
         actual0.SequenceEqual(value0).Should().BeTrue();
-        
+
         // Set get value 1
         dict.Set(key, hash, value1, meta1);
         dict.TryGet(key, hash, out var actual1).Should().BeTrue();
         actual1.SequenceEqual(value1).Should().BeTrue();
-        
+
         // value 0 should still be equal as preserves old values
         actual0.SequenceEqual(value0).Should().BeTrue();
-        
+
         using var e = dict.GetEnumerator();
-        
+
         e.MoveNext().Should().BeTrue();
         e.Current.Metadata.Should().Be(meta1);
         e.Current.Hash.Should().Be((uint)hash);
-        
+
         e.MoveNext().Should().BeFalse();
     }
 
@@ -101,7 +101,7 @@ public class PooledSpanDictionaryTests
         using var e2 = dict.GetEnumerator();
         e2.MoveNext().Should().BeFalse();
     }
-    
+
     [Test]
     public void Update_to_larger_value()
     {
@@ -109,11 +109,11 @@ public class PooledSpanDictionaryTests
         using var dict = new PooledSpanDictionary(pool);
 
         Span<byte> key = stackalloc byte[] { 13, 17 };
-        
+
         Span<byte> value0 = new byte[1];
         value0.Fill(0x13);
         const byte meta0 = 0;
-        
+
         Span<byte> value1 = new byte[13];
         value1.Fill(0x17);
         const byte meta1 = 1;
@@ -124,7 +124,7 @@ public class PooledSpanDictionaryTests
         dict.Set(key, hash, value0, meta0);
         dict.TryGet(key, hash, out var result).Should().BeTrue();
         result.SequenceEqual(value0).Should().BeTrue();
-        
+
         // Set & Assert value1
         dict.Set(key, hash, value1, meta1);
         dict.TryGet(key, hash, out result).Should().BeTrue();
@@ -141,7 +141,7 @@ public class PooledSpanDictionaryTests
 
         e.MoveNext().Should().BeFalse();
     }
-    
+
     [Test]
     public void On_page_boundary()
     {
@@ -179,7 +179,7 @@ public class PooledSpanDictionaryTests
     public void Large_spin()
     {
         const uint size = 1_000;
-        
+
         // Set two kvp, key0 + data0 + key1 fill first page, data1, will be empty
         using var pool = new BufferPool(128);
 

--- a/src/Paprika.Tests/Paprika.Tests.csproj
+++ b/src/Paprika.Tests/Paprika.Tests.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
+      <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.2.20220510" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
       <PackageReference Include="NUnit" Version="3.13.3" />
       <PackageReference Include="NUnit3TestAdapter" version="4.3.1" />

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -528,11 +528,11 @@ public class Blockchain : IAsyncDisposable
             var xor = new Xor8(_bloom);
 
             // clean no longer used fields
-
             var data = new PooledSpanDictionary(Pool, false);
-            Squash(_state, data);
-            Squash(_storage, data);
-            Squash(_preCommit, data);
+            
+            _state.CopyTo(data);
+            _storage.CopyTo(data);
+            _preCommit.CopyTo(data);
 
             // Creation acquires the lease
             return new CommittedBlockState(xor, _destroyed, _blockchain, data, hash,
@@ -957,9 +957,9 @@ public class Blockchain : IAsyncDisposable
         {
             using var squashed = new PooledSpanDictionary(Pool);
 
-            Squash(_state, squashed);
-            Squash(_storage, squashed);
-            Squash(_preCommit, squashed);
+            _state.CopyTo(squashed);
+            _storage.CopyTo(squashed);
+            _preCommit.CopyTo(squashed);
 
             foreach (var kvp in squashed)
             {
@@ -978,17 +978,6 @@ public class Blockchain : IAsyncDisposable
                     throw new Exception($"Values are different for {key.ToString()}. " +
                                         $"Expected is {expected} while found is {actual}.");
                 }
-            }
-        }
-
-        private static void Squash(PooledSpanDictionary source, PooledSpanDictionary destination)
-        {
-            Span<byte> span = stackalloc byte[128];
-
-            foreach (var kvp in source)
-            {
-                Key.ReadFrom(kvp.Key, out var key);
-                destination.Set(key.WriteTo(span), GetHash(key), kvp.Value, kvp.Metadata);
             }
         }
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -530,8 +530,9 @@ public class Blockchain : IAsyncDisposable
             // clean no longer used fields
             var data = new PooledSpanDictionary(Pool, false);
             
-            _state.CopyTo(data);
-            _storage.CopyTo(data);
+            // use append for faster copies as state and storage won't overwrite each other
+            _state.CopyTo(data, true);
+            _storage.CopyTo(data, true);
             _preCommit.CopyTo(data);
 
             // Creation acquires the lease

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -529,7 +529,7 @@ public class Blockchain : IAsyncDisposable
 
             // clean no longer used fields
             var data = new PooledSpanDictionary(Pool, false);
-            
+
             // use append for faster copies as state and storage won't overwrite each other
             _state.CopyTo(data, true);
             _storage.CopyTo(data, true);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -470,7 +470,7 @@ public class Blockchain : IAsyncDisposable
                     dict.Dispose();
                 }
 
-                dict = new PooledSpanDictionary(pool, true, true);
+                dict = new PooledSpanDictionary(pool, true);
             }
         }
 
@@ -529,7 +529,7 @@ public class Blockchain : IAsyncDisposable
 
             // clean no longer used fields
 
-            var data = new PooledSpanDictionary(Pool, false, true);
+            var data = new PooledSpanDictionary(Pool, false);
             Squash(_state, data);
             Squash(_storage, data);
             Squash(_preCommit, data);
@@ -765,7 +765,7 @@ public class Blockchain : IAsyncDisposable
 
             public ChildCommit(BufferPool pool, ICommit parent)
             {
-                _dict = new PooledSpanDictionary(pool, true, false);
+                _dict = new PooledSpanDictionary(pool, true);
                 _pool = pool;
                 _parent = parent;
             }

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -342,8 +342,6 @@ public class PooledSpanDictionary : IDisposable
                 }
             }
 
-            public ushort ShortHash { get; }
-
             public uint Hash => ((uint)GetLeftover(ref _b) << Root.BitShiftToUint) | _bucket;
 
             public byte Metadata => (byte)((_b & MetadataBit) >> MetadataShift);

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -57,6 +57,11 @@ public class PooledSpanDictionary : IDisposable
         return false;
     }
 
+    /// <summary>
+    /// The total overhead to write one item.
+    /// </summary>
+    public const int ItemOverhead = PreambleLength + AddressLength + KeyLengthLength + ValueLengthLength;
+    
     // Preamble
     private const byte PreambleBits = 0b1100_0000;
     private const byte DestroyedBit = 0b1000_0000;

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -204,7 +204,7 @@ public class PooledSpanDictionary : IDisposable
             if (_preserveOldValues == false)
             {
                 if (search.TryUpdateInSitu(data0, data1, metadata))
-                    return;    
+                    return;
             }
 
             // Destroy the search as it should not be visible later and move on with inserting as usual
@@ -290,10 +290,10 @@ public class PooledSpanDictionary : IDisposable
                 {
                     // Capture the current, move address to next immediately
                     ref var at = ref dictionary.GetAt(_address);
-                    
+
                     // The position is captured in ref at above, move to next
                     _address = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref at, PreambleLength));
-                    
+
                     if ((at & DestroyedBit) == 0)
                     {
                         // Set at the at as it represents an active item

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -197,12 +197,15 @@ public class PooledSpanDictionary : IDisposable
     {
         Debug.Assert(metadata <= MaxMetadata, "Metadata size breached");
 
-        var search = _preserveOldValues == false ? TryGetImpl(key, hash) : default;
+        var search = TryGetImpl(key, hash);
 
         if (search.IsFound)
         {
-            if (search.TryUpdateInSitu(data0, data1, metadata))
-                return;
+            if (_preserveOldValues == false)
+            {
+                if (search.TryUpdateInSitu(data0, data1, metadata))
+                    return;    
+            }
 
             // Destroy the search as it should not be visible later and move on with inserting as usual
             search.Destroy();


### PR DESCRIPTION
This PR changes the implementation of the `PooledSpanDictionary`, turning it into an unmanaged one with a default fanout of 8k slots.