### PR TITLE
Parallelism optional

### DIFF
--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -61,15 +61,20 @@ public class RootHashFuzzyTests
         AssertRootHash(rootHash, generator);
     }
 
-    [TestCase(nameof(Accounts_1000_Storage_1), int.MaxValue)]
-    [TestCase(nameof(Accounts_1_Storage_100), int.MaxValue)]
-    [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue)]
-    public async Task CalculateStateRootHash(string test, int commitEvery)
+    [TestCase(nameof(Accounts_1000_Storage_1), int.MaxValue, true)]
+    [TestCase(nameof(Accounts_1_Storage_100), int.MaxValue, true)]
+    [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue, true)]
+    [TestCase(nameof(Accounts_1000_Storage_1), int.MaxValue, false)]
+    [TestCase(nameof(Accounts_1_Storage_100), int.MaxValue, false)]
+    [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue, false)]
+    public async Task CalculateStateRootHash(string test, int commitEvery, bool parallel)
     {
         var generator = Build(test);
 
         using var db = PagedDb.NativeMemoryDb(16 * 1024 * 1024, 2);
-        var merkle = new ComputeMerkleBehavior(2, 2);
+        var parallelism = parallel ? ComputeMerkleBehavior.ParallelismUnlimited : ComputeMerkleBehavior.ParallelismNone;
+        var merkle = new ComputeMerkleBehavior(1, 1, Memoization.None, parallelism);
+
         await using var blockchain = new Blockchain(db, merkle);
 
         var rootHash = generator.Run(blockchain, commitEvery);


### PR DESCRIPTION
This PR allows to switch on and off parallel processing of the Merkle construct. Benchmarking shows that the majority of the work is spent in synchronization, not the actual computation. It needs to be tested whether running on a single thread, without any proxy, could be beneficial for a node to run. 

The prefetching, if any would be done in a separate thread in the background but for the compute it might be right to keep it simple and single threaded. It might not be true, but this PR allows for some experimentation.