### PR TITLE
Volatile caching for read data

### DIFF
--- a/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
+++ b/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
@@ -235,7 +235,7 @@ public class PooledSpanDictionaryTests
 
         // dotMemory.Check();
         static void Set(uint i, byte[] key) => BinaryPrimitives.WriteUInt32LittleEndian(key, i);
-        static byte GetMetadata(ReadOnlySpan<byte> key) => (byte)(key[0] & 1);
+        static byte GetMetadata(ReadOnlySpan<byte> key) => (byte)(key[0] & 3);
 
         static void AssertIterate(PooledSpanDictionary dict)
         {

--- a/src/Paprika.Tests/Performance.cs
+++ b/src/Paprika.Tests/Performance.cs
@@ -1,0 +1,86 @@
+﻿using System.Runtime.CompilerServices;
+using Nethermind.Int256;
+using NUnit.Framework;
+using Paprika.Chain;
+using Paprika.Crypto;
+using Paprika.Merkle;
+using Paprika.Store;
+
+namespace Paprika.Tests;
+
+[Explicit("Performance tests are only to be run on an imported database")]
+public class Performance
+{
+    private const long GB = 1024 * 1024 * 1024;
+
+    [Test]
+    public async Task Read_non_existing()
+    {
+        const byte historyDepth = 64;
+        const long size = 64 * GB;
+
+        var random = new Random(17);
+        var value = new byte[] { 13 };
+
+        var path = ImportedDbPath();
+
+        using var db = PagedDb.MemoryMappedDb(size, historyDepth, path);
+        var cache = new CacheBudget.Options(5000, 16);
+        var merkle = new ComputeMerkleBehavior();
+
+        await using var blockchain = new Blockchain(db, merkle, TimeSpan.FromSeconds(10), cache, cache);
+
+        // Create 64 blocks, then try to read non-existing accounts
+
+        using var latest = db.BeginReadOnlyBatchOrLatest(default);
+
+        var parent = latest.Metadata.StateHash;
+        var parentNumber = latest.Metadata.BlockNumber;
+
+        for (var atBlock = 0; atBlock < 64; atBlock++)
+        {
+            using var block = blockchain.StartNew(parent);
+
+            for (var atAccount = 0; atAccount < 256; atAccount++)
+            {
+                Keccak account = default;
+                random.NextBytes(account.BytesAsSpan);
+
+                block.SetAccount(account, new Account(121, 23423));
+
+                for (var atStorage = 0; atStorage < 10; atStorage++)
+                {
+                    Keccak storage = default;
+                    random.NextBytes(storage.BytesAsSpan);
+
+                    block.SetStorage(account, storage, value);
+                }
+            }
+
+            parent = block.Commit(parentNumber + 1);
+            parentNumber++;
+        }
+
+        using var read = blockchain.StartNew(parent);
+        DoNonExistentReads(read, random);
+
+        static void DoNonExistentReads(IWorldState block, Random random)
+        {
+            UInt256 sum = 0;
+
+            for (var atAccount = 0; atAccount < 10_000; atAccount++)
+            {
+                Keccak account = default;
+                random.NextBytes(account.BytesAsSpan);
+
+                sum += block.GetAccount(account).Balance;
+            }
+        }
+    }
+
+    private static string ImportedDbPath([CallerFilePath] string path = "")
+    {
+        var dir = Path.GetDirectoryName(path);
+        return Path.Combine(dir, "..\\Paprika.Importer\\db");
+    }
+}

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -802,11 +802,11 @@ public class Blockchain : IAsyncDisposable
                 {
                     Key.ReadFrom(kvp.Key, out var key);
                     var type = (EntryType)kvp.Metadata;
-                    
+
                     // flush down only volatiles
                     if (type != EntryType.Volatile)
                     {
-                        parent.Set(key, kvp.Value, type);    
+                        parent.Set(key, kvp.Value, type);
                     }
                 }
             }

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -636,7 +636,7 @@ public class Blockchain : IAsyncDisposable
         {
             if (_cacheBudgetStorageAndStage.ShouldCache(owner))
             {
-                SetImpl(key, owner.Span, EntryType.TransientCache, dict);
+                SetImpl(key, owner.Span, EntryType.Transient, dict);
             }
         }
 
@@ -761,18 +761,9 @@ public class Blockchain : IAsyncDisposable
 
         public IReadOnlyDictionary<Keccak, int> Stats => _stats!;
 
-        class ChildCommit : RefCountingDisposable, IChildCommit
+        class ChildCommit(BufferPool pool, ICommit parent) : RefCountingDisposable, IChildCommit
         {
-            private readonly PooledSpanDictionary _dict;
-            private readonly BufferPool _pool;
-            private readonly ICommit _parent;
-
-            public ChildCommit(BufferPool pool, ICommit parent)
-            {
-                _dict = new PooledSpanDictionary(pool, true);
-                _pool = pool;
-                _parent = parent;
-            }
+            private readonly PooledSpanDictionary _dict = new(pool, true);
 
             public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
             {
@@ -785,7 +776,8 @@ public class Blockchain : IAsyncDisposable
                     return new ReadOnlySpanOwnerWithMetadata<byte>(new ReadOnlySpanOwner<byte>(result, this), 0);
                 }
 
-                return _parent.Get(key);
+                // Return as nested to show that it's beyond level 0.
+                return parent.Get(key).Nest();
             }
 
             public void Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type)
@@ -809,11 +801,17 @@ public class Blockchain : IAsyncDisposable
                 foreach (var kvp in _dict)
                 {
                     Key.ReadFrom(kvp.Key, out var key);
-                    _parent.Set(key, kvp.Value, (EntryType)kvp.Metadata);
+                    var type = (EntryType)kvp.Metadata;
+                    
+                    // flush down only volatiles
+                    if (type != EntryType.Volatile)
+                    {
+                        parent.Set(key, kvp.Value, type);    
+                    }
                 }
             }
 
-            public IChildCommit GetChild() => new ChildCommit(_pool, this);
+            public IChildCommit GetChild() => new ChildCommit(pool, this);
 
             public IReadOnlyDictionary<Keccak, int> Stats =>
                 throw new NotImplementedException("Child commits provide no stats");

--- a/src/Paprika/Chain/EntryType.cs
+++ b/src/Paprika/Chain/EntryType.cs
@@ -1,0 +1,22 @@
+﻿namespace Paprika.Chain;
+
+/// <summary>
+/// Used as metadata to differentiate between entries stored in blocks. 
+/// </summary>
+public enum EntryType : byte
+{
+    /// <summary>
+    /// A regular entry that should be persisted in the database.
+    /// </summary>
+    Persistent = 0,
+
+    /// <summary>
+    /// An entry representing data that were cached on the behalf of the decision of <see cref="CacheBudget.ShouldCache"/>.
+    /// </summary>
+    Transient = 1,
+
+    /// <summary>
+    /// The entry is put only for a short period of computation and should not be considered to be stored in memory beyond this computation.
+    /// </summary>
+    Volatile = 2
+}

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -59,7 +59,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     /// <param name="memoizeKeccakEvery">How often (which lvl mod) should Keccaks be memoized.</param>
     /// <param name="memoization">What to memoize, specifically.</param>
     public ComputeMerkleBehavior(int minimumTreeLevelToMemoizeKeccak = DefaultMinimumTreeLevelToMemoizeKeccak,
-        int memoizeKeccakEvery = MemoizeKeccakEveryNLevel, Memoization memoization = Memoization.Branch)
+        int memoizeKeccakEvery = MemoizeKeccakEveryNLevel, Memoization memoization = Memoization.None)
     {
         _minimumTreeLevelToMemoizeKeccak = minimumTreeLevelToMemoizeKeccak;
         _memoizeKeccakEvery = memoizeKeccakEvery;

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -316,9 +316,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         // As leafs are not stored in the database, hint to lookup again on missing.
         using var owner = ctx.Commit.Get(key);
 
-        if (ctx.Budget.ShouldCache(owner))
+        if (ctx.Budget.ShouldCache(owner, out var entryType))
         {
-            ctx.Commit.Set(key, owner.Span, EntryType.TransientCache);
+            ctx.Commit.Set(key, owner.Span, entryType);
         }
 
         if (owner.IsEmpty)
@@ -372,9 +372,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         }
 #endif
 
-        if (ctx.Budget.ShouldCache(leafData))
+        if (ctx.Budget.ShouldCache(leafData, out var entryType))
         {
-            ctx.Commit.Set(leafKey, leafData.Span, EntryType.TransientCache);
+            ctx.Commit.Set(leafKey, leafData.Span, entryType);
         }
 
         KeccakOrRlp keccakOrRlp;
@@ -995,9 +995,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
                         if (diffAt == leaf.Path.Length)
                         {
-                            if (budget.ShouldCache(owner))
+                            if (budget.ShouldCache(owner, out var cacheType))
                             {
-                                commit.SetLeaf(key, leftoverPath, EntryType.TransientCache);
+                                commit.SetLeaf(key, leftoverPath, cacheType);
                             }
 
                             return;
@@ -1150,9 +1150,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                             }
                         }
 
-                        if (updated == false && budget.ShouldCache(owner))
+                        if (updated == false && budget.ShouldCache(owner, out var entryType))
                         {
-                            commit.SetBranch(key, children, EntryType.TransientCache);
+                            commit.SetBranch(key, children, entryType);
                         }
 
                         if (array != null)

--- a/src/Paprika/Merkle/EntryType.cs
+++ b/src/Paprika/Merkle/EntryType.cs
@@ -1,8 +1,0 @@
-﻿namespace Paprika.Merkle;
-
-public enum EntryType : byte
-{
-    Persistent = 0,
-
-    TransientCache = 1
-}


### PR DESCRIPTION
This PR introduces a new kind of entry type called `Volatile` and aggressively uses it whenever there's not room for the transient cache and data are quite likely to be accessed again (for example: branches, leafs for Merkle). This is leveraged by Merkle, so that if the data are not cached in a Transient manner, they will be cached with `Volatile`. `Volatile` entries are not squashed into the parent commit so this should greatly limit the amount of data being kept in memory