### PR TITLE
Optimize DataPage lookup

### DIFF
--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -46,7 +46,7 @@ public class DataPageTests : BasePageTests
             Keccak search = default;
             BinaryPrimitives.WriteInt32LittleEndian(search.BytesAsSpan, j);
 
-            data.TryGet(NibblePath.FromKey(search), batch, out var result)
+            data.TryGet(batch, NibblePath.FromKey(search), out var result)
                 .Should()
                 .BeTrue($"Failed to read {j}");
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -944,7 +944,7 @@ public class Blockchain : IAsyncDisposable
 
             return TryGetDatabase(key);
         }
-        
+
         [SkipLocalsInit]
         private ReadOnlySpanOwnerWithMetadata<byte> TryGetDatabase(scoped in Key key)
         {

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -917,13 +917,17 @@ public class Blockchain : IAsyncDisposable
         /// A recursive search through the block and its parent until null is found at the end of the weekly referenced
         /// chain.
         /// </summary>
-        private ReadOnlySpanOwnerWithMetadata<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten,
-            ulong bloom)
+        private ReadOnlySpanOwnerWithMetadata<byte> TryGet(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, ulong bloom)
         {
             var owner = TryGetLocal(key, keyWritten, bloom, out var succeeded);
             if (succeeded)
                 return owner.WithDepth(0);
 
+            return TryGetAncestors(key, keyWritten, bloom);
+        }
+
+        private ReadOnlySpanOwnerWithMetadata<byte> TryGetAncestors(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten, ulong bloom)
+        {
             ushort depth = 1;
 
             var destroyedHash = CommittedBlockState.GetDestroyedHash(key);
@@ -931,13 +935,19 @@ public class Blockchain : IAsyncDisposable
             // walk all the blocks locally
             foreach (var ancestor in _ancestors)
             {
-                owner = ancestor.TryGetLocal(key, keyWritten, bloom, destroyedHash, out succeeded);
+                var owner = ancestor.TryGetLocal(key, keyWritten, bloom, destroyedHash, out var succeeded);
                 if (succeeded)
                     return owner.WithDepth(depth);
 
                 depth++;
             }
 
+            return TryGetDatabase(key);
+        }
+        
+        [SkipLocalsInit]
+        private ReadOnlySpanOwnerWithMetadata<byte> TryGetDatabase(scoped in Key key)
+        {
             // report db read
             Interlocked.Increment(ref _dbReads);
 
@@ -974,14 +984,6 @@ public class Blockchain : IAsyncDisposable
                 return default;
             }
 
-            // select the map to search for
-            var dict = key.Type switch
-            {
-                DataType.Account => _state,
-                DataType.StorageCell => _storage,
-                _ => null
-            };
-
             // First always try pre-commit as it may overwrite data.
             // Don't do it for the storage though! StorageCell entries are not modified by pre-commit! It can only read them!
             if (key.Type != DataType.StorageCell && _preCommit.TryGet(keyWritten, bloom, out var span))
@@ -992,7 +994,21 @@ public class Blockchain : IAsyncDisposable
                 return new ReadOnlySpanOwner<byte>(span, this);
             }
 
-            if (dict != null && dict.TryGet(keyWritten, bloom, out span))
+            return TryGetLocalDict(key, keyWritten, bloom, out succeeded);
+        }
+
+        private ReadOnlySpanOwner<byte> TryGetLocalDict(scoped in Key key, scoped ReadOnlySpan<byte> keyWritten,
+            ulong bloom, out bool succeeded)
+        {
+            // select the map to search for
+            var dict = key.Type switch
+            {
+                DataType.Account => _state,
+                DataType.StorageCell => _storage,
+                _ => null
+            };
+
+            if (dict is not null && dict.TryGet(keyWritten, bloom, out var span))
             {
                 // return with owned lease
                 succeeded = true;
@@ -1003,13 +1019,7 @@ public class Blockchain : IAsyncDisposable
             _xorMissed.Add(1);
 
             // if destroyed, return false as no previous one will contain it
-            if (IsAccountDestroyed(key))
-            {
-                succeeded = true;
-                return default;
-            }
-
-            succeeded = false;
+            succeeded = IsAccountDestroyed(key);
             return default;
         }
 

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -362,7 +362,7 @@ public readonly ref struct SlottedArray
         }
     }
 
-    public bool TryGet(in NibblePath key, out ReadOnlySpan<byte> data)
+    public bool TryGet(scoped in NibblePath key, out ReadOnlySpan<byte> data)
     {
         var hash = Slot.PrepareKey(key, out byte preamble, out var trimmed);
         if (TryGetImpl(trimmed, hash, preamble, out var span, out _))

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -1,7 +1,10 @@
 using System.Diagnostics;
+using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Paprika.Data;
+
+using static Paprika.Merkle.Node;
 
 namespace Paprika.Store;
 
@@ -226,39 +229,46 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
         public Span<byte> DataSpan => MemoryMarshal.CreateSpan(ref DataStart, DataSize);
     }
 
-    public bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
+    public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
+        => TryGet(batch, key, out result, this);
+
+    private static bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result, DataPage page)
     {
-        batch.AssertRead(Header);
-
-        // read in-page
-        var map = Map;
-
-        // try regular map
-        if (map.TryGet(key, out result))
+        var returnValue = false;
+        var sliced = key;
+        do
         {
-            return true;
-        }
+            batch.AssertRead(page.Header);
+            // try regular map
+            if (page.Map.TryGet(sliced, out result))
+            {
+                returnValue = true;
+                break;
+            }
 
-        if (key.IsEmpty) // empty keys are left in page
-        {
-            return false;
-        }
+            if (sliced.IsEmpty) // empty keys are left in page
+            {
+                break;
+            }
 
-        var selected = key.FirstNibble;
-        var bucket = Data.Buckets[selected];
+            var bucket = page.Data.Buckets[sliced.FirstNibble];
+            if (bucket.IsNull)
+            {
+                break;
+            }
 
-        // non-null page jump, follow it!
-        if (bucket.IsNull == false)
-        {
-            var sliced = key.SliceFrom(1);
+            // non-null page jump, follow it!
+            sliced = sliced.SliceFrom(1);
             var child = batch.GetAt(bucket);
-            return child.Header.PageType == PageType.Leaf
-                ? new LeafPage(child).TryGet(sliced, batch, out result)
-                : new DataPage(child).TryGet(sliced, batch, out result);
-        }
+            if (child.Header.PageType == PageType.Leaf)
+            {
+                return new LeafPage(child).TryGet(batch, sliced, out result);
+            }
 
-        result = default;
-        return false;
+            page = new DataPage(child);
+        } while (true);
+
+        return returnValue;
     }
 
     private SlottedArray Map => new(Data.DataSpan);

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -23,7 +23,7 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
 {
     private const int ConsumedNibbles = 1;
 
-    public static DataPage Wrap(Page page) => new(page);
+    public static DataPage Wrap(Page page) => Unsafe.As<Page, DataPage>(ref page);
 
     private const int BucketCount = 16;
 
@@ -262,10 +262,10 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
             var child = batch.GetAt(bucket);
             if (child.Header.PageType == PageType.Leaf)
             {
-                return new LeafPage(child).TryGet(batch, sliced, out result);
+                return Unsafe.As<Page, LeafPage>(ref child).TryGet(batch, sliced, out result);
             }
 
-            page = new DataPage(child);
+            page = Unsafe.As<Page, DataPage>(ref child);
         } while (true);
 
         return returnValue;

--- a/src/Paprika/Store/FanOutList.cs
+++ b/src/Paprika/Store/FanOutList.cs
@@ -26,7 +26,7 @@ public readonly ref struct FanOutList<TPage, TPageType>(Span<DbAddress> addresse
     private readonly Span<DbAddress> _addresses = addresses;
     private const int ConsumedNibbles = 2;
 
-    public bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
+    public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
     {
         var index = GetIndex(key);
 
@@ -37,7 +37,7 @@ public readonly ref struct FanOutList<TPage, TPageType>(Span<DbAddress> addresse
             return false;
         }
 
-        return TPage.Wrap(batch.GetAt(addr)).TryGet(key.SliceFrom(ConsumedNibbles), batch, out result);
+        return TPage.Wrap(batch.GetAt(addr)).TryGet(batch, key.SliceFrom(ConsumedNibbles), out result);
     }
 
     private static int GetIndex(scoped in NibblePath key) => (key.GetAt(0) << NibblePath.NibbleShift) + key.GetAt(1);

--- a/src/Paprika/Store/FanOutPage.cs
+++ b/src/Paprika/Store/FanOutPage.cs
@@ -50,7 +50,7 @@ public readonly unsafe struct FanOutPage(Page page) : IPageWithData<FanOutPage>
         public Span<byte> Data => MemoryMarshal.CreateSpan(ref DataFirst, DataSize);
     }
 
-    public bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
+    public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
     {
         batch.AssertRead(Header);
 
@@ -68,7 +68,7 @@ public readonly unsafe struct FanOutPage(Page page) : IPageWithData<FanOutPage>
             return false;
         }
 
-        return new DataPage(batch.GetAt(addr)).TryGet(key.SliceFrom(ConsumedNibbles), batch, out result);
+        return new DataPage(batch.GetAt(addr)).TryGet(batch, key.SliceFrom(ConsumedNibbles), out result);
     }
 
     private static int GetIndex(scoped in NibblePath key) => (key.GetAt(0) << NibblePath.NibbleShift) + key.GetAt(1);

--- a/src/Paprika/Store/FanOutPage.cs
+++ b/src/Paprika/Store/FanOutPage.cs
@@ -16,7 +16,7 @@ namespace Paprika.Store;
 [method: DebuggerStepThrough]
 public readonly unsafe struct FanOutPage(Page page) : IPageWithData<FanOutPage>
 {
-    public static FanOutPage Wrap(Page page) => new(page);
+    public static FanOutPage Wrap(Page page) => Unsafe.As<Page, FanOutPage>(ref page);
 
     private const int ConsumedNibbles = 2;
 

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -12,7 +12,7 @@ namespace Paprika.Store;
 [method: DebuggerStepThrough]
 public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
 {
-    public static LeafPage Wrap(Page page) => new(page);
+    public static LeafPage Wrap(Page page) =>Unsafe.As<Page, LeafPage>(ref page);
 
     private ref PageHeader Header => ref page.Header;
 

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -12,7 +12,7 @@ namespace Paprika.Store;
 [method: DebuggerStepThrough]
 public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
 {
-    public static LeafPage Wrap(Page page) =>Unsafe.As<Page, LeafPage>(ref page);
+    public static LeafPage Wrap(Page page) => Unsafe.As<Page, LeafPage>(ref page);
 
     private ref PageHeader Header => ref page.Header;
 

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -181,7 +181,7 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
         return (Map.TrySet(key, data), page);
     }
 
-    public bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
+    public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
     {
         batch.AssertRead(Header);
 

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -24,7 +24,7 @@ public interface IPageWithData<TPage> : IPage
     /// </summary>
     static abstract TPage Wrap(Page page);
 
-    bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result);
+    bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result);
 
     Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch);
 

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -121,7 +121,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
                 return false;
             }
 
-            return new FanOutPage(batch.GetAt(Data.StateRoot)).TryGet(key.Path, batch, out result);
+            return new FanOutPage(batch.GetAt(Data.StateRoot)).TryGet(batch, key.Path, out result);
         }
 
         Span<byte> idSpan = stackalloc byte[sizeof(uint)];
@@ -143,7 +143,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         }
         else
         {
-            if (Data.Ids.TryGet(key.Path, batch, out id))
+            if (Data.Ids.TryGet(batch, key.Path, out id))
             {
                 if (cache.Count < IdCacheLimit)
                 {
@@ -161,7 +161,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
 
         var path = NibblePath.FromKey(id).Append(key.StoragePath, stackalloc byte[StorageKeySize]);
 
-        return Data.Storage.TryGet(path, batch, out result);
+        return Data.Storage.TryGet(batch, path, out result);
     }
 
     private static uint ReadId(ReadOnlySpan<byte> id) => BinaryPrimitives.ReadUInt32LittleEndian(id);
@@ -189,7 +189,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
             else
             {
                 // try fetch existing first
-                if (Data.Ids.TryGet(key.Path, batch, out var existingId) == false)
+                if (Data.Ids.TryGet(batch, key.Path, out var existingId) == false)
                 {
                     Data.AccountCounter++;
                     WriteId(idSpan, Data.AccountCounter);

--- a/src/Paprika/Store/StorageFanOutPage.cs
+++ b/src/Paprika/Store/StorageFanOutPage.cs
@@ -23,7 +23,7 @@ public readonly unsafe struct StorageFanOutPage<TNext>(Page page) : IPageWithDat
 
     private ref StorageFanOutPage.Payload Data => ref Unsafe.AsRef<StorageFanOutPage.Payload>(page.Payload);
 
-    public bool TryGet(scoped NibblePath key, IReadOnlyBatchContext batch, out ReadOnlySpan<byte> result)
+    public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
     {
         var map = new SlottedArray(Data.Data);
 
@@ -41,7 +41,7 @@ public readonly unsafe struct StorageFanOutPage<TNext>(Page page) : IPageWithDat
             return false;
         }
 
-        return TNext.Wrap(batch.GetAt(addr)).TryGet(key.SliceFrom(ConsumedNibbles), batch, out result);
+        return TNext.Wrap(batch.GetAt(addr)).TryGet(batch, key.SliceFrom(ConsumedNibbles), out result);
     }
 
     private static int GetIndex(scoped in NibblePath key) => (key.GetAt(0) << NibblePath.NibbleShift) + key.GetAt(1);

--- a/src/Paprika/Store/StorageFanOutPage.cs
+++ b/src/Paprika/Store/StorageFanOutPage.cs
@@ -14,7 +14,7 @@ namespace Paprika.Store;
 public readonly unsafe struct StorageFanOutPage<TNext>(Page page) : IPageWithData<StorageFanOutPage<TNext>>
     where TNext : struct, IPageWithData<TNext>
 {
-    public static StorageFanOutPage<TNext> Wrap(Page page) => new(page);
+    public static StorageFanOutPage<TNext> Wrap(Page page) => Unsafe.As<Page, StorageFanOutPage<TNext>>(ref page);
 
     private const int ConsumedNibbles = 2;
     private const int LevelDiff = 1;


### PR DESCRIPTION
- Change DataPage.TryGet into single method iteration rather than multi-call recursion, which means the stack is only prepped once rather than 7 times if the data pages are 7 deep
- Pass params <= pointer sized first (better for abi, more register vs stack use)
- Split long methods with distinct early exits into multiple; as all the stack prep is done on method entry whether or not its needed. So splitting into multiple means methods only do as much stack prep as they need for that chunk of code rather than always doing it for everything even if only the first bit is called.
- Unsafe.As cast Pages in-place rather than going via constructor and using more stack