### PR TITLE
Memoization properly asserted

### DIFF
--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Diagnostics.Metrics;
@@ -51,7 +52,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     /// </summary>
     /// <param name="minimumTreeLevelToMemoizeKeccak">Minimum lvl of the tree to memoize the Keccak of a branch node.</param>
     /// <param name="memoizeKeccakEvery">How often (which lvl mod) should Keccaks be memoized.</param>
-    /// <param name="memoizeRlp">For tests purposes only</param>
+    /// <param name="memoization">What to memoize, specifically.</param>
     public ComputeMerkleBehavior(int minimumTreeLevelToMemoizeKeccak = DefaultMinimumTreeLevelToMemoizeKeccak,
         int memoizeKeccakEvery = MemoizeKeccakEveryNLevel, Memoization memoization = Memoization.Branch)
     {
@@ -248,9 +249,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
         var node = Node.Header.Peek(data).NodeType;
 
-        if (node != Node.Type.Branch)
+        if (node != Node.Type.Branch || _memoization != Memoization.Branch)
         {
-            // extension is not modified
+            // Return data as is, either the node is not a branch or the memoization is not set for branches.
             return data;
         }
 

--- a/src/Paprika/Merkle/Memoization.cs
+++ b/src/Paprika/Merkle/Memoization.cs
@@ -1,4 +1,6 @@
-﻿namespace Paprika.Merkle;
+﻿using Paprika.Chain;
+
+namespace Paprika.Merkle;
 
 /// <summary>
 /// What should be memoized in Merkle as transient, to speed up the compute.
@@ -6,12 +8,15 @@
 public enum Memoization
 {
     /// <summary>
-    /// Nothing.
+    /// Nothing. The memoization will default to the <see cref="CacheBudget"/> available for Merkle and
+    /// will not create additional structures.
     /// </summary>
     None = 0,
 
     /// <summary>
-    /// 512bytes per branch, copied over between commits. Can cost a lot in terms of memory being copied.
+    /// Merkle component will additionally create a 512bytes per branch, copied over between commits.
+    /// Can cost a lot in terms of memory being copied. Tests showed reduced usefulness after introduction of
+    /// large enough <see cref="CacheBudget"/>. Much less copying, less memory occupied and less memory fragmentation.
     /// </summary>
     Branch = 1,
 }


### PR DESCRIPTION
This PR makes the `InspectBeforeApply` properly assert the content that is inspected only when the memoization is set to a branch