### PR TITLE
More System.Diagnostics.Metrics 

### DIFF
--- a/src/Paprika/Chain/CacheBudget.cs
+++ b/src/Paprika/Chain/CacheBudget.cs
@@ -12,7 +12,7 @@ namespace Paprika.Chain;
 /// Remember that db reads use <see cref="ReadOnlySpanOwnerWithMetadata{T}.DatabaseQueryDepth"/>
 /// so that they will always fall into any number.
 /// </summary>
-public class CacheBudget
+public sealed class CacheBudget
 {
     public readonly record struct Options(int EntriesPerBlock, ushort CacheFromDepth)
     {
@@ -25,7 +25,7 @@ public class CacheBudget
     private readonly ushort _depth;
     private int _entriesPerBlock;
 
-    public int BudgetLeft => _entriesPerBlock;
+    public int BudgetLeft => Volatile.Read(ref _entriesPerBlock);
 
     private CacheBudget(int entriesPerBlock, ushort depth)
     {


### PR DESCRIPTION
This PR adds more metrics that should help in understanding the right setup for running the node:

1. `_cacheUsageState` - `State transient cache usage per commit` that shows the percentage of used budget for storing state&storage entries
1. `_cacheUsagePreCommit` - `PreCommit transient cache usage per commit` that shows the percentage of used budget for storing state&storage entries