### PR TITLE
New account hint introduced

### DIFF
--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers.Binary;
+using System.Security.Cryptography;
 using FluentAssertions;
 using NUnit.Framework;
 using Paprika.Chain;
@@ -181,6 +182,11 @@ public static class TestExtensions
         {
             if (block.blockNumber == blockNumber)
                 tcs.SetResult();
+        };
+
+        chain.FlusherFailure += (_, ex) =>
+        {
+            tcs.SetException(ex);
         };
 
         return tcs.Task;

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -26,6 +26,13 @@ public interface IPreCommitBehavior
     /// <param name="data">The data.</param>
     /// <returns>The data that should be put in place.</returns>
     ReadOnlySpan<byte> InspectBeforeApply(in Key key, ReadOnlySpan<byte> data) => data;
+
+    /// <summary>
+    /// Executed when the new account is created, allowing for some optimizations.
+    /// </summary>
+    void OnNewAccountCreated(in Keccak address, ICommit commit)
+    {
+    }
 }
 
 /// <summary>

--- a/src/Paprika/Chain/IWorldState.cs
+++ b/src/Paprika/Chain/IWorldState.cs
@@ -16,7 +16,11 @@ public interface IWorldState : IDisposable
     /// </summary>
     Keccak Hash { get; }
 
-    void SetAccount(in Keccak address, in Account account);
+    /// <summary>
+    /// Sets the account. If the caller is sure that this is a new account,
+    /// pass the <paramref name="newAccountHint"/> to reduce the overhead of the creation.
+    /// </summary>
+    void SetAccount(in Keccak address, in Account account, bool newAccountHint = false);
 
     /// <summary>
     /// Destroys the given account.

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -185,7 +185,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     /// </summary>
     /// <param name="commit">The original commit.</param>
     /// <param name="workItems">The work items.</param>
-    private void ScatterGather(ICommit commit, IEnumerable<IWorkItem> workItems)
+    private static void ScatterGather(ICommit commit, IEnumerable<IWorkItem> workItems)
     {
         var children = new ConcurrentQueue<IChildCommit>();
 
@@ -206,8 +206,13 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         }
     }
 
-    private static bool ShouldCacheKey(in Key key) => key.Type == DataType.Merkle;
-    private static bool ShouldCacheResult(in ReadOnlySpanOwnerWithMetadata<byte> result) => true;
+    public void OnNewAccountCreated(in Keccak address, ICommit commit)
+    {
+        // Set a transient empty entry for the newly created account.
+        // This simulates an empty storage tree. 
+        // If this account has storage set, it won't try to query the database to get nothing, it will get nothing from here.
+        commit.Set(Key.Merkle(NibblePath.FromKey(address)), ReadOnlySpan<byte>.Empty, EntryType.Transient);
+    }
 
     /// <summary>
     /// Builds works items responsible for building up the storage tries.


### PR DESCRIPTION
This PR introduces a hint that can be used by state provider when a new account is detected (see: [`ChangeType.New` in Nethermind](https://github.com/NethermindEth/nethermind/blob/fd9c8ba72e32fba1bb7f92b08ffc11f137c3de26/src/Nethermind/Nethermind.State/StateProvider.cs#L784)). When used, the cost of creating a new contract with storage falls down drastically (ten times).

### Benchmark

Same synthetic test

#### Before

![image](https://github.com/NethermindEth/Paprika/assets/519707/0febb045-d980-4361-91f3-2e2668ae8280)

#### After

![image](https://github.com/NethermindEth/Paprika/assets/519707/8c49f1f5-027e-40e8-ade9-9e7467077d89)
