### PR TITLE
StorageFanOutPage introduces

### DIFF
--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -97,7 +97,7 @@ public class PagedDbTests
         const int accounts = 512 * 1024;
         const int size = 10_000;
 
-        using var db = PagedDb.NativeMemoryDb(512 * Mb, 2);
+        using var db = PagedDb.NativeMemoryDb(1024 * Mb, 2);
 
         var value = new byte[1] { 13 };
 

--- a/src/Paprika/Store/FanOutList.cs
+++ b/src/Paprika/Store/FanOutList.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using Paprika.Data;
+﻿using Paprika.Data;
 
 namespace Paprika.Store;
 
@@ -71,7 +70,7 @@ public readonly ref struct FanOutList<TPage, TPageType>(Span<DbAddress> addresse
         {
             if (!bucket.IsNull)
             {
-                new DataPage(resolver.GetAt(bucket)).Report(reporter, resolver, level + 1);
+                TPage.Wrap(resolver.GetAt(bucket)).Report(reporter, resolver, level + 1);
             }
         }
     }

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -27,6 +27,8 @@ public interface IPageWithData<TPage> : IPage
     bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result);
 
     Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch);
+
+    void Report(IReporter reporter, IPageResolver resolver, int level);
 }
 
 /// <summary>

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -1,5 +1,4 @@
 ﻿using System.Buffers.Binary;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Paprika.Crypto;
@@ -68,7 +67,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         [FieldOffset(DbAddress.Size * 2 + sizeof(uint) + Metadata.Size)]
         private DbAddress StoragePayload;
 
-        public FanOutList<DataPage, StandardType> Storage => new(MemoryMarshal.CreateSpan(ref StoragePayload, FanOutList.FanOut));
+        public FanOutList<StorageFanOutPage<DataPage>, StandardType> Storage => new(MemoryMarshal.CreateSpan(ref StoragePayload, FanOutList.FanOut));
 
         /// <summary>
         /// Identifiers

--- a/src/Paprika/Store/StorageFanOutPage.cs
+++ b/src/Paprika/Store/StorageFanOutPage.cs
@@ -1,0 +1,136 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Paprika.Data;
+
+namespace Paprika.Store;
+
+/// <summary>
+/// The fan out page for storage, buffering some writes and providing a heavy fan out.
+/// Once filled, flushed down all its content to make room for more.
+/// Useful only for higher levels of the storage trie.
+/// </summary>
+[method: DebuggerStepThrough]
+public readonly unsafe struct StorageFanOutPage<TNext>(Page page) : IPageWithData<StorageFanOutPage<TNext>>
+    where TNext : struct, IPageWithData<TNext>
+{
+    public static StorageFanOutPage<TNext> Wrap(Page page) => new(page);
+
+    private const int ConsumedNibbles = 2;
+    private const int LevelDiff = 1;
+
+    private ref PageHeader Header => ref page.Header;
+
+    private ref StorageFanOutPage.Payload Data => ref Unsafe.AsRef<StorageFanOutPage.Payload>(page.Payload);
+
+    public bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
+    {
+        var map = new SlottedArray(Data.Data);
+
+        if (map.TryGet(key, out result))
+        {
+            return true;
+        }
+
+        var index = GetIndex(key);
+
+        var addr = Data.Addresses[index];
+        if (addr.IsNull)
+        {
+            result = default;
+            return false;
+        }
+
+        return TNext.Wrap(batch.GetAt(addr)).TryGet(key.SliceFrom(ConsumedNibbles), batch, out result);
+    }
+
+    private static int GetIndex(scoped in NibblePath key) => (key.GetAt(0) << NibblePath.NibbleShift) + key.GetAt(1);
+
+    public Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        if (Header.BatchId != batch.BatchId)
+        {
+            // the page is from another batch, meaning, it's readonly. Copy
+            var writable = batch.GetWritableCopy(page);
+            return new StorageFanOutPage<TNext>(writable).Set(key, data, batch);
+        }
+
+        var map = new SlottedArray(Data.Data);
+
+        if (map.TrySet(key, data))
+        {
+            return page;
+        }
+
+        // No space in page, flush down
+        foreach (var item in map.EnumerateAll())
+        {
+            var index = GetIndex(item.Key);
+            var sliced = item.Key.SliceFrom(ConsumedNibbles);
+
+            ref var addr = ref Data.Addresses[index];
+
+            Page child;
+
+            if (addr.IsNull)
+            {
+                child = batch.GetNewPage(out addr, true);
+                child.Header.PageType = Header.PageType;
+                child.Header.Level = (byte)(page.Header.Level + LevelDiff);
+            }
+            else
+            {
+                child = batch.GetAt(addr);
+            }
+
+            // set and delete
+            addr = batch.GetAddress(TNext.Wrap(child).Set(sliced, item.RawData, batch));
+            map.Delete(item);
+        }
+
+        // retry
+        return Set(key, data, batch);
+    }
+
+    public void Report(IReporter reporter, IPageResolver resolver, int level)
+    {
+        foreach (var bucket in Data.Addresses)
+        {
+            if (!bucket.IsNull)
+            {
+                TNext.Wrap(resolver.GetAt(bucket)).Report(reporter, resolver, level + LevelDiff);
+            }
+        }
+    }
+}
+
+static class StorageFanOutPage
+{
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    public struct Payload
+    {
+        private const int Size = Page.PageSize - PageHeader.Size;
+
+        private const int FanOutSize = FanOut * DbAddress.Size;
+
+        private const int DataSize = Size - FanOutSize;
+
+        /// <summary>
+        /// The number of buckets to fan out to.
+        /// </summary>
+        private const int FanOut = 256;
+
+        /// <summary>
+        /// The first item of map of frames to allow ref to it.
+        /// </summary>
+        [FieldOffset(0)] private DbAddress Address;
+
+        public Span<DbAddress> Addresses => MemoryMarshal.CreateSpan(ref Address, FanOut);
+
+        [FieldOffset(FanOutSize)] private byte DataFirst;
+
+        public Span<byte> Data => MemoryMarshal.CreateSpan(ref DataFirst, DataSize);
+    }
+
+}
+


### PR DESCRIPTION
This PR introduces an additional fan out of 256 under the list of 256 in storage. This means that to reach one of 64k buckets, only root page and fanout page needs to be traversed. The side effect, beside much better performance are terribly nested generics (TM) `FanOutList<StorageFanOutPage<DataPage>, StandardType>` that provide the structure for the tree. This particular one is `FanOutList` a list of addresses in the `RootPage` that fans out to `StorageFanOutPage<DataPage>` pages that later are followed by regular `DataPage`