### PR TITLE
Slotted array empty value

### DIFF
--- a/src/Paprika.Tests/Data/SlottedArrayTests.cs
+++ b/src/Paprika.Tests/Data/SlottedArrayTests.cs
@@ -84,6 +84,27 @@ public class SlottedArrayTests
     }
 
     [Test]
+    public void Set_Get_Empty()
+    {
+        var key0 = Values.Key0.Span;
+
+        Span<byte> span = stackalloc byte[48];
+        var map = new SlottedArray(span);
+
+        var data = ReadOnlySpan<byte>.Empty;
+
+        map.SetAssert(key0, data);
+        map.GetAssert(key0, data);
+
+        map.DeleteAssert(key0);
+        map.GetShouldFail(key0);
+
+        // should be ready to accept some data again
+        map.SetAssert(key0, data, "Should have memory after previous delete");
+        map.GetAssert(key0, data);
+    }
+
+    [Test]
     public void Defragment_when_no_more_space()
     {
         // by trial and error, found the smallest value that will allow to put these two

--- a/src/Paprika.Tests/Data/SlottedArrayTests.cs
+++ b/src/Paprika.Tests/Data/SlottedArrayTests.cs
@@ -102,6 +102,14 @@ public class SlottedArrayTests
         // should be ready to accept some data again
         map.SetAssert(key0, data, "Should have memory after previous delete");
         map.GetAssert(key0, data);
+
+        using var e = map.EnumerateAll();
+
+        e.MoveNext().Should().BeTrue();
+        e.Current.Key.Equals(NibblePath.FromKey(key0));
+        e.Current.RawData.SequenceEqual(data).Should().BeTrue();
+
+        e.MoveNext().Should().BeFalse();
     }
 
     [Test]

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using Paprika.Store;
 using Paprika.Utils;
 
@@ -347,7 +348,7 @@ public readonly ref struct SlottedArray
         var hash = Slot.PrepareKey(key, out byte preamble, out var trimmed);
         if (TryGetImpl(trimmed, hash, preamble, out var span, out _))
         {
-            data = MemoryMarshal.CreateSpan(ref span[0], span.Length);
+            data = span.IsEmpty ? ReadOnlySpan<byte>.Empty : MemoryMarshal.CreateReadOnlySpan(ref span[0], span.Length);
             return true;
         }
 


### PR DESCRIPTION
The fix for the bug in `SlottedArray` that was causing `IndexOutOfRangeException` as an empty span cannot have its first item reffed.