### PR TITLE
Delayed metrics introduced

### DIFF
--- a/src/Paprika.Runner/Measurement.cs
+++ b/src/Paprika.Runner/Measurement.cs
@@ -70,40 +70,23 @@ abstract class Measurement : JustInTimeRenderable, IMeasurement
         throw new NotImplementedException($"Not implemented for type {type}");
     }
 
-    private class GaugeMeasurement : Measurement
+    private class GaugeMeasurement(Instrument instrument) : Measurement(instrument)
     {
-        public GaugeMeasurement(Instrument instrument) : base(instrument)
-        {
-        }
-
         protected override long Update(double measurement) => (long)measurement;
     }
 
-    // for now use the last value
-    private class HistogramLastMeasurement : Measurement
+    private class HistogramLastMeasurement(Instrument instrument) : Measurement(instrument)
     {
         protected override long Update(double measurement)
         {
             return (long)measurement;
         }
-
-        public HistogramLastMeasurement(Instrument instrument) : base(instrument)
-        {
-        }
     }
 
-    private class HistogramHdrMeasurement : JustInTimeRenderable, IMeasurement
+    private class HistogramHdrMeasurement(Instrument instrument) : JustInTimeRenderable, IMeasurement
     {
-        private readonly Instrument _instrument;
-        private readonly ConcurrentQueue<long> _measurements;
-        private readonly LongHistogram _histogram;
-
-        public HistogramHdrMeasurement(Instrument instrument)
-        {
-            _instrument = instrument;
-            _measurements = new ConcurrentQueue<long>();
-            _histogram = new LongHistogram(1, 1, int.MaxValue, 4);
-        }
+        private readonly ConcurrentQueue<long> _measurements = new();
+        private readonly LongHistogram _histogram = new(1, 1, int.MaxValue, 4);
 
         protected override IRenderable Build()
         {
@@ -136,17 +119,13 @@ abstract class Measurement : JustInTimeRenderable, IMeasurement
             MarkAsDirty();
         }
 
-        public override string ToString() => $"{nameof(Instrument)}: {_instrument.Name}, Histogram";
+        public override string ToString() => $"{nameof(Instrument)}: {instrument.Name}, Histogram";
     }
 
-    private class CounterMeasurement : Measurement
+    private class CounterMeasurement(Instrument instrument) : Measurement(instrument)
     {
         private long _sum;
 
         protected override long Update(double measurement) => Interlocked.Add(ref _sum, (long)measurement);
-
-        public CounterMeasurement(Instrument instrument) : base(instrument)
-        {
-        }
     }
 }

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using FluentAssertions;
 using Nethermind.Int256;
@@ -61,6 +62,50 @@ public class BlockchainTests
         using var block3A = blockchain.StartNew(keccak2A);
 
         block3A.GetAccount(Key0).Should().Be(account1A);
+    }
+
+    [Test]
+    public async Task Delays_reporting_metrics()
+    {
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) => { l.EnableMeasurementEvents(instrument, instrument); };
+        listener.MeasurementsCompleted = (instrument, l) => { listener.DisableMeasurementEvents(instrument); };
+
+        const int spins = 1000;
+
+        var allow = new ManualResetEventSlim(false);
+
+        listener.Start();
+
+        listener.SetMeasurementEventCallback<double>((i, m, l, c) => Notify());
+        listener.SetMeasurementEventCallback<float>((i, m, l, c) => Notify());
+        listener.SetMeasurementEventCallback<long>((i, m, l, c) => Notify());
+        listener.SetMeasurementEventCallback<int>((i, m, l, c) => Notify());
+        listener.SetMeasurementEventCallback<short>((i, m, l, c) => Notify());
+        listener.SetMeasurementEventCallback<byte>((i, m, l, c) => Notify());
+        listener.SetMeasurementEventCallback<decimal>((i, m, l, c) => Notify());
+
+        using var db = PagedDb.NativeMemoryDb(1 * Mb, 2);
+
+        allow.Set();
+        await using var blockchain = new Blockchain(db, new PreCommit());
+        allow.Reset();
+
+        var block = blockchain.StartNew(Keccak.EmptyTreeHash);
+        block.SetAccount(Key0, new Account(1, 1));
+
+        for (var i = 0; i < spins; i++)
+        {
+            Keccak k = default;
+            BinaryPrimitives.WriteInt32LittleEndian(k.BytesAsSpan, i);
+            block.GetAccount(k).Should().Be(new Account(0, 0));
+        }
+
+        allow.Set();
+        block.Dispose();
+        allow.Reset();
+
+        void Notify() => allow.IsSet.Should().BeTrue();
     }
 
     [Test(Description =

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -429,7 +429,7 @@ public class Blockchain : IAsyncDisposable
         /// </summary>
         private PooledSpanDictionary _preCommit = null!;
 
-        private readonly DelayedMetrics.ICounter<long> _xorMissed;
+        private readonly DelayedMetrics.DelayedCounter<long, DelayedMetrics.LongIncrement> _xorMissed;
         private readonly CacheBudget _cacheBudgetStorageAndStage;
         private readonly CacheBudget _cacheBudgetPreCommit;
 
@@ -1049,8 +1049,8 @@ public class Blockchain : IAsyncDisposable
         private readonly PooledSpanDictionary _committed;
 
         private readonly bool _raw;
-        private bool _discarable;
-        private readonly DelayedMetrics.ICounter<long> _xorMissed;
+        private bool _discardable;
+        private readonly DelayedMetrics.DelayedCounter<long, DelayedMetrics.LongIncrement> _xorMissed;
 
         public CommittedBlockState(Xor8 xor, HashSet<Keccak>? destroyed, Blockchain blockchain,
             PooledSpanDictionary committed, Keccak hash, Keccak parentHash,
@@ -1160,7 +1160,7 @@ public class Blockchain : IAsyncDisposable
             _xorMissed.Dispose();
             _committed.Dispose();
 
-            if (_raw == false && _discarable == false)
+            if (_raw == false && _discardable == false)
             {
                 _blockchain.Remove(this);
             }
@@ -1201,7 +1201,7 @@ public class Blockchain : IAsyncDisposable
 
         public void MakeDiscardable()
         {
-            _discarable = true;
+            _discardable = true;
         }
     }
 

--- a/src/Paprika/Utils/DelayedMetrics.cs
+++ b/src/Paprika/Utils/DelayedMetrics.cs
@@ -1,0 +1,58 @@
+﻿using System.Diagnostics.Metrics;
+
+namespace Paprika.Utils;
+
+/// <summary>
+/// The delayed metrics to amortize access to the regular metrics in case the reporter is terribly slow and impact the how path.
+/// </summary>
+public static class DelayedMetrics
+{
+    private interface IAtomicIncrement<T>
+    {
+        T Add(ref T dest, T delta);
+    }
+
+    private struct LongIncrement : IAtomicIncrement<long>
+    {
+        public long Add(ref long dest, long delta) => Interlocked.Add(ref dest, delta);
+    }
+
+    private struct IntIncrement : IAtomicIncrement<int>
+    {
+        public int Add(ref int dest, int delta) => Interlocked.Add(ref dest, delta);
+    }
+
+    /// <summary>
+    /// Returns the delayed reporting counter, that reports back to the original counter on the disposal.
+    /// </summary>
+    public static ICounter<int> Delay(this Counter<int> counter) => new DelayedCounter<int, IntIncrement>(counter);
+
+    /// <summary>
+    /// Returns the delayed reporting counter, that reports back to the original counter on the disposal.
+    /// </summary>
+    public static ICounter<long> Delay(this Counter<long> counter) => new DelayedCounter<long, LongIncrement>(counter);
+
+    /// <summary>
+    /// A <see cref="Counter{T}"/> like object that sums up all the deltas and reports back on disposal.
+    /// </summary>
+    public interface ICounter<in T> : IDisposable
+        where T : struct
+    {
+        void Add(T delta);
+    }
+
+    private sealed class DelayedCounter<T, TAtomic>(Counter<T>? counter) : ICounter<T>
+        where T : struct
+            where TAtomic : struct, IAtomicIncrement<T>
+    {
+        private T _value;
+
+        public void Add(T delta) => default(TAtomic).Add(ref _value, delta);
+
+        public void Dispose()
+        {
+            counter?.Add(_value);
+            counter = null;
+        }
+    }
+}

--- a/src/Paprika/Utils/DelayedMetrics.cs
+++ b/src/Paprika/Utils/DelayedMetrics.cs
@@ -7,17 +7,17 @@ namespace Paprika.Utils;
 /// </summary>
 public static class DelayedMetrics
 {
-    private interface IAtomicIncrement<T>
+    public interface IAtomicIncrement<T>
     {
         T Add(ref T dest, T delta);
     }
 
-    private struct LongIncrement : IAtomicIncrement<long>
+    public struct LongIncrement : IAtomicIncrement<long>
     {
         public long Add(ref long dest, long delta) => Interlocked.Add(ref dest, delta);
     }
 
-    private struct IntIncrement : IAtomicIncrement<int>
+    public struct IntIncrement : IAtomicIncrement<int>
     {
         public int Add(ref int dest, int delta) => Interlocked.Add(ref dest, delta);
     }
@@ -25,23 +25,14 @@ public static class DelayedMetrics
     /// <summary>
     /// Returns the delayed reporting counter, that reports back to the original counter on the disposal.
     /// </summary>
-    public static ICounter<int> Delay(this Counter<int> counter) => new DelayedCounter<int, IntIncrement>(counter);
+    public static DelayedCounter<int, IntIncrement> Delay(this Counter<int> counter) => new(counter);
 
     /// <summary>
     /// Returns the delayed reporting counter, that reports back to the original counter on the disposal.
     /// </summary>
-    public static ICounter<long> Delay(this Counter<long> counter) => new DelayedCounter<long, LongIncrement>(counter);
+    public static DelayedCounter<long, LongIncrement> Delay(this Counter<long> counter) => new(counter);
 
-    /// <summary>
-    /// A <see cref="Counter{T}"/> like object that sums up all the deltas and reports back on disposal.
-    /// </summary>
-    public interface ICounter<in T> : IDisposable
-        where T : struct
-    {
-        void Add(T delta);
-    }
-
-    private sealed class DelayedCounter<T, TAtomic>(Counter<T>? counter) : ICounter<T>
+    public sealed class DelayedCounter<T, TAtomic>(Counter<T>? counter)
         where T : struct
             where TAtomic : struct, IAtomicIncrement<T>
     {

--- a/src/Paprika/Utils/Metrics.cs
+++ b/src/Paprika/Utils/Metrics.cs
@@ -161,15 +161,10 @@ public sealed class Metrics : IDisposable
             protected override long Update(double measurement) => (long)measurement;
         }
 
-        private class HistogramHdrMeasurement : Measurement
+        private class HistogramHdrMeasurement(Instrument instrument) : Measurement(instrument)
         {
             private const double Percentile = 99;
-            private readonly LongConcurrentHistogram _histogram;
-
-            public HistogramHdrMeasurement(Instrument instrument) : base(instrument)
-            {
-                _histogram = new LongConcurrentHistogram(1, 1, int.MaxValue, 4);
-            }
+            private readonly LongConcurrentHistogram _histogram = new(1, 1, int.MaxValue, 4);
 
             protected override long Update(double measurement)
             {


### PR DESCRIPTION
This PR introduces a delayed metrics reporting for xor misses. If a reporter is registered that does a lot of work on the `Record(...)` like Prometheus for .NET (see: [OnMeasurementRecorded](https://github.com/prometheus-net/prometheus-net/blob/60e9106a83ff1274fec0022c37366f04822b1d1b/Prometheus/MeterAdapter.cs#L126-L215)), then it can impact the the cases where xor reports positively quite a lot. After introduction of the `Delayed`, the value is reported once at the end of the lifetime of the block state.

Below, two snippets from the profiling

![Storage computation](https://github.com/NethermindEth/Paprika/assets/519707/49002f38-85de-439e-b0bd-11487a746cd6)
![State computation](https://github.com/NethermindEth/Paprika/assets/519707/16c350fd-06e9-4669-8892-2085701134a4)
