### PR TITLE
Shorter leafs

### DIFF
--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -19,6 +19,34 @@ namespace Paprika.Data;
 /// </remarks>
 public readonly ref struct NibblePath
 {
+    /// <summary>
+    /// An array of singles, that can be used to create a path of length 1, both odd and even.
+    /// Used by <see cref="Single"/>.
+    /// </summary>
+    private static ReadOnlySpan<byte> Singles => new byte[]
+    {
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
+    };
+
+    /// <summary>
+    /// Creates a <see cref="NibblePath"/> with length of 1.
+    /// </summary>
+    /// <param name="nibble">The nibble that should be in the path.</param>
+    /// <param name="odd">The oddity.</param>
+    /// <returns>The path</returns>
+    /// <remarks>
+    /// Highly optimized, branchless, just a few moves and adds.
+    /// </remarks>
+    public static NibblePath Single(byte nibble, int odd)
+    {
+        Debug.Assert(nibble <= NibbleMask, "Nibble breached the value");
+        Debug.Assert(odd <= 1, "Odd should be 1 or 0");
+
+        ref var singles = ref Unsafe.AsRef(ref MemoryMarshal.GetReference(Singles));
+        return new NibblePath(ref Unsafe.Add(ref singles, nibble), (byte)odd, 1);
+    }
+
     public const int MaxLengthValue = byte.MaxValue / 2 + 2;
     public const int NibblePerByte = 2;
     public const int NibbleShift = 8 / NibblePerByte;
@@ -33,6 +61,7 @@ public readonly ref struct NibblePath
     private readonly byte _odd;
 
     public bool IsOdd => _odd == OddBit;
+    public int Oddity => _odd;
 
     public static NibblePath Empty => default;
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -587,8 +587,8 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             // parallel calculation
             Parallel.For((long)0, NibbleSet.NibbleCount, nibble =>
             {
-                var childPath = NibblePath.FromKey(stackalloc byte[1] { (byte)(nibble << NibblePath.NibbleShift) }, 0)
-                    .SliceTo(1);
+                var childPath = NibblePath.Single((byte)nibble, 0);
+
                 var child = commits[nibble] = commit.GetChild();
                 UIntPtr stack = default;
                 using var ctx = new ComputeContext(child, trieType, hint, budget, _pool, ref stack);
@@ -910,10 +910,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                     // need to collapse the branch
                     var childType = Node.ReadFrom(out var childLeaf, out var childExt, onlyChildSpanOwner.Span);
 
-                    var firstNibblePath =
-                        NibblePath
-                            .FromKey(stackalloc byte[1] { (byte)(onlyNibble << NibblePath.NibbleShift) })
-                            .SliceTo(1);
+                    var firstNibblePath = NibblePath.Single(onlyNibble, odd: 1 - newAt % 2);
 
                     if (childType == Node.Type.Extension)
                     {


### PR DESCRIPTION
This PR changes the way `Merkle` leafs are persisted. Previously, the node header (one initial byte) was used only store metadata. With this PR, if a leaf's path is odd, meaning it starts on odd nibble and has an odd length, the odd nibble will be stored in the leaf's header saving one byte. For a small database this gives a ~1.5% size reduction that should have bigger impact for bigger dbs.

One byte may not seem much, especially when this is applied only on odd levels of the trie at first glance. Consider though bigger databases with deeper tries (Ethereum, mainnet). Then, the leafs have shorter paths (as they have longer keys) and the one byte on odd levels will have much bigger impact.

The changes introduced:

1. Leafs' encoding for odd levels is shorter by 1 byte
2. `NibblePath.Single` introduced to generate single nibble NibblePaths in a fast manner (branchless asm with a few mov and add)
3. Fix alignment of paths in `Delete`, where previously leafs on odd levels had even paths. There's a potential for this alignment to make the comparisons much faster.

The single method and its output

```csharp
private static ReadOnlySpan<byte> Singles => new byte[]
{
    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
    0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
};

public static NibblePath Single(byte nibble, int odd)
{
    ref var singles = ref Unsafe.AsRef(ref MemoryMarshal.GetReference(Singles));
    return new NibblePath(ref Unsafe.Add(ref singles, nibble), (byte)odd, 1);
}
```

```asm
NibblePath.Single(Byte, Int32)
    L0000: movzx eax, dl
    L0003: mov rdx, 0x21823490ac8
    L000d: add rax, rdx
    L0010: movzx edx, r8b
    L0014: mov byte ptr [rcx], 1
    L0017: mov [rcx+8], rax
    L001b: mov [rcx+0x10], dl
    L001e: mov rax, rcx
    L0021: ret
```

### Benchmarks

Benchmarks run with `Pareto Runner` that does the distribution over keys in a nicely skewed manner and stores a lot of storage. For such a small database, the size reduction is at ~1.5%. As on mainnet Merkle Leafs take 40GB out of 200GB, this should be much bigger change.

#### Before

![image](https://github.com/NethermindEth/Paprika/assets/519707/5f085531-418e-4734-9c82-54138fc42dbd)

#### After

![image](https://github.com/NethermindEth/Paprika/assets/519707/954220d4-5af5-464f-99b9-30d63d3180ad)
