### PR TITLE
Better hash

### DIFF
--- a/src/Paprika.Tests/Data/KeyTests.cs
+++ b/src/Paprika.Tests/Data/KeyTests.cs
@@ -97,6 +97,18 @@ public class KeyTests
                 NibblePath.FromKey(Keccak.EmptyTreeHash).SliceTo(i)));
         }
 
+        for (var x = 0; x < 16; x++)
+        {
+            var nibbles = NibblePath.Parse("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde" + x.ToString("x").ToLowerInvariant());
+            Unique(Key.Raw(aPath, DataType.Merkle, nibbles));
+
+            nibbles = NibblePath.Parse(x.ToString("x").ToLowerInvariant() + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde");
+            for (var i = 1; i < 32; i++)
+            {
+                Unique(Key.Raw(aPath, DataType.Merkle, nibbles.SliceTo(i)));
+            }
+        }
+
         // Additional colliding ones
         Unique(Key.Merkle(NibblePath.Parse("DAE3")));
         Unique(Key.Merkle(NibblePath.Parse("251C")));
@@ -118,7 +130,8 @@ public class KeyTests
             if (hashes.TryAdd(hash, hex) == false)
             {
                 var existing = hashes[hash];
-                Assert.Fail($"The hash for {hex} is the same as for {existing}");
+                if (existing != hex)
+                    Assert.Fail($"The hash for {hex} is the same as for {existing}");
             }
         }
     }

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO.Hashing;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using Paprika.Crypto;
 using Paprika.Store;
@@ -99,14 +100,17 @@ public readonly ref partial struct Key
     [SkipLocalsInit]
     public override int GetHashCode()
     {
-        return (int)Type ^ Path.GetHashCode() ^ StoragePath.GetHashCode();
+        return (int)BitOperations.Crc32C((uint)Path.GetHashCode(), (uint)StoragePath.GetHashCode()) + (byte)Type;
     }
 
     [SkipLocalsInit]
     public ulong GetHashCodeULong()
     {
-        return unchecked((ulong)(((long)Path.GetHashCode() << 32) |
-                                 (long)(StoragePath.GetHashCode() ^ (byte)Type)));
+        var pathHash = Path.GetHashCode();
+        var storageHash = StoragePath.GetHashCode();
+
+        ulong hash = BitOperations.Crc32C((uint)pathHash, (uint)storageHash) + (byte)Type;
+        return (((ulong)(uint)pathHash) << 32 | (uint)storageHash) ^ (hash << 32 | hash);
     }
 
     public override string ToString()

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -585,7 +585,7 @@ public readonly ref struct NibblePath
             if (length >= sizeof(short))
             {
                 hash = BitOperations.Crc32C(hash, Unsafe.ReadUnaligned<ushort>(ref span));
-                length -= sizeof(int);
+                length -= sizeof(short);
                 if (length > 0)
                 {
                     // Do final hash as sizeof(long) from end rather than start


### PR DESCRIPTION
- Use hardware accelerated Crc32C
- When in a size path `ulong`, `uint` etc use that for final bytes also if don't fit by hashing from the end rather than start