### PR TITLE
Destroy handling updated

### DIFF
--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -33,6 +33,13 @@ public interface IPreCommitBehavior
     void OnNewAccountCreated(in Keccak address, ICommit commit)
     {
     }
+
+    /// <summary>
+    /// Executed after the current state & storage is cleared.
+    /// </summary>
+    void OnAccountDestroyed(in Keccak address, ICommit commit)
+    {
+    }
 }
 
 /// <summary>

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -209,9 +209,17 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     public void OnNewAccountCreated(in Keccak address, ICommit commit)
     {
         // Set a transient empty entry for the newly created account.
+        // This simulates an empty storage tree.
+        // If this account has storage set, it won't try to query the database to get nothing, it will get nothing from here.
+        commit.Set(Key.Merkle(NibblePath.FromKey(address)), ReadOnlySpan<byte>.Empty, EntryType.UseOnce);
+    }
+
+    public void OnAccountDestroyed(in Keccak address, ICommit commit)
+    {
+        // Set an empty entry as the storage root for the destroyed account.
         // This simulates an empty storage tree. 
         // If this account has storage set, it won't try to query the database to get nothing, it will get nothing from here.
-        commit.Set(Key.Merkle(NibblePath.FromKey(address)), ReadOnlySpan<byte>.Empty, EntryType.Cached);
+        commit.Set(Key.Merkle(NibblePath.FromKey(address)), ReadOnlySpan<byte>.Empty, EntryType.UseOnce);
     }
 
     /// <summary>


### PR DESCRIPTION
This PR changes the way destruction is applied:

1. It explicitly puts a destroy value for the account, an empty span. This allows to serve the empty state from the block without checking the destruction set. Also, allows for simpler visiting the tree.
2. It extends the `Merkle` behavior so that it puts an empty storage root. If the contract is recreated in the same block, it will use this value to read that there's an empty root rather than scanning the destroy set.