### PR TITLE
Pooling: BufferPool with meters and RLP memoization is back

### DIFF
--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -88,7 +88,8 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior(1, 1);
+            using var preCommit =
+                new ComputeMerkleBehavior(1, 1, Memoization.None, ComputeMerkleBehavior.ParallelismNone);
 
             var blockHash = Keccak.EmptyTreeHash;
             var finalization = new Queue<Keccak>();

--- a/src/Paprika.Tests/Chain/PagePoolTests.cs
+++ b/src/Paprika.Tests/Chain/PagePoolTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Diagnostics.Metrics;
 using FluentAssertions;
 using NUnit.Framework;
 using Paprika.Chain;
@@ -11,7 +12,8 @@ public class PagePoolTests
     [Test]
     public void Simple_reuse()
     {
-        using var pool = new BufferPool(1);
+        using var meter = new Meter(nameof(Simple_reuse));
+        using var pool = new BufferPool(1, true, meter);
 
         // lease and return
         var initial = pool.Rent();

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -61,19 +61,18 @@ public class RootHashFuzzyTests
         AssertRootHash(rootHash, generator);
     }
 
-    [TestCase(nameof(Accounts_1000_Storage_1), int.MaxValue, true)]
-    [TestCase(nameof(Accounts_1_Storage_100), int.MaxValue, true)]
-    [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue, true)]
-    [TestCase(nameof(Accounts_1000_Storage_1), int.MaxValue, false)]
-    [TestCase(nameof(Accounts_1_Storage_100), int.MaxValue, false)]
-    [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue, false)]
-    public async Task CalculateStateRootHash(string test, int commitEvery, bool parallel)
+    [Test]
+    public async Task CalculateStateRootHash(
+        [Values(nameof(Accounts_1_Storage_100), nameof(Accounts_100_Storage_1), nameof(Accounts_1000_Storage_1))] string test,
+        [Values(int.MaxValue, 23)] int commitEvery,
+        [Values(true, false)] bool parallel,
+        [Values(Memoization.None, Memoization.Branch)] Memoization memoization)
     {
         var generator = Build(test);
 
         using var db = PagedDb.NativeMemoryDb(16 * 1024 * 1024, 2);
         var parallelism = parallel ? ComputeMerkleBehavior.ParallelismUnlimited : ComputeMerkleBehavior.ParallelismNone;
-        var merkle = new ComputeMerkleBehavior(1, 1, Memoization.None, parallelism);
+        var merkle = new ComputeMerkleBehavior(1, 1, memoization, parallelism);
 
         await using var blockchain = new Blockchain(db, merkle);
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -22,7 +22,7 @@ namespace Paprika.Chain;
 public class Blockchain : IAsyncDisposable
 {
     // allocate 1024 pages (4MB) at once
-    private readonly BufferPool _pool = new(1024, true, "Blockchain");
+    private readonly BufferPool _pool;
 
     private readonly object _blockLock = new();
     private readonly Dictionary<uint, List<CommittedBlockState>> _blocksByNumber = new();
@@ -100,6 +100,9 @@ public class Blockchain : IAsyncDisposable
             "Number of reads that passed bloom but missed in dictionary");
         _cacheUsageState = _meter.CreateHistogram<int>("State transient cache usage per commit", "%", "How much used was the transient cache");
         _cacheUsagePreCommit = _meter.CreateHistogram<int>("PreCommit transient cache usage per commit", "%", "How much used was the transient cache");
+
+        // pool
+        _pool = new(1024, true, _meter);
 
         using var batch = _db.BeginReadOnlyBatch();
         _lastFinalized = batch.Metadata.BlockNumber;

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -73,10 +73,10 @@ public class PagedDb : IPageResolver, IDb, IDisposable
         _roots = new RootPage[historyDepth];
         _batchCurrent = null;
         _ctx = new Context();
-        _pooledRoots = new BufferPool(16, true, "PagedDb-Roots");
 
         RootInit();
 
+        // Metrics
         _meter = new Meter(MeterName);
         _dbSize = _meter.CreateAtomicObservableGauge(DbSize, "MB", "The size of the database in MB");
 
@@ -91,6 +91,9 @@ public class PagedDb : IPageResolver, IDb, IDisposable
             "The number of pages flushed during the commit");
         _commitPageCountNewlyAllocated = _meter.CreateHistogram<int>("Commit page count (new)", "pages",
             "The number of pages flushed during the commit");
+
+        // Pool
+        _pooledRoots = new BufferPool(16, true, _meter);
     }
 
     public static PagedDb NativeMemoryDb(long size, byte historyDepth = 2) =>


### PR DESCRIPTION
This PR combines the following:

1. BufferPool now reports to a `Meter` passed as a parameter allowing to have less meters per app that are more coarse-grained
2. RLP memoization, if enabled, no longer uses the `ArrayPool` and just borrows from the already borrowed buffer with `ComputeContext.Rent`
3. Pareto runner uses single threaded with memoization now

### Benchmarking with Pareto

Two tests were run to show difference with rlp memoization and without. Noticeable differences:

1. Buffer pool size (now visible thanks to reporting under the meter), bigger for memoization
2. Merkle timing, smaller for memoization
3. Bloom missed, smaller for memoization (as it's much less reads)
4. DB reads, smaller for memoization (as it's much less reads)

#### RLP Memoization enabled
![image](https://github.com/NethermindEth/Paprika/assets/519707/56dd9950-ce9e-413d-838a-91baf31832f3)

#### RLP Memoization disabled
![image](https://github.com/NethermindEth/Paprika/assets/519707/26514a4a-16fa-40b0-84f8-ab2b35a07d94)



