### PR TITLE
Faster SELF-DESTRUCTs

### DIFF
--- a/src/Paprika/Utils/Xor8.cs
+++ b/src/Paprika/Utils/Xor8.cs
@@ -32,8 +32,6 @@ public class Xor8
     public Xor8(IReadOnlyCollection<ulong> keys)
     {
         // TODO: remove all array allocations, use ArrayPool<ulong> more and/or buffer pool, potentially combine chunks of memory together
-
-
         var size = keys.Count;
         var arrayLength = GetArrayLength(size);
 


### PR DESCRIPTION
This reduces the impact of SELF-DESTRUCTs on the speed of data retrieval. The measurement is based on a long running spin test. The changes are the following:

1. Account destruction is done now by its key only, without scanning the whole dictionary.
2. Destroying values is done by the new  `.Destroy` method that can be called on the iterator of the pooled dict.
3. Introduction of Xor for destroyed.

### Results

This PR reduces the retrieval of data that are filtered by the destroyed by 20% to 30%. This should be even higher when getting more data after a block that includes SELF-DESTRUCTed contracts.