### PR TITLE
Getting data for Merkle of Storage time reduced

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -920,8 +920,9 @@ public class Blockchain : IAsyncDisposable
                 _ => null
             };
 
-            // first always try pre-commit as it may overwrite data
-            if (_preCommit.TryGet(keyWritten, bloom, out var span))
+            // First always try pre-commit as it may overwrite data.
+            // Don't do it for the storage though! StorageCell entries are not modified by pre-commit! It can only read them!
+            if (key.Type != DataType.StorageCell && _preCommit.TryGet(keyWritten, bloom, out var span))
             {
                 // return with owned lease
                 succeeded = true;


### PR DESCRIPTION
This PR removes one retrieval from the dictionary for `StorageCell` entries. As Merkleization of Storage tree never changes `StorageCell`s, there's no reason to first try to read from the pre-commit data. If the hash points that a given cell was written for this commit, jump directly to the `_storage` dictionary.