### PR TITLE
Dense slotted array

### DIFF
--- a/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
+++ b/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
-      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.7" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Paprika.Tests/Data/NibblePathTests.cs
+++ b/src/Paprika.Tests/Data/NibblePathTests.cs
@@ -256,7 +256,7 @@ public class NibblePathTests
     }
 
     [Test]
-    public void PrependNibble_odd()
+    public void Append_nibble_odd()
     {
         const byte first = 0xDC;
         const byte second = 0xBA;
@@ -277,7 +277,7 @@ public class NibblePathTests
     }
 
     [Test]
-    public void PrependNibble_even()
+    public void Append_nibble_even()
     {
         const byte first = 0xDC;
         const byte nibble = 0xE;

--- a/src/Paprika.Tests/Data/SlottedArrayTests.cs
+++ b/src/Paprika.Tests/Data/SlottedArrayTests.cs
@@ -32,7 +32,7 @@ public class SlottedArrayTests
     }
 
     [Test]
-    public void Enumerate_all([Values(0,1)] int odd)
+    public void Enumerate_all([Values(0, 1)] int odd)
     {
         Span<byte> span = stackalloc byte[256];
         var map = new SlottedArray(span);
@@ -199,7 +199,7 @@ file static class FixedMapTestExtensions
     {
         map.TrySet(key, data).Should().BeTrue(because ?? "TrySet should succeed");
     }
-    
+
     public static void SetAssert(this SlottedArray map, in ReadOnlySpan<byte> key, ReadOnlySpan<byte> data,
         string? because = null)
     {

--- a/src/Paprika.Tests/Data/SlottedArrayTests.cs
+++ b/src/Paprika.Tests/Data/SlottedArrayTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
+using Paprika.Crypto;
 using Paprika.Data;
 
 namespace Paprika.Tests.Data;
@@ -166,50 +167,59 @@ public class SlottedArrayTests
             map.GetAssert(key, value);
         }
     }
-    //
-    // [Test]
-    // public void Hashing()
-    // {
-    //     var hashes = new Dictionary<ushort, string>();
-    //
-    //     // empty
-    //     Unique(ReadOnlySpan<byte>.Empty);
-    //
-    //     // single byte
-    //     Unique(stackalloc byte[] { 1 });
-    //     Unique(stackalloc byte[] { 2 });
-    //     Unique(stackalloc byte[] { 16 });
-    //     Unique(stackalloc byte[] { 17 });
-    //
-    //
-    //     // two bytes
-    //     Unique(stackalloc byte[] { 0xA, 0xC });
-    //     Unique(stackalloc byte[] { 0xA, 0xB });
-    //     Unique(stackalloc byte[] { 0xB, 0xC });
-    //
-    //     // three bytes
-    //     Unique(stackalloc byte[] { 0xA, 0xD, 0xC });
-    //     Unique(stackalloc byte[] { 0xAA, 0xEE, 0xCC });
-    //     Unique(stackalloc byte[] { 0xAA, 0xFF, 0xCC });
-    //
-    //     // three bytes
-    //     Unique(stackalloc byte[] { 0xAA, 0xDD, 0xCC, 0x11 });
-    //     Unique(stackalloc byte[] { 0xAA, 0xEE, 0xCC, 0x11 });
-    //     Unique(stackalloc byte[] { 0xAA, 0xFF, 0xCC, 0x11 });
-    //
-    //     return;
-    //
-    //     void Unique(in ReadOnlySpan<byte> key)
-    //     {
-    //         var hash = SlottedArray.PrepareKey(NibblePath.FromKey(key));
-    //         var hex = key.ToHexString(true);
-    //
-    //         if (hashes.TryAdd(hash, hex) == false)
-    //         {
-    //             Assert.Fail($"The hash for {hex} is the same as for {hashes[hash]}");
-    //         }
-    //     }
-    // }
+
+    [Test]
+    public void Hashing()
+    {
+        var hashes = new Dictionary<ushort, string>();
+
+        // empty
+        Unique("");
+
+        // single nibble
+        Unique("A");
+        Unique("B");
+        Unique("C");
+        Unique("7");
+
+        // two nibbles
+        Unique("AC");
+        Unique("AB");
+        Unique("BC");
+
+        // three nibbles
+        Unique("ADC");
+        Unique("AEB");
+        Unique("BEC");
+
+        // four nibbles
+        Unique("ADC1");
+        Unique("AEB1");
+        Unique("BEC1");
+
+        // 5 nibbles, with last changed
+        Unique("AD0C2");
+        Unique("AE0B2");
+        Unique("BE0C2");
+
+        // 6 nibbles, with last changed
+        Unique("AD00C3");
+        Unique("AE00B3");
+        Unique("BE00C3");
+
+        return;
+
+        void Unique(string key)
+        {
+            var path = NibblePath.Parse(key);
+            var hash = SlottedArray.HashForTests(path);
+
+            if (hashes.TryAdd(hash, key) == false)
+            {
+                Assert.Fail($"The hash for {key} is the same as for {hashes[hash]}");
+            }
+        }
+    }
 }
 
 file static class FixedMapTestExtensions

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -278,6 +278,34 @@ public readonly ref struct NibblePath
         return appended;
     }
 
+    /// <summary>
+    /// Appends the <see cref="other1"/> and then <see cref="other2"/> path using the <paramref name="workingSet"/> as the working memory.
+    /// </summary>
+    public NibblePath Append(scoped in NibblePath other1, scoped in NibblePath other2, Span<byte> workingSet)
+    {
+        if (workingSet.Length <= MaxByteLength)
+        {
+            throw new ArgumentException("Not enough memory to append");
+        }
+
+        // TODO: do a ref comparison with Unsafe, if the same, no need to copy!
+        WriteTo(workingSet);
+
+        var appended = new NibblePath(ref workingSet[PreambleLength], _odd, (byte)(Length + other1.Length + other2.Length));
+
+        for (var i = 0; i < other1.Length; i++)
+        {
+            appended.UnsafeSetAt(Length + i, 0, other1[i]);
+        }
+
+        for (var i = 0; i < other2.Length; i++)
+        {
+            appended.UnsafeSetAt(Length + other1.Length + i, 0, other2[i]);
+        }
+
+        return appended;
+    }
+
     public byte FirstNibble => (byte)((_span >> ((1 - _odd) * NibbleShift)) & NibbleMask);
 
     private static int GetSpanLength(byte length, int odd) => (length + 1 + odd) / 2;

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -282,6 +282,18 @@ public readonly ref struct NibblePath
 
         return source.Slice(PreambleLength + GetSpanLength(length, odd));
     }
+    
+    public static Span<byte> ReadFrom(Span<byte> source, out NibblePath nibblePath)
+    {
+        var b = source[0];
+
+        var odd = OddBit & b;
+        var length = (byte)(b >> LengthShift);
+
+        nibblePath = new NibblePath(source.Slice(PreambleLength), odd, length);
+
+        return source.Slice(PreambleLength + GetSpanLength(length, odd));
+    }
 
     /// <summary>
     /// Reads the first byte of nibble of the path without decoding it fully.

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -77,6 +77,24 @@ public readonly ref struct NibblePath
     }
 
     /// <summary>
+    /// Reuses the memory of this nibble path moving it to odd position.
+    /// </summary>
+    public NibblePath UnsafeMakeOdd(int odd)
+    {
+        if (odd == 0)
+            return this;
+
+        Debug.Assert(_odd == 0, "Should not be applied to odd");
+
+        for (int i = Length; i > 0; i--)
+        {
+            UnsafeSetAt(i, 0, GetAt(i - 1));
+        }
+
+        return new NibblePath(ref _span, OddBit, Length);
+    }
+
+    /// <summary>
     /// Creates the nibble path from preamble and raw slice
     /// </summary>
     public static NibblePath FromRaw(byte preamble, ReadOnlySpan<byte> slice)
@@ -282,7 +300,7 @@ public readonly ref struct NibblePath
 
         return source.Slice(PreambleLength + GetSpanLength(length, odd));
     }
-    
+
     public static Span<byte> ReadFrom(Span<byte> source, out NibblePath nibblePath)
     {
         var b = source[0];
@@ -573,7 +591,8 @@ public readonly ref struct NibblePath
                 {
                     do
                     {
-                        hash = BitOperations.Crc32C(hash, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref span, offset)));
+                        hash = BitOperations.Crc32C(hash,
+                            Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref span, offset)));
                         offset += sizeof(long);
                     } while (longLoop > offset);
                 }

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -34,9 +34,9 @@ public readonly ref struct SlottedArray
         _slots = MemoryMarshal.Cast<byte, Slot>(_data);
     }
 
-    public bool TrySet(in NibblePath key, ReadOnlySpan<byte> data, ushort? keyHash = default)
+    public bool TrySet(in NibblePath key, ReadOnlySpan<byte> data)
     {
-        var hash = keyHash ?? GetHash(key);
+        var hash = GetHash(key);
 
         if (TryGetImpl(key, hash, out var existingData, out var index))
         {

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -447,6 +447,11 @@ public readonly ref struct SlottedArray
         return _data.Slice(slot.ItemAddress, length);
     }
 
+    /// <summary>
+    /// Exposes <see cref="Slot.PrepareKey"/> for tests only.
+    /// </summary>
+    public static ushort HashForTests(in NibblePath key) => Slot.PrepareKey(key, out _, out _);
+
     [StructLayout(LayoutKind.Explicit, Size = Size)]
     private struct Slot
     {


### PR DESCRIPTION
This PR changes the way `SlottedArray` generates the hash. It makes it in a way that nibbles used for hash creation are removed from the key so that key is much smaller. This should make the db much more compact and the trees less deep.

An additional change that was introduced after running benchmarks is using both prefix and suffix for longer keys. As tree in Paprika has a write-caching behavior, heavily written storage slots for same accounts could dominate the map with their prefixes. In that case, the search would be terribly slow (shown by benchmarks). To address it, when a key is longer than 4 nibbles, 2 first nibbles and 2 last nibbles are extracted as hash. This should limit the simple collisions that can be caused by data not being flushed deep into the tree.

### Benchmarks

Benchmarks showing that using prefix/suffix nibbles can help a lot where the data share the prefix (described above).

| Method                              | Mean     | Error    | StdDev   | Median   |
|------------------------------------ |---------:|---------:|---------:|---------:|
| Write_whole_page_of_data            | 21.16 us | 0.420 us | 1.178 us | 21.34 us |
| Read_existing_keys_prefix_different | 21.76 us | 0.200 us | 0.187 us | 21.78 us |
| (before) Read_existing_keys_suffix_different | **903.65 us** | 20.705 us | 61.048 us | 931.70 us |
| (after) Read_existing_keys_suffix_different | **19.29 us** | 0.520 us | 1.533 us | 19.48 us |
| Read_nonexistent_keys               | 21.01 us | 1.031 us | 2.992 us | 22.83 us |

### Results

The results that are shown are for different versions of this approach

| Network  | RocksDb   | Paprika (before)  | Paprika (after) | Size reduction | Version |
|---|---|---|---|---|---|
|  Holesky  | 6.7GB  | 7.3GB  | 7GB  | ~4%  | at 3d5aee6, 3 nibbles extracted
| Mainnet  |  184G | 165GB | 159GB | ~4%  | at 3d5aee6, 3 nibbles extracted
| Mainnet  |  184G | 165GB | 159GB | ~4%  | with 4 nibbles extracted

#### Mainnet

![image](https://github.com/NethermindEth/Paprika/assets/519707/957d4126-4067-4f95-9b91-07aecdc3be0e)


