### PR TITLE
Merkle scatter gather simplified

### DIFF
--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -12,6 +12,8 @@ using static Paprika.Tests.Values;
 
 namespace Paprika.Tests.Chain;
 
+// As there's the metrics test
+[Parallelizable(ParallelScope.None)]
 public class BlockchainTests
 {
     private const int Mb = 1024 * 1024;
@@ -65,6 +67,7 @@ public class BlockchainTests
     }
 
     [Test]
+    [Explicit("Non parallel")]
     public async Task Delays_reporting_metrics()
     {
         using var listener = new MeterListener();
@@ -105,7 +108,10 @@ public class BlockchainTests
         block.Dispose();
         allow.Reset();
 
-        void Notify() => allow.IsSet.Should().BeTrue();
+        void Notify()
+        {
+            allow.IsSet.Should().BeTrue();
+        }
     }
 
     [Test(Description =

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -12,8 +12,6 @@ using static Paprika.Tests.Values;
 
 namespace Paprika.Tests.Chain;
 
-// As there's the metrics test
-[Parallelizable(ParallelScope.None)]
 public class BlockchainTests
 {
     private const int Mb = 1024 * 1024;

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -198,7 +198,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             workItems[0].DoWork(commit);
             return;
         }
-        
+
         var children = new ConcurrentQueue<IChildCommit>();
         Parallel.ForEach(workItems,
             commit.GetChild,
@@ -241,7 +241,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         return commit.Stats
             .Where(kvp => kvp.Value > 0)
             .Select(kvp => new BuildStorageTriesItem(this, commit, kvp.Key, budget))
-            .ToArray()            ;
+            .ToArray();
     }
 
     public ReadOnlySpan<byte> InspectBeforeApply(in Key key, ReadOnlySpan<byte> data)
@@ -1302,7 +1302,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             _prefixed = new PrefixingCommit(commit);
             _prefixed.SetPrefix(_account);
             _parent.Visit(OnStorage, TrieType.Storage);
-            
+
             CalculateStorageRoots(commit);
         }
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -200,11 +200,11 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         }
 
         var children = new ConcurrentQueue<IChildCommit>();
-        Parallel.ForEach(workItems,
+        Parallel.For(0, workItems.Length,
             commit.GetChild,
-            (workItem, _, child) =>
+            (i, _, child) =>
             {
-                workItem.DoWork(child);
+                workItems[i].DoWork(child);
                 return child;
             },
             children.Enqueue


### PR DESCRIPTION
This PR touches the same area as #272 delegating now fully the work to the underlying partitioner of PLINQ. It may cause some spikes as items are potentially not distributed ideally, but should make run simpler and less skewed in cases where the distributions is similar.