### PR TITLE
Much better statistics

### DIFF
--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -183,8 +183,8 @@ public static class Program
 
             using var read = db.BeginReadOnlyBatch();
 
-            var state = new StatisticsReporter();
-            var storage = new StatisticsReporter();
+            var state = new StatisticsReporter(TrieType.State);
+            var storage = new StatisticsReporter(TrieType.Storage);
             read.Report(state, storage);
 
             spectre.Cancel();

--- a/src/Paprika.Runner/SingleAsyncGate.cs
+++ b/src/Paprika.Runner/SingleAsyncGate.cs
@@ -1,18 +1,11 @@
-namespace Paprika.Runner.Pareto;
+namespace Paprika.Runner;
 
-public sealed class SingleAsyncGate
+public sealed class SingleAsyncGate(uint minGap)
 {
-    private readonly uint _minGap;
-
     private readonly object _lock = new();
     private uint _signaled;
     private uint _awaited;
     private TaskCompletionSource? _wait;
-
-    public SingleAsyncGate(uint minGap)
-    {
-        _minGap = minGap;
-    }
 
     public Task WaitAsync(uint wait)
     {
@@ -29,7 +22,7 @@ public sealed class SingleAsyncGate
         }
     }
 
-    private bool IsSatisfied(uint value) => _signaled + _minGap >= value;
+    private bool IsSatisfied(uint value) => _signaled + minGap >= value;
 
     public void Signal(uint value)
     {

--- a/src/Paprika.Runner/StatisticsForPagedDb.cs
+++ b/src/Paprika.Runner/StatisticsForPagedDb.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using HdrHistogram;
+using Paprika.Merkle;
 using Paprika.Store;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -14,8 +15,8 @@ public static class StatisticsForPagedDb
 
         try
         {
-            var state = new StatisticsReporter();
-            var storage = new StatisticsReporter();
+            var state = new StatisticsReporter(TrieType.State);
+            var storage = new StatisticsReporter(TrieType.Storage);
 
             read.Report(state, storage);
 
@@ -38,6 +39,8 @@ public static class StatisticsForPagedDb
         }
     }
 
+    private static double ToGb(long value) => (double)value / 1024 / 1024 / 1024;
+
     private static Layout BuildReport(StatisticsReporter reporter, string name)
     {
         var up = new Layout("up");
@@ -46,7 +49,15 @@ public static class StatisticsForPagedDb
 
         var layout = new Layout().SplitRows(up, sizes, leafs);
 
-        var general = $"Number of pages: {reporter.PageCount}";
+        var totalMerkle = reporter.MerkleBranchSize + reporter.MerkleExtensionSize + reporter.MerkleLeafSize;
+        var general =
+            $"Size total: {ToGb(reporter.PageCount * Page.PageSize):F2}GB:\n" +
+            $" Merkle:    {ToGb(totalMerkle):F2}GB:\n" +
+            $"  Branches: {ToGb(reporter.MerkleBranchSize):F2}GB\n" +
+            $"  Ext.:     {ToGb(reporter.MerkleExtensionSize):F2}GB\n" +
+            $"  Leaf:     {ToGb(reporter.MerkleLeafSize):F2}GB\n" +
+            $" Data:      {ToGb(reporter.MerkleLeafSize):F2}GB\n";
+
         up.Update(new Panel(general).Header($"General stats for {name}").Expand());
 
         var t = new Table();

--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using Paprika.Crypto;
 using Paprika.Data;
+using Paprika.Merkle;
 using Paprika.Store;
 
 namespace Paprika.Tests.Store;
@@ -182,8 +183,8 @@ public class PagedDbTests
                 actual.SequenceEqual(expected).Should().BeTrue();
             }
 
-            var state = new StatisticsReporter();
-            var storage = new StatisticsReporter();
+            var state = new StatisticsReporter(TrieType.State);
+            var storage = new StatisticsReporter(TrieType.Storage);
 
             read.Report(state, storage);
         }

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -126,6 +126,7 @@ public readonly ref struct SlottedArray
     public int Count => _header.Low / Slot.Size;
 
     public int CapacityLeft => _data.Length - _header.Taken;
+    public int CapacityTotal => _data.Length;
 
     public Enumerator EnumerateAll() =>
         new(this);

--- a/src/Paprika/Store/FanOutList.cs
+++ b/src/Paprika/Store/FanOutList.cs
@@ -64,13 +64,15 @@ public readonly ref struct FanOutList<TPage, TPageType>(Span<DbAddress> addresse
         addr = batch.GetAddress(updated);
     }
 
-    public void Report(IReporter reporter, IPageResolver resolver, int level)
+    public void Report(IReporter reporter, IPageResolver resolver, int level, int trimmedNibbles)
     {
+        var consumedNibbles = trimmedNibbles + ConsumedNibbles;
+
         foreach (var bucket in _addresses)
         {
             if (!bucket.IsNull)
             {
-                TPage.Wrap(resolver.GetAt(bucket)).Report(reporter, resolver, level + 1);
+                TPage.Wrap(resolver.GetAt(bucket)).Report(reporter, resolver, level + 1, consumedNibbles);
             }
         }
     }

--- a/src/Paprika/Store/FanOutPage.cs
+++ b/src/Paprika/Store/FanOutPage.cs
@@ -118,13 +118,14 @@ public readonly unsafe struct FanOutPage(Page page) : IPageWithData<FanOutPage>
     [StackTraceHidden]
     private static void ThrowNoSpaceInline() => throw new Exception("Could not set the data inline");
 
-    public void Report(IReporter reporter, IPageResolver resolver, int level)
+    public void Report(IReporter reporter, IPageResolver resolver, int pageLevel, int trimmedNibbles)
     {
+        var consumedNibbles = trimmedNibbles + ConsumedNibbles;
         foreach (var bucket in Data.Addresses)
         {
             if (!bucket.IsNull)
             {
-                new DataPage(resolver.GetAt(bucket)).Report(reporter, resolver, level + 1);
+                new DataPage(resolver.GetAt(bucket)).Report(reporter, resolver, pageLevel + 1, consumedNibbles);
             }
         }
     }

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -41,8 +41,8 @@ public readonly unsafe struct LeafOverflowPage(Page page)
         using var scope = visitor.On(this, addr);
     }
 
-    public void Report(IReporter reporter, IPageResolver resolver, int level)
+    public void Report(IReporter reporter, IPageResolver resolver, int level, int trimmedNibbles)
     {
-        reporter.ReportDataUsage(Header.PageType, level, 0, Map.Count, Map.CapacityLeft);
+        reporter.ReportDataUsage(Header.PageType, level, trimmedNibbles, Map);
     }
 }

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -208,16 +208,16 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
 
     public int CapacityLeft => Map.CapacityLeft;
 
-    public void Report(IReporter reporter, IPageResolver resolver, int level)
+    public void Report(IReporter reporter, IPageResolver resolver, int pageLevel, int trimmedNibbles)
     {
         var slotted = new SlottedArray(Data.DataSpan);
-        reporter.ReportDataUsage(Header.PageType, level, 0, slotted.Count, slotted.CapacityLeft);
+        reporter.ReportDataUsage(Header.PageType, pageLevel, trimmedNibbles, slotted);
 
         foreach (var bucket in Data.Buckets)
         {
             if (bucket.IsNull == false)
             {
-                new LeafOverflowPage(resolver.GetAt(bucket)).Report(reporter, resolver, level + 1);
+                new LeafOverflowPage(resolver.GetAt(bucket)).Report(reporter, resolver, pageLevel + 1, trimmedNibbles);
             }
         }
     }

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -28,7 +28,7 @@ public interface IPageWithData<TPage> : IPage
 
     Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch);
 
-    void Report(IReporter reporter, IPageResolver resolver, int level);
+    void Report(IReporter reporter, IPageResolver resolver, int pageLevel, int trimmedNibbles);
 
     void Accept(IPageVisitor visitor, IPageResolver resolver, DbAddress addr);
 }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -436,10 +436,10 @@ public class PagedDb : IPageResolver, IDb, IDisposable
         {
             if (root.Data.StateRoot.IsNull == false)
             {
-                new FanOutPage(GetAt(root.Data.StateRoot)).Report(state, this, 0);
+                new DataPage(GetAt(root.Data.StateRoot)).Report(state, this, 0, 0);
             }
 
-            root.Data.Storage.Report(storage, this, 0);
+            root.Data.Storage.Report(storage, this, 0, 0);
         }
 
         public uint BatchId => root.Header.BatchId;

--- a/src/Paprika/Store/StorageFanOutPage.cs
+++ b/src/Paprika/Store/StorageFanOutPage.cs
@@ -92,15 +92,18 @@ public readonly unsafe struct StorageFanOutPage<TNext>(Page page) : IPageWithDat
         return Set(key, data, batch);
     }
 
-    public void Report(IReporter reporter, IPageResolver resolver, int level)
+    public void Report(IReporter reporter, IPageResolver resolver, int pageLevel, int trimmedNibbles)
     {
+        var consumedNibbles = trimmedNibbles + ConsumedNibbles;
         foreach (var bucket in Data.Addresses)
         {
             if (!bucket.IsNull)
             {
-                TNext.Wrap(resolver.GetAt(bucket)).Report(reporter, resolver, level + LevelDiff);
+                TNext.Wrap(resolver.GetAt(bucket)).Report(reporter, resolver, pageLevel + LevelDiff, consumedNibbles);
             }
         }
+
+        reporter.ReportDataUsage(Header.PageType, pageLevel, trimmedNibbles, new SlottedArray(Data.Data));
     }
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver, DbAddress addr)


### PR DESCRIPTION
This PR improves the statistics reporting for the database, providing better split in data and less ceremony in regards to the gathering page usage across different page types. Additionally, it separates the level the page is at from the number of nibbles that are consumed by the given structure. This allows to efficiently find what is a Merkle (a not-full path) and what is not (64 nibbles in path) and report it properly.