### PR TITLE
ReadOnlyBatch caches ids

### DIFF
--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -49,7 +49,7 @@ abstract class BatchContextBase : IBatchContext
 
     public abstract void RegisterForFutureReuse(Page page);
 
-    public abstract Dictionary<Keccak, uint> IdCache { get; }
+    public abstract IDictionary<Keccak, uint> IdCache { get; }
 
     /// <summary>
     /// Assigns the batch identifier to a given page, marking it writable by this batch.

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -33,8 +33,6 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// </summary>
     void RegisterForFutureReuse(Page page);
 
-    Dictionary<Keccak, uint> IdCache { get; }
-
     /// <summary>
     /// Assigns the batch identifier to a given page, marking it writable by this batch.
     /// </summary>
@@ -55,6 +53,8 @@ public interface IReadOnlyBatchContext : IPageResolver
     /// Gets the current <see cref="IBatch"/> id.
     /// </summary>
     uint BatchId { get; }
+
+    IDictionary<Keccak, uint> IdCache { get; }
 }
 
 public static class ReadOnlyBatchContextExtensions

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -357,7 +357,9 @@ public class PagedDb : IPageResolver, IDb, IDisposable
 
     private class ReadOnlyBatch(PagedDb db, RootPage root, string name) : IReportingReadOnlyBatch, IReadOnlyBatchContext
     {
-        private readonly ConcurrentDictionary<Keccak, uint> _idCache = new();
+        private readonly ConcurrentDictionary<Keccak, uint> _idCache = new(Environment.ProcessorCount,
+            RootPage.IdCacheLimit);
+
         public RootPage Root => root;
 
         private long _reads;

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Runtime.InteropServices;
 using Paprika.Chain;
@@ -356,6 +357,7 @@ public class PagedDb : IPageResolver, IDb, IDisposable
 
     private class ReadOnlyBatch(PagedDb db, RootPage root, string name) : IReportingReadOnlyBatch, IReadOnlyBatchContext
     {
+        private readonly ConcurrentDictionary<Keccak, uint> _idCache = new();
         public RootPage Root => root;
 
         private long _reads;
@@ -392,6 +394,8 @@ public class PagedDb : IPageResolver, IDb, IDisposable
         }
 
         public uint BatchId => root.Header.BatchId;
+
+        public IDictionary<Keccak, uint> IdCache => _idCache;
 
         public Page GetAt(DbAddress address) => db._manager.GetAt(address);
 

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -105,6 +105,11 @@ public readonly unsafe struct RootPage(Page root) : IPage
         Data.AbandonedList.Accept(visitor, resolver);
     }
 
+    /// <summary>
+    /// How many id entries should be cached per readonly batch.
+    /// </summary>
+    public const int IdCacheLimit = 2_000;
+
     public bool TryGet(scoped in Key key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
     {
         if (key.IsState)
@@ -139,8 +144,10 @@ public readonly unsafe struct RootPage(Page root) : IPage
         {
             if (Data.Ids.TryGet(key.Path, batch, out id))
             {
-                // found, memoize
-                cache[keccak] = ReadId(id);
+                if (cache.Count < IdCacheLimit)
+                {
+                    cache[keccak] = ReadId(id);
+                }
             }
             else
             {


### PR DESCRIPTION
This PR introduces a cache of ids for the `ReadOnlyBatch`. As the readonly batch is used to access data that are not in memory, caching ids may speed up each query against storage (Merkle or value) by a few lookups. This, if a given account has its storage Merkleized, should benefit a lot.