### PR TITLE
PooledSpanDictionary respects the lifecycle of UseOnce

### DIFF
--- a/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
+++ b/src/Paprika.Tests/Chain/PooledSpanDictionaryTests.cs
@@ -163,7 +163,7 @@ public class PooledSpanDictionaryTests
 
         // Copy
         using var copy = new PooledSpanDictionary(pool);
-        dict.CopyTo(copy);
+        dict.CopyTo(copy, b => true);
 
         // Assert
         dict.TryGet(key, hash, out result).Should().BeTrue();
@@ -228,7 +228,7 @@ public class PooledSpanDictionaryTests
 
         // Copy & test copy
         using var copy = new PooledSpanDictionary(pool, false);
-        dict.CopyTo(copy);
+        dict.CopyTo(copy, b => true);
 
         AssertIterate(copy);
         return;

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -538,15 +538,22 @@ public class Blockchain : IAsyncDisposable
             var data = new PooledSpanDictionary(Pool, false);
 
             // use append for faster copies as state and storage won't overwrite each other
-            _state.CopyTo(data, true);
-            _storage.CopyTo(data, true);
-            _preCommit.CopyTo(data);
+            _state.CopyTo(data, OmitVolatile, true);
+            _storage.CopyTo(data, OmitVolatile, true);
+            _preCommit.CopyTo(data, OmitVolatile);
 
             // Creation acquires the lease
             return new CommittedBlockState(xor, _destroyed, _blockchain, data, hash,
                 ParentHash,
                 blockNumber, raw);
         }
+
+        /// <summary>
+        /// Filters out entries that are of type <see cref="EntryType.UseOnce"/>.
+        /// </summary>
+        /// <param name="metadata"></param>
+        /// <returns></returns>
+        private static bool OmitVolatile(byte metadata) => metadata != (int)EntryType.UseOnce;
 
         public CommittedBlockState CommitRaw() => CommitImpl(0, true)!;
 
@@ -642,7 +649,7 @@ public class Blockchain : IAsyncDisposable
         {
             if (_cacheBudgetStorageAndStage.ShouldCache(owner))
             {
-                SetImpl(key, owner.Span, EntryType.Transient, dict);
+                SetImpl(key, owner.Span, EntryType.Cached, dict);
             }
         }
 
@@ -816,7 +823,7 @@ public class Blockchain : IAsyncDisposable
                     var type = (EntryType)kvp.Metadata;
 
                     // flush down only volatiles
-                    if (type != EntryType.Volatile)
+                    if (type != EntryType.UseOnce)
                     {
                         parent.Set(key, kvp.Value, type);
                     }
@@ -966,34 +973,6 @@ public class Blockchain : IAsyncDisposable
             foreach (var ancestor in _ancestors)
             {
                 ancestor.Dispose();
-            }
-        }
-
-        public void Assert(IReadOnlyBatch batch)
-        {
-            using var squashed = new PooledSpanDictionary(Pool);
-
-            _state.CopyTo(squashed);
-            _storage.CopyTo(squashed);
-            _preCommit.CopyTo(squashed);
-
-            foreach (var kvp in squashed)
-            {
-                Key.ReadFrom(kvp.Key, out var key);
-
-                if (!batch.TryGet(key, out var value))
-                {
-                    throw new KeyNotFoundException($"Key {key.ToString()} not found.");
-                }
-
-                if (!value.SequenceEqual(kvp.Value))
-                {
-                    var expected = kvp.Value.ToHexString(false);
-                    var actual = value.ToHexString(false);
-
-                    throw new Exception($"Values are different for {key.ToString()}. " +
-                                        $"Expected is {expected} while found is {actual}.");
-                }
             }
         }
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -538,9 +538,9 @@ public class Blockchain : IAsyncDisposable
             var data = new PooledSpanDictionary(Pool, false);
 
             // use append for faster copies as state and storage won't overwrite each other
-            _state.CopyTo(data, OmitVolatile, true);
-            _storage.CopyTo(data, OmitVolatile, true);
-            _preCommit.CopyTo(data, OmitVolatile);
+            _state.CopyTo(data, OmitUseOnce, true);
+            _storage.CopyTo(data, OmitUseOnce, true);
+            _preCommit.CopyTo(data, OmitUseOnce);
 
             // Creation acquires the lease
             return new CommittedBlockState(xor, _destroyed, _blockchain, data, hash,
@@ -549,11 +549,9 @@ public class Blockchain : IAsyncDisposable
         }
 
         /// <summary>
-        /// Filters out entries that are of type <see cref="EntryType.UseOnce"/>.
+        /// Filters out entries that are of type <see cref="EntryType.UseOnce"/> as they should be used once only.
         /// </summary>
-        /// <param name="metadata"></param>
-        /// <returns></returns>
-        private static bool OmitVolatile(byte metadata) => metadata != (int)EntryType.UseOnce;
+        private static bool OmitUseOnce(byte metadata) => metadata != (int)EntryType.UseOnce;
 
         public CommittedBlockState CommitRaw() => CommitImpl(0, true)!;
 

--- a/src/Paprika/Chain/CacheBudget.cs
+++ b/src/Paprika/Chain/CacheBudget.cs
@@ -49,14 +49,14 @@ public class CacheBudget
     {
         if (ShouldCache(owner))
         {
-            type = EntryType.Transient;
+            type = EntryType.Cached;
             return true;
         }
 
         // Either budget is full or depth was not sufficient. For anything beyond 0, use volatile
         if (owner.QueryDepth > 0)
         {
-            type = EntryType.Volatile;
+            type = EntryType.UseOnce;
             return true;
         }
 

--- a/src/Paprika/Chain/EntryType.cs
+++ b/src/Paprika/Chain/EntryType.cs
@@ -11,12 +11,12 @@ public enum EntryType : byte
     Persistent = 0,
 
     /// <summary>
-    /// An entry representing data that were cached on the behalf of the decision of <see cref="CacheBudget.ShouldCache"/>.
+    /// An entry representing data that were cached on the behalf of the decision of <see cref="CacheBudget"/>.
     /// </summary>
-    Transient = 1,
+    Cached = 1,
 
     /// <summary>
     /// The entry is put only for a short period of computation and should not be considered to be stored in memory beyond this computation.
     /// </summary>
-    Volatile = 2
+    UseOnce = 2
 }

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -135,11 +135,14 @@ public class PooledSpanDictionary : IDisposable
         return default;
     }
 
-    public void CopyTo(PooledSpanDictionary destination, bool append = false)
+    public void CopyTo(PooledSpanDictionary destination, Predicate<byte> metadataWhere, bool append = false)
     {
         foreach (var kvp in this)
         {
-            destination.SetImpl(kvp.Key, kvp.Hash, kvp.Value, ReadOnlySpan<byte>.Empty, kvp.Metadata, append);
+            if (metadataWhere(kvp.Metadata))
+            {
+                destination.SetImpl(kvp.Key, kvp.Hash, kvp.Value, ReadOnlySpan<byte>.Empty, kvp.Metadata, append);
+            }
         }
     }
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -211,7 +211,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         // Set a transient empty entry for the newly created account.
         // This simulates an empty storage tree. 
         // If this account has storage set, it won't try to query the database to get nothing, it will get nothing from here.
-        commit.Set(Key.Merkle(NibblePath.FromKey(address)), ReadOnlySpan<byte>.Empty, EntryType.Transient);
+        commit.Set(Key.Merkle(NibblePath.FromKey(address)), ReadOnlySpan<byte>.Empty, EntryType.Cached);
     }
 
     /// <summary>


### PR DESCRIPTION
This PR fixes the behavior of `PooledSpanDictionary` that previously was not respecting the `EntryType.Volatile` (renamed to `UseOnce`) and was copying it over to the committed state. Entries that are `UseOnce` should be discarded on copying between dictionaries and should never go to the `CommittedState`