### PR TITLE
Batching file writes

### DIFF
--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -51,7 +51,7 @@ public static class Program
         new(50_000, 1000, 11 * Gb, true, TimeSpan.FromSeconds(5), false, false);
 
     private static readonly Case DiskSmallFlushFile =
-        new(50_000, 1000, 32 * Gb, true, TimeSpan.FromSeconds(5), true, false);
+        new(50_000, 1000, 32 * Gb, true, TimeSpan.FromSeconds(60), true, false);
 
     private const int MaxReorgDepth = 64;
     private const int FinalizeEvery = 64;

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -160,7 +160,7 @@ public static class Program
 
             using var preCommit = new ComputeMerkleBehavior(ComputeMerkleBehavior.ParallelismNone);
 
-            var gate = new SingleAsyncGate(FinalizeEvery + 10);
+            var gate = new SingleAsyncGate(FinalizeEvery + 32);
             //IPreCommitBehavior preCommit = null;
 
             await using (var blockchain =

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -51,14 +51,14 @@ public static class Program
         new(50_000, 1000, 11 * Gb, true, TimeSpan.FromSeconds(5), false, false);
 
     private static readonly Case DiskSmallFlushFile =
-        new(50_000, 1000, 11 * Gb, true, TimeSpan.FromSeconds(5), true, false);
+        new(50_000, 1000, 32 * Gb, true, TimeSpan.FromSeconds(5), true, false);
 
     private const int MaxReorgDepth = 64;
     private const int FinalizeEvery = 64;
 
     private const int RandomSeed = 17;
     private const long Gb = 1024 * 1024 * 1024L;
-    private const int UseStorageEveryNAccounts = 10;
+    private const int UseStorageEveryNAccounts = 2;
 
     public static async Task Main(String[] args)
     {
@@ -158,7 +158,7 @@ public static class Program
                     ctx.Refresh();
                 }));
 
-            using var preCommit = new ComputeMerkleBehavior();
+            using var preCommit = new ComputeMerkleBehavior(ComputeMerkleBehavior.ParallelismNone);
 
             var gate = new SingleAsyncGate(FinalizeEvery + 10);
             //IPreCommitBehavior preCommit = null;

--- a/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
+++ b/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
@@ -1,0 +1,85 @@
+﻿using FluentAssertions;
+using Paprika.Utils;
+
+namespace Paprika.Tests.Utils;
+
+public class SpanExtensionsTests
+{
+    [Test]
+    public void Batch_empty()
+    {
+        var e = Span<int>.Empty.BatchConsecutive();
+
+        End(e);
+    }
+
+    [Test]
+    public void Batch_single_consecutive()
+    {
+        Span<int> span = [1, 2, 3];
+
+        var e = span.BatchConsecutive();
+
+        MoveNext(ref e, new Range(0, span.Length));
+
+        End(e);
+    }
+
+    [Test]
+    public void Batch_single_consecutive_with_max()
+    {
+        Span<int> span = [1, 2, 3, 4];
+
+        const int max = 2;
+
+        var e = span.BatchConsecutive(max);
+
+        MoveNext(ref e, new Range(0, max));
+        MoveNext(ref e, new Range(2, max));
+
+        End(e);
+    }
+
+    [Test]
+    public void Batch_splits()
+    {
+        Span<int> span = [1, 3, 4, 5, 6];
+
+        const int at = 1;
+
+        var e = span.BatchConsecutive();
+
+        MoveNext(ref e, new Range(0, at));
+        MoveNext(ref e, new Range(at, span.Length - at));
+
+        End(e);
+    }
+
+    [Test]
+    public void Batch_splits_with_max()
+    {
+        Span<int> span = [1, 3, 4, 5, 6, 7];
+
+        const int max = 2;
+
+        var e = span.BatchConsecutive(max);
+
+        MoveNext(ref e, new Range(0, 1));
+        MoveNext(ref e, new Range(1, max));
+        MoveNext(ref e, new Range(3, max));
+        MoveNext(ref e, new Range(5, 1));
+
+        End(e);
+    }
+
+    private static void MoveNext(ref SpanExtensions.RangeEnumerator<int> e, Range range)
+    {
+        e.MoveNext().Should().BeTrue();
+        e.Current.Should().Be(range);
+    }
+
+    private static void End(SpanExtensions.RangeEnumerator<int> e)
+    {
+        e.MoveNext().Should().BeFalse();
+    }
+}

--- a/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
+++ b/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
@@ -20,7 +20,7 @@ public class SpanExtensionsTests
 
         var e = span.BatchConsecutive();
 
-        MoveNext(ref e, new Range(0, span.Length));
+        MoveNext(ref e, new(0, span.Length));
 
         End(e);
     }
@@ -34,8 +34,8 @@ public class SpanExtensionsTests
 
         var e = span.BatchConsecutive(max);
 
-        MoveNext(ref e, new Range(0, max));
-        MoveNext(ref e, new Range(2, max));
+        MoveNext(ref e, new(0, max));
+        MoveNext(ref e, new(2, max));
 
         End(e);
     }
@@ -49,8 +49,8 @@ public class SpanExtensionsTests
 
         var e = span.BatchConsecutive();
 
-        MoveNext(ref e, new Range(0, at));
-        MoveNext(ref e, new Range(at, span.Length - at));
+        MoveNext(ref e, new(0, at));
+        MoveNext(ref e, new(at, span.Length - at));
 
         End(e);
     }
@@ -64,15 +64,15 @@ public class SpanExtensionsTests
 
         var e = span.BatchConsecutive(max);
 
-        MoveNext(ref e, new Range(0, 1));
-        MoveNext(ref e, new Range(1, max));
-        MoveNext(ref e, new Range(3, max));
-        MoveNext(ref e, new Range(5, 1));
+        MoveNext(ref e, new(0, 1));
+        MoveNext(ref e, new(1, max));
+        MoveNext(ref e, new(3, max));
+        MoveNext(ref e, new(5, 1));
 
         End(e);
     }
 
-    private static void MoveNext(ref SpanExtensions.RangeEnumerator<int> e, Range range)
+    private static void MoveNext(ref SpanExtensions.RangeEnumerator<int> e, (int Start, int Length) range)
     {
         e.MoveNext().Should().BeTrue();
         e.Current.Should().Be(range);

--- a/src/Paprika/Utils/SpanExtensions.cs
+++ b/src/Paprika/Utils/SpanExtensions.cs
@@ -82,7 +82,7 @@ public static class SpanExtensions
         }
 
         /// <summary>Gets the element at the current position of the enumerator.</summary>
-        public Range Current
+        public (int Start, int Length) Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => new(_from, _length);

--- a/src/Paprika/Utils/SpanExtensions.cs
+++ b/src/Paprika/Utils/SpanExtensions.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
 namespace Paprika.Utils;
 
 public static class SpanExtensions
@@ -14,5 +17,75 @@ public static class SpanExtensions
         int nonZeroIndex = bytes.IndexOfAnyExcept((byte)0);
 
         return nonZeroIndex < 0 ? bytes[^1..] : bytes[nonZeroIndex..];
+    }
+
+    /// <summary>
+    /// Batches consecutive numbers into ranges.
+    /// </summary>
+    public static RangeEnumerator<T> BatchConsecutive<T>(this Span<T> span, int maxBatchLength = int.MaxValue)
+        where T : INumberBase<T>
+    {
+        return new RangeEnumerator<T>(span, maxBatchLength);
+    }
+
+    public ref struct RangeEnumerator<T>
+        where T : INumberBase<T>
+    {
+        public RangeEnumerator<T> GetEnumerator() => this;
+
+        /// <summary>The span being enumerated.</summary>
+        private readonly Span<T> _span;
+
+        private readonly int _maxRangeLength;
+
+        /// <summary>The start of the current range.</summary>
+        private int _from;
+
+        private int _length;
+
+        /// <summary>Initialize the enumerator.</summary>
+        /// <param name="span">The span to enumerate.</param>
+        /// <param name="maxRangeLength">The maximum batch length.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal RangeEnumerator(Span<T> span, int maxRangeLength)
+        {
+            _span = span;
+            _maxRangeLength = maxRangeLength;
+            _from = -1;
+            _length = 1;
+        }
+
+        /// <summary>Advances the enumerator to the next element of the span.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            _from += _length;
+            _length = 1;
+
+            if (_from >= _span.Length)
+                return false;
+
+            for (var i = _from + _length; i < _span.Length; i++)
+            {
+                var next = _span[i - 1] + T.One;
+                if (next == _span[i] && _length < _maxRangeLength)
+                {
+                    _length += 1;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>Gets the element at the current position of the enumerator.</summary>
+        public Range Current
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new(_from, _length);
+        }
     }
 }


### PR DESCRIPTION
Paprika uses memory mapped files for its storage. To persist changes, it issues writes without `MSYNC` or `FlushViewOfFile` which have terrible performance, but with a regular `RandomAccess.WriteAsync`. As the underlying file is mapped, issuing writes will write through the cache and keep coherency of the view. This PR alters the way writes are scheduled to disk and leverages a potential consecutive pages. Once a longer slice is detected, up to 64 pages will be batched together.

Measurements show a great reduction of `ScheduleWrites` and moving the weight to where it belongs, the FSYNC call.

This usually should not impact the speed, but can lead to blocks accumulating in the flusher queue. By speeding up the `FlusherTask` the right of high saturation is getting lower.

![image](https://github.com/NethermindEth/Paprika/assets/519707/772c2546-6c31-45c4-90a8-f32782866a5b)

![image](https://github.com/NethermindEth/Paprika/assets/519707/c09aedad-31bd-40aa-9263-d32267fbdf5b)

Clearly, there's some potential to improve page collocation when reused, but this is a step in a good direction to limit the number of syscall and make it more visible.