### PR TITLE
Faster slotted array

### DIFF
--- a/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
+++ b/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
@@ -17,8 +17,4 @@
       <ProjectReference Include="..\Paprika\Paprika.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="BenchmarkDotNet.Artifacts\" />
-    </ItemGroup>
-
 </Project>

--- a/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
+++ b/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
@@ -17,4 +17,8 @@
       <ProjectReference Include="..\Paprika\Paprika.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="BenchmarkDotNet.Artifacts\" />
+    </ItemGroup>
+
 </Project>

--- a/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
@@ -6,7 +6,6 @@ using Paprika.Store;
 
 namespace Paprika.Benchmarks;
 
-[DisassemblyDiagnoser(maxDepth: 1)]
 public class SlottedArrayBenchmarks
 {
     private readonly byte[] _writtenLittleEndian = new byte[Page.PageSize];

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -342,6 +342,18 @@ public readonly ref struct NibblePath
         return source.Slice(PreambleLength + GetSpanLength(length, odd));
     }
 
+    public static bool TryReadFrom(Span<byte> source, in NibblePath expected, out Span<byte> leftover)
+    {
+        if (source[0] != expected.RawPreamble)
+        {
+            leftover = default;
+            return false;
+        }
+
+        leftover = ReadFrom(source, out var actualKey);
+        return actualKey.Equals(expected);
+    }
+
     /// <summary>
     /// Reads the first byte of nibble of the path without decoding it fully.
     /// </summary>

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -393,9 +393,7 @@ public readonly ref struct SlottedArray
 
                     if (slot.HasKeyBytes)
                     {
-                        var leftover = NibblePath.ReadFrom(actual, out var actualKey);
-
-                        if (actualKey.Equals(key))
+                        if (NibblePath.TryReadFrom(actual, key, out var leftover))
                         {
                             data = leftover;
                             slotIndex = i;


### PR DESCRIPTION
This PR slightly amends the search in `SlottedArray` making it a bit faster (~5%) for colliding hashes. This is based on not creating the `NibblePath` when preamble is different and comparison for the key can default much faster. The comparison should happen only when the hash is the same and the preamble (length + odd) is the same.

### Benchmarks

| Method          | Mean     | Error    | StdDev   | Code Size |
|---------------- |---------:|---------:|---------:|----------:|
| Hash_collisions (before) | 19.92 us | 0.389 us | 0.701 us |   3,222 B |
| Hash_collisions (after) | 18.35 us | 0.366 us | 0.697 us |   3,359 B |
