### PR TITLE
Pointer based PooledSpanDictionary

### DIFF
--- a/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
+++ b/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using Paprika.Chain;
 
@@ -7,6 +8,83 @@ namespace Paprika.Benchmarks;
 public class PooledSpanDictionaryBenchmarks
 {
     private readonly BufferPool _pool = new(1, false);
+    private readonly PooledSpanDictionary _bigDict;
+    private const int BigDictCount = 32_000;
+    private static ReadOnlySpan<byte> Value32Bytes => new byte[]
+    {
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+    };
+
+    public PooledSpanDictionaryBenchmarks()
+    {
+        _bigDict = new PooledSpanDictionary(new BufferPool(124, false, null));
+
+        Span<byte> key = stackalloc byte[4];
+
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i);
+            _bigDict.Set(key, i, Value32Bytes, 1);
+        }
+    }
+
+    [Benchmark]
+    public int Read_from_big_dict()
+    {
+        Span<byte> key = stackalloc byte[4];
+
+        var count = 0;
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i);
+            if (_bigDict.TryGet(key, i, out var data))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+
+    [Benchmark]
+    public int Read_missing_with_hash_collisions()
+    {
+        Span<byte> key = stackalloc byte[4];
+
+        var count = 0;
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i + 1_000_000);
+            if (_bigDict.TryGet(key, i, out var data))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int Read_missing_with_no_hash_collisions()
+    {
+        Span<byte> key = stackalloc byte[4];
+
+        var count = 0;
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i);
+            if (_bigDict.TryGet(key, i + 1_000_000, out var data))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
 
     [Benchmark]
     public int Read_write_small()
@@ -15,17 +93,12 @@ public class PooledSpanDictionaryBenchmarks
 
         Span<byte> key = stackalloc byte[2];
 
-        for (byte i = 0; i < 255; i++)
-        {
-            key[0] = i;
-            dict.Set(key, i, key, 1);
-        }
-
         var count = 0;
         for (byte i = 0; i < 255; i++)
         {
             key[0] = i;
-            dict.TryGet(key, (ulong)i, out var result);
+            dict.Set(key, i, key, 1);
+            dict.TryGet(key, i, out var result);
             count += result[0];
         }
 

--- a/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
+++ b/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
@@ -5,11 +5,14 @@ using Paprika.Chain;
 namespace Paprika.Benchmarks;
 
 [MemoryDiagnoser]
+[DisassemblyDiagnoser]
 public class PooledSpanDictionaryBenchmarks
 {
     private readonly BufferPool _pool = new(1, false);
     private readonly PooledSpanDictionary _bigDict;
+
     private const int BigDictCount = 32_000;
+
     private static ReadOnlySpan<byte> Value32Bytes => new byte[]
     {
         0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
@@ -18,9 +21,21 @@ public class PooledSpanDictionaryBenchmarks
         0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
     };
 
+    private readonly PooledSpanDictionary _varLengthKeys;
+    private const int VarLengthKeyCollisions = 8;
+    private const ulong VarLengthKeyCollisionHash = 2348598349058394;
+
+    private static ReadOnlySpan<byte> VarLengthKey => new byte[]
+    {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    };
+
     public PooledSpanDictionaryBenchmarks()
     {
-        _bigDict = new PooledSpanDictionary(new BufferPool(124, false, null));
+        _bigDict = new PooledSpanDictionary(new BufferPool(128, false, null));
 
         Span<byte> key = stackalloc byte[4];
 
@@ -28,6 +43,13 @@ public class PooledSpanDictionaryBenchmarks
         {
             Unsafe.WriteUnaligned(ref key[0], i);
             _bigDict.Set(key, i, Value32Bytes, 1);
+        }
+
+        _varLengthKeys = new PooledSpanDictionary(new BufferPool(32, false, null));
+
+        for (uint i = 0; i < VarLengthKeyCollisions; i++)
+        {
+            _bigDict.Set(VarLengthKey[..VarLengthKeyCollisions], VarLengthKeyCollisionHash, Value32Bytes, 1);
         }
     }
 
@@ -44,6 +66,19 @@ public class PooledSpanDictionaryBenchmarks
             {
                 count++;
             }
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int Enumerate_big_dict()
+    {
+        var count = 0;
+
+        foreach (var item in _bigDict)
+        {
+            count += item.Metadata;
         }
 
         return count;
@@ -100,6 +135,20 @@ public class PooledSpanDictionaryBenchmarks
             dict.Set(key, i, key, 1);
             dict.TryGet(key, i, out var result);
             count += result[0];
+        }
+
+        return count;
+    }
+
+    [Benchmark(OperationsPerInvoke = VarLengthKeyCollisions)]
+    public int Read_colliding_hashes_different_lengths()
+    {
+        var count = 0;
+
+        for (var i = 0; i < VarLengthKeyCollisions; i++)
+        {
+            _varLengthKeys.TryGet(VarLengthKey[..(i + 1)], VarLengthKeyCollisionHash, out var data);
+            count += data.Length;
         }
 
         return count;

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -1,6 +1,3 @@
-using System.Diagnostics;
-using System.Net.Sockets;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Paprika.Crypto;
@@ -21,7 +18,12 @@ public class PooledSpanDictionary : IDisposable
     private readonly List<Page> _pages = new();
 
     private Page _current;
+    private int _currentNumber;
     private int _position;
+
+    private Page _entries;
+    private int _entryPage;
+    private int _entryPosition = Page.PageSize;
 
     private readonly Root _root;
 
@@ -41,7 +43,7 @@ public class PooledSpanDictionary : IDisposable
         _pool = pool;
         _preserveOldValues = preserveOldValues;
 
-        var pages = new Page[Root.PageCount];
+        Span<Page> pages = stackalloc Page[Root.PageCount];
         for (var i = 0; i < Root.PageCount; i++)
         {
             pages[i] = RentNewPage(true);
@@ -54,11 +56,12 @@ public class PooledSpanDictionary : IDisposable
 
     public bool TryGet(scoped ReadOnlySpan<byte> key, ulong hash, out ReadOnlySpan<byte> result)
     {
-        var (leftover, bucket) = GetBucketAndLeftover(hash);
-        var search = TryGetImpl(leftover, bucket, key);
-        if (search.IsFound)
+        ref var entry = ref TryGetImpl(hash, key);
+
+        if (Entry.Exists(in entry))
         {
-            result = search.Data;
+            ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
+            result = GetData(entry, in pages);
             return true;
         }
 
@@ -69,78 +72,85 @@ public class PooledSpanDictionary : IDisposable
     /// <summary>
     /// The total overhead to write one item.
     /// </summary>
-    public const int ItemOverhead = PreambleLength + AddressLength + KeyLengthLength + ValueLengthLength;
+    public const int ItemOverhead = PreambleLength + KeyLengthLength + ValueLengthLength;
 
     // Preamble
-    private const byte PreambleBits = 0b1110_0000;
     private const byte DestroyedBit = 0b1000_0000;
-    private const byte MetadataBits = 0b0110_0000;
-    private const byte MetadataShift = 5;
-
-    public const int MaxMetadata = MetadataBits >> MetadataShift;
-
-    private const byte Byte0Mask = 0b0001_1111;
+    private const byte MetadataBits = 0b0111_1111;
 
     // How many bytes are used for preamble + hash leftover
-    private const int PreambleLength = 3;
-
-    private const int AddressLength = 4;
-
+    private const int PreambleLength = 1;
     private const int KeyLengthLength = 1;
     private const int ValueLengthLength = 2;
 
-    private SearchResult TryGetImpl(uint leftover, uint bucket, scoped ReadOnlySpan<byte> key)
+    private ref Entry TryGetImpl(ulong hash, scoped ReadOnlySpan<byte> key)
     {
-        Debug.Assert(BitOperations.LeadingZeroCount(leftover) >= 11, "First 10 bits should be left unused");
+        var next = _root[hash];
+        ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
 
-        var address = _root[(int)bucket];
-        if (address == 0) return default;
-
-        var pages = CollectionsMarshal.AsSpan(_pages);
-        do
+        while (next != default)
         {
-            var (pageNo, atPage) = Math.DivRem(address, Page.PageSize);
-
-            // TODO: optimize, unsafe ref?
-            var sliced = pages[(int)pageNo].Span.Slice((int)atPage);
-
-            ref var at = ref MemoryMarshal.GetReference(sliced);
-
-            var header = at & PreambleBits;
-            if ((header & DestroyedBit) == 0)
+            ref var entry = ref GetEntry(next, ref pages);
+            if (entry.hash == hash)
             {
-                // not destroyed, ready to be searched, decode leftover, big endian
-                var leftoverStored = GetLeftover(ref at);
-
-                if (leftoverStored == leftover)
+                ref var preamble = ref GetPreamble(entry, in pages);
+                if ((preamble & DestroyedBit) != DestroyedBit)
                 {
-                    ref var payload = ref Unsafe.Add(ref at, PreambleLength + AddressLength);
-
-                    var storedKeyLength = payload;
-                    if (storedKeyLength == key.Length)
+                    var actual = GetKey(ref preamble);
+                    if (actual.SequenceEqual(key))
                     {
-                        var storedKey = MemoryMarshal.CreateSpan(ref Unsafe.Add(ref payload, KeyLengthLength),
-                            storedKeyLength);
-                        if (storedKey.SequenceEqual(key))
-                        {
-                            ref var data = ref Unsafe.Add(ref payload, KeyLengthLength + storedKeyLength);
-                            return new SearchResult(ref at, ref data);
-                        }
+                        return ref entry;
                     }
                 }
             }
 
-            // Decode next entry address
-            address = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref at, PreambleLength));
-        } while (address != 0);
-        return default;
+            next = entry.next;
+        }
+
+        return ref Unsafe.NullRef<Entry>();
     }
 
-    private static (uint leftover, uint bucket) GetBucketAndLeftover(ulong hash)
-        => Math.DivRem(Mix(hash), Root.BucketCount);
+    private static unsafe ref Entry GetEntry(int entry, ref Page pages)
+    {
+        var (page, at) = Math.DivRem(entry, Entry.EntriesPerPage);
+        var raw = Unsafe.Add(ref pages, page).Raw;
+        return ref Unsafe.AsRef<Entry>((byte*)raw.ToPointer() + at);
+    }
 
-    private static (uint leftover, uint bucket) GetBucketAndLeftover(uint mixed)
-        => Math.DivRem(mixed, Root.BucketCount);
+    private static ref byte GetPreamble(in Entry entry, in Page pages) => ref GetEntryPayload(entry, in pages);
+
+    private static ReadOnlySpan<byte> GetKey(in Entry entry, in Page pages)
+    {
+        ref var payload = ref GetEntryPayload(entry, in pages);
+        var length = Unsafe.Add(ref payload, PreambleLength);
+        return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref payload, PreambleLength + KeyLengthLength), length);
+    }
+
+    private static ReadOnlySpan<byte> GetKey(ref byte preamble)
+    {
+        var length = Unsafe.Add(ref preamble, PreambleLength);
+        return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref preamble, PreambleLength + KeyLengthLength), length);
+    }
+
+    private static ReadOnlySpan<byte> GetData(in Entry entry, in Page pages)
+    {
+        ref var payload = ref GetEntryPayload(entry, in pages);
+        var keyLength = Unsafe.Add(ref payload, PreambleLength);
+
+        var dataOffset = PreambleLength + KeyLengthLength + keyLength;
+        ref var dataStart = ref Unsafe.Add(ref payload, dataOffset);
+
+        var dataLength = Unsafe.ReadUnaligned<ushort>(ref dataStart);
+
+        return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref dataStart, ValueLengthLength), dataLength);
+    }
+
+    private static unsafe ref byte GetEntryPayload(in Entry entry, in Page pages)
+    {
+        var (page, at) = Math.DivRem(entry.ptr, Page.PageSize);
+        var raw = (byte*)Unsafe.Add(ref Unsafe.AsRef(in pages), page).Raw.ToPointer();
+        return ref Unsafe.AsRef<byte>(raw + at);
+    }
 
     public void CopyTo(PooledSpanDictionary destination, Predicate<byte> metadataWhere, bool append = false)
     {
@@ -153,143 +163,91 @@ public class PooledSpanDictionary : IDisposable
         }
     }
 
-    private static int GetLeftover(ref byte sliced) =>
-        ((sliced & Byte0Mask) << 16) +
-        (Unsafe.Add(ref sliced, 1) << 8) +
-        Unsafe.Add(ref sliced, 2);
-
-    private readonly ref struct SearchResult
-    {
-        public bool IsFound => !Unsafe.IsNullRef(ref _header);
-
-        private readonly ref byte _header;
-        private readonly ref byte _data;
-
-        public SearchResult(ref byte header, ref byte data)
-        {
-            _data = ref data;
-            _header = ref header;
-        }
-
-        /// <summary>
-        /// The length is encoded as the first byte.
-        /// </summary>
-        public readonly ReadOnlySpan<byte> Data
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref _data, ValueLengthLength),
-                Unsafe.ReadUnaligned<ushort>(ref _data));
-            }
-        }
-
-        public bool TryUpdateInSitu(ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1, byte metadata)
-        {
-            if (IsFound == false)
-                return false;
-
-            var length = data0.Length + data1.Length;
-            if (Unsafe.ReadUnaligned<ushort>(ref _data) >= length)
-            {
-                // update metadata bit
-                _header = (byte)((_header & ~MetadataBits) | (metadata << MetadataShift));
-
-                // There's the place to have it update in place
-                Unsafe.WriteUnaligned(ref _data, (ushort)length);
-
-                var destination = MemoryMarshal.CreateSpan(ref Unsafe.Add(ref _data, ValueLengthLength), length);
-                data0.CopyTo(destination);
-                if (data1.IsEmpty == false)
-                {
-                    data1.CopyTo(destination[data0.Length..]);
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
-        public void Destroy()
-        {
-            Debug.Assert(IsFound, "Only found can be destroyed");
-            _header |= DestroyedBit;
-        }
-    }
-
     public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data, byte metadata) =>
-        SetImpl(key, Mix(hash), data, ReadOnlySpan<byte>.Empty, metadata);
+        SetImpl(key, hash, data, ReadOnlySpan<byte>.Empty, metadata);
 
     public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1,
-        byte metadata) => SetImpl(key, Mix(hash), data0, data1, metadata);
+        byte metadata) => SetImpl(key, hash, data0, data1, metadata);
 
-
-    private void SetImpl(scoped ReadOnlySpan<byte> key, uint mixed, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1,
+    private void SetImpl(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1,
         byte metadata, bool append = false)
     {
-        Debug.Assert(metadata <= MaxMetadata, "Metadata size breached");
-
-        var (leftover, bucket) = GetBucketAndLeftover(mixed);
         if (append == false)
         {
-            var search = TryGetImpl(leftover, bucket, key);
+            ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
+            ref var search = ref TryGetImpl(hash, key);
 
-            if (search.IsFound)
+            if (Entry.Exists(search))
             {
                 if (_preserveOldValues == false)
                 {
-                    if (search.TryUpdateInSitu(data0, data1, metadata))
+                    if (TryUpdateInSitu(ref search, ref pages, data0, data1, metadata))
+                    {
                         return;
+                    }
                 }
 
                 // Destroy the search as it should not be visible later and move on with inserting as usual
-                search.Destroy();
+                Destroy(search, pages);
             }
         }
 
-        Debug.Assert(BitOperations.LeadingZeroCount(leftover) >= 10, "First 10 bits should be left unused");
-
-        var root = _root[(int)bucket];
-
+        // Prepare destination first
         var dataLength = data1.Length + data0.Length;
+        var size = PreambleLength + KeyLengthLength + key.Length + ValueLengthLength + dataLength;
+        var destination = Write(size, out var address);
 
-        var size = PreambleLength + AddressLength + KeyLengthLength + key.Length + ValueLengthLength + dataLength;
-        Span<byte> destination = Write(size, out var address);
+        // Pick up the root that will be updated soon
+        ref var root = ref _root[hash];
+        ref var entry = ref NewEntry(out var addr);
+
+        entry = new Entry
+        {
+            next = root,
+            hash = hash,
+            ptr = address
+        };
+
+        // First write entry above, then write root back to point correctly
+        root = addr;
 
         // Write preamble, big endian
-        destination[0] = (byte)((leftover >> 16) | (uint)(metadata << MetadataShift));
-        destination[1] = (byte)(leftover >> 8);
-        destination[2] = (byte)(leftover & 0xFF);
-
-        // Write next
-        Unsafe.WriteUnaligned(ref destination[PreambleLength], root);
-
-        // Key length
-        const int keyStart = PreambleLength + AddressLength;
-        destination[keyStart] = (byte)key.Length;
+        destination[0] = metadata;
+        destination[PreambleLength] = (byte)key.Length;
 
         // Key
-        key.CopyTo(destination.Slice(keyStart + KeyLengthLength));
+        key.CopyTo(destination.Slice(PreambleLength + KeyLengthLength));
 
         // Value length
-        var valueStart = keyStart + KeyLengthLength + key.Length;
+        var valueStart = PreambleLength + KeyLengthLength + key.Length;
 
         Unsafe.WriteUnaligned(ref destination[valueStart], (ushort)dataLength);
 
         data0.CopyTo(destination[(valueStart + ValueLengthLength)..]);
         data1.CopyTo(destination[(valueStart + ValueLengthLength + data0.Length)..]);
+    }
 
-        _root[(int)bucket] = address;
+    private bool TryUpdateInSitu(ref Entry search, ref Page pages, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1,
+        byte metadata)
+    {
+        return false;
     }
 
     public void Destroy(scoped ReadOnlySpan<byte> key, ulong hash)
     {
-        var (leftover, bucket) = GetBucketAndLeftover(hash);
-        var found = TryGetImpl(leftover, bucket, key);
+        ref var entry = ref TryGetImpl(hash, key);
+        ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
 
-        if (found.IsFound)
-            found.Destroy();
+        if (Entry.Exists(in entry))
+        {
+            Destroy(entry, pages);
+        }
+    }
+
+    private static void Destroy(in Entry entry, in Page pages)
+    {
+        ref var preamble = ref GetPreamble(entry, in pages);
+        preamble = (byte)(preamble | DestroyedBit);
     }
 
     public Enumerator GetEnumerator() => new(this);
@@ -298,117 +256,92 @@ public class PooledSpanDictionary : IDisposable
     /// Enumerator walks through all the values beside the ones that were destroyed in this dictionary
     /// with <see cref="PooledSpanDictionary.Destroy"/>.
     /// </summary>
-    public ref struct Enumerator(PooledSpanDictionary dictionary)
+    public ref struct Enumerator
     {
-        private int _bucket = -1;
-        private uint _address = 0;
-        private ref byte _at;
+        private readonly ref Page _pages;
+        private ref Entry _entry;
+
+        private int _next = 0;
+        private Root.Enumerator _rootEnumerator;
+
+        /// <summary>
+        /// Enumerator walks through all the values beside the ones that were destroyed in this dictionary
+        /// with <see cref="PooledSpanDictionary.Destroy"/>.
+        /// </summary>
+        public Enumerator(PooledSpanDictionary dictionary)
+        {
+            _pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(dictionary._pages));
+            _rootEnumerator = dictionary._root.GetEnumerator();
+            if (_rootEnumerator.MoveNext())
+            {
+                // start enumerator
+                _next = _rootEnumerator.Current;
+            }
+
+            _entry = ref Unsafe.NullRef<Entry>();
+        }
 
         public bool MoveNext()
         {
-            while (_bucket < Root.BucketCount)
+            do
             {
-                // On empty, scan to the next bucket that is not empty
-                while (_address == 0)
+                while (_next == 0)
                 {
-                    _bucket++;
-                    if (_bucket == Root.BucketCount)
+                    if (!_rootEnumerator.MoveNext())
                     {
                         return false;
                     }
 
-                    _address = dictionary._root[_bucket];
+                    _next = _rootEnumerator.Current;
                 }
 
-                // Scan the bucket till it's not destroyed
-                while (_address != 0)
-                {
-                    // Capture the current, move address to next immediately
-                    ref var at = ref dictionary.GetAt(_address);
+                _entry = ref GetEntry(_next, ref _pages);
+                _next = _entry.next;
+            } while ((GetPreamble(in _entry, ref _pages) & DestroyedBit) == DestroyedBit);
 
-                    // The position is captured in ref at above, move to next
-                    _address = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref at, PreambleLength));
-
-                    if ((at & DestroyedBit) == 0)
-                    {
-                        // Set at the at as it represents an active item
-                        _at = ref at;
-                        return true;
-                    }
-                }
-            }
-
-            return false;
+            return true;
         }
 
-        public KeyValue Current => new(ref _at, (uint)_bucket);
+        public Item Current => new(ref _entry, ref _pages);
 
         public void Dispose()
         {
             // throw new ex
         }
 
-        public readonly ref struct KeyValue
+        public readonly ref struct Item
         {
-            private readonly uint _bucket;
-            private readonly ref byte _b;
+            private readonly ref readonly Entry _entry;
+            private readonly ref readonly Page _pages;
 
-            public ReadOnlySpan<byte> Key
+            public Item(in Entry entry, in Page pages)
             {
-                get
-                {
-                    // Key length
-                    const int keyStart = PreambleLength + AddressLength;
-                    ref var start = ref Unsafe.Add(ref _b, keyStart);
-                    return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref start, 1), start);
-                }
+                _entry = ref entry;
+                _pages = ref pages;
             }
 
-            public ReadOnlySpan<byte> Value
-            {
-                get
-                {
-                    // Key length
-                    const int keyStart = PreambleLength + AddressLength;
-                    var keyLength = Unsafe.Add(ref _b, keyStart);
+            public ReadOnlySpan<byte> Key => GetKey(in _entry, in _pages);
 
-                    // Get the start to data pointer
-                    ref var data = ref Unsafe.Add(ref _b, PreambleLength + AddressLength + KeyLengthLength + keyLength);
 
-                    return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref data, ValueLengthLength),
-                        Unsafe.ReadUnaligned<ushort>(ref data));
-                }
-            }
+            public ReadOnlySpan<byte> Value => GetData(in _entry, in _pages);
 
-            public uint Hash => ((uint)GetLeftover(ref _b) << Root.BucketCountLog2) | _bucket;
+            public ulong Hash => _entry.hash;
 
-            public byte Metadata => (byte)((_b & MetadataBits) >> MetadataShift);
-
-            public KeyValue(ref byte b, uint bucket)
-            {
-                _bucket = bucket;
-                _b = ref b;
-            }
+            public byte Metadata => (byte)(GetPreamble(in _entry, in _pages) & MetadataBits);
 
             public void Destroy()
             {
-                _b |= DestroyedBit;
+                ref var b = ref GetPreamble(in _entry, in _pages);
+                b = (byte)(b | DestroyedBit);
             }
         }
-    }
-
-    private ref byte GetAt(uint address)
-    {
-        Debug.Assert(address > 0);
-
-        var (pageNo, atPage) = Math.DivRem(address, Page.PageSize);
-        return ref Unsafe.Add(ref MemoryMarshal.GetReference(_pages[(int)pageNo].Span), (int)atPage);
     }
 
     private void AllocateNewPage()
     {
         var page = RentNewPage(false);
         _current = page;
+        _currentNumber = _pages.Count - 1;
         _position = 0;
     }
 
@@ -418,10 +351,6 @@ public class PooledSpanDictionary : IDisposable
         _pages.Add(page);
         return page;
     }
-
-
-    private static uint Mix(ulong hash) => unchecked((uint)((hash >> 32) ^ hash));
-
 
     private Span<byte> Write(int size, out uint addr)
     {
@@ -434,10 +363,28 @@ public class PooledSpanDictionary : IDisposable
         // allocated before the position is changed
         var span = _current.Span.Slice(_position, size);
 
-        addr = (uint)(_position + (_pages.Count - 1) * BufferSize);
+        addr = (uint)(_position + _currentNumber * BufferSize);
         _position += size;
 
         return span;
+    }
+
+    private unsafe ref Entry NewEntry(out int addr)
+    {
+        const int perPage = Entry.EntriesPerPage;
+
+        if (_entryPosition >= perPage)
+        {
+            _entryPosition = 0;
+            _entries = RentNewPage(false);
+            _entryPage = _pages.Count - 1;
+        }
+
+        var position = _entryPosition;
+        addr = position + _entryPage * perPage;
+        _entryPosition += Entry.Size;
+
+        return ref Unsafe.AsRef<Entry>((byte*)_entries.Raw.ToPointer() + position);
     }
 
     public void Dispose()
@@ -492,28 +439,77 @@ public class PooledSpanDictionary : IDisposable
         static string S(in NibblePath full) => full.UnsafeAsKeccak.ToString();
     }
 
-    private readonly struct Root(Page[] pages)
+
+    [StructLayout(LayoutKind.Explicit, Size = MaxPointerSize * PageCount)]
+    private readonly struct Root
     {
-        /// <summary>
-        /// 16gives 4kb * 16, 64kb allocated per dictionary.
-        /// This gives 16k buckets which should be sufficient to have a really low ratio of collisions for majority of the blocks.
-        /// </summary>
+        private const int MaxPointerSize = 8;
         public const int PageCount = 16;
+        private const int RootEntriesPerPage = Page.PageSize / sizeof(int);
+        private const int EntriesTotal = RootEntriesPerPage * PageCount;
+        private const uint EntryHashMask = EntriesTotal - 1;
 
-        public static readonly int BucketCountLog2 = BitOperations.Log2(BucketCount);
+        [FieldOffset(0)] private readonly Page _start;
 
-        public const int BucketCount = PageCount * BucketsPerPage;
-        private const int BucketsPerPage = Page.PageSize / sizeof(uint);
-        private const int InPageMask = BucketsPerPage - 1;
-        private static readonly int PageShift = BitOperations.Log2(BucketsPerPage);
-
-        public unsafe ref uint this[int bucket]
+        public Root(ReadOnlySpan<Page> pages)
         {
-            get
-            {
-                var raw = pages[bucket >> PageShift].Raw;
-                return ref Unsafe.Add(ref Unsafe.AsRef<uint>(raw.ToPointer()), bucket & InPageMask);
-            }
+            pages.CopyTo(MemoryMarshal.CreateSpan(ref _start, PageCount));
         }
+
+        public ref int this[ulong hash] => ref GetRef((int)(hash & EntryHashMask));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe ref int GetRef(int at)
+        {
+            var (pageNo, indexAtPage) = Math.DivRem(at, RootEntriesPerPage);
+            var raw = Unsafe.Add(ref Unsafe.AsRef(in _start), pageNo).Raw;
+            return ref Unsafe.Add(ref Unsafe.AsRef<int>(raw.ToPointer()), indexAtPage);
+        }
+
+        public Enumerator GetEnumerator() => new(this);
+
+        public ref struct Enumerator(Root dictionary)
+        {
+            private int _at = -1;
+            private int _pointer = 0;
+
+            public bool MoveNext()
+            {
+                _at++;
+
+                while (_at < EntriesTotal && (_pointer = dictionary.GetRef(_at)) == default)
+                {
+                    _at++;
+                }
+
+                return _at < EntriesTotal;
+            }
+
+            public int Current => _pointer;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Entry
+    {
+        public static bool Exists(in Entry e) => Unsafe.IsNullRef(in e) == false;
+
+        public const int Size = 16;
+        public const int EntriesPerPage = Page.PageSize / Size;
+
+        /// <summary>
+        /// The <see cref="ulong"/> hash after <see cref="PooledSpanDictionary.Mix"/>.
+        /// </summary>
+        public ulong hash;
+
+        /// <summary>
+        /// The next entry.
+        /// </summary>
+        public int next;
+
+        /// <summary>
+        /// The pointer to <see cref="PooledSpanDictionary._pages"/>, to a page then to its content, both key and the value.
+        /// </summary>
+        public uint ptr;
     }
 }

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -54,9 +54,10 @@ public class PooledSpanDictionary : IDisposable
         AllocateNewPage();
     }
 
+    [SkipLocalsInit]
     public bool TryGet(scoped ReadOnlySpan<byte> key, ulong hash, out ReadOnlySpan<byte> result)
     {
-        ref var entry = ref TryGetImpl(hash, key);
+        ref var entry = ref TryGetImpl(key, hash);
 
         if (Entry.Exists(in entry))
         {
@@ -83,7 +84,8 @@ public class PooledSpanDictionary : IDisposable
     private const int KeyLengthLength = 1;
     private const int ValueLengthLength = 2;
 
-    private ref Entry TryGetImpl(ulong hash, scoped ReadOnlySpan<byte> key)
+    [SkipLocalsInit]
+    private ref Entry TryGetImpl(scoped ReadOnlySpan<byte> key, ulong hash)
     {
         var next = _root[hash];
         ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
@@ -175,7 +177,7 @@ public class PooledSpanDictionary : IDisposable
         if (append == false)
         {
             ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
-            ref var search = ref TryGetImpl(hash, key);
+            ref var search = ref TryGetImpl(key, hash);
 
             if (Entry.Exists(search))
             {
@@ -235,7 +237,7 @@ public class PooledSpanDictionary : IDisposable
 
     public void Destroy(scoped ReadOnlySpan<byte> key, ulong hash)
     {
-        ref var entry = ref TryGetImpl(hash, key);
+        ref var entry = ref TryGetImpl(key, hash);
         ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
 
         if (Entry.Exists(in entry))


### PR DESCRIPTION
This PR introduces the separation of `Entry` from the actual data and the key in the `PooledSpanDictionary`. It does it by allocating page for entries separately from the data pages. A few assumptions that this PR is based:

1. even if the `Xor` filter reports that the given block `MayContain` the entry, the tests against the hash equality should be made much faster as they are collocated and separate from actual data
2. jumping between entries and data is now pointer based, so no need to reach out to pages and get pointer and do the all the pointer arithmetic. Just follow the pointers. This makes the entries a bit bigger though (pointer is 8 bytes on x64) but should be worth it
3. reading the data, key, etc is now done directly by following the pointer. Again, no need to reach out to list table
4. `Root` struct is inlined and keeps 32 pointers now which makes it ~128 bytes big. Plus the actual 32 pages of 4kb used for buckets.

### Benchmarks

The biggest game changer is 4857256. It sucks out the pages altogether leaving it only pointer based. Still, in the benchmarks it does not show like something that can beat the current implementation in the `main`. Maybe due to wrongly selected data?

### Dissassembly

Some snippets from the ongoing work are below. The last optimization makes the method so small that it's inlined that is extracted below. ORed and just one jump for the search `je short M00_L06`

```asm
M00_L04:
       mov       rcx,[r15+10]
       movzx     r8d,byte ptr [rcx+1]
       mov       rdx,0FFF7A7F655AF2EA6
       add       rdx,[r15]
       movzx     eax,byte ptr [rcx]
       and       eax,80
       or        rdx,rax
       mov       eax,r14d
       sub       eax,r8d
       or        rdx,rax
       je        short M00_L06
M00_L05:
       mov       r15,[r15+8]
       test      r15,r15
       jne       short M00_L04
       jmp       short M00_L01
M00_L06:
       add       rcx,2
       mov       edx,r14d
       cmp       r8d,edx
       jne       short M00_L05
       mov       r8d,r14d
       mov       rdx,rbp
       call      qword ptr [7FF8F8D45068]; System.SpanHelpers.SequenceEqual(Byte ByRef, Byte ByRef, UIntPtr)
       test      eax,eax
       je        short M00_L05
       mov       rdx,r15
       jmp       near ptr M00_L02
```

<details>

#### Stage 1 - original

```assembly
      push      r15
       push      r14
       push      r13
       push      r12
       push      rdi
       push      rsi
       push      rbp
       push      rbx
       sub       rsp,28
       mov       rbx,rdx
       mov       esi,r8d
       mov       rdi,[rsp+90]
       mov       rax,[rcx+28]
       mov       r8d,r9d
       sar       r8d,0A
       cmp       r8d,[rax+8]
       jae       near ptr M01_L06
       mov       rax,[rax+r8*8+10]
       and       r9d,3FF
       movsxd    r8,r9d
       mov       ebp,[rax+r8*4]
       test      ebp,ebp
       je        near ptr M01_L02
       mov       r8,[rcx+10]
       test      r8,r8
       je        near ptr M01_L03
       mov       r14,[r8+8]
       mov       r15d,[r8+10]
       test      r14,r14
       je        near ptr M01_L05
       cmp       [r14+8],r15d
       jb        near ptr M01_L04
       add       r14,10
M01_L00:
       mov       r8d,ebp
       shr       r8d,0C
       mov       ecx,r8d
       shl       ecx,0C
       sub       ebp,ecx
       cmp       r8d,r15d
       jae       near ptr M01_L06
       mov       r13,[r14+r8*8]
       cmp       ebp,1000
       ja        near ptr M01_L04
       add       rbp,r13
       movzx     r8d,byte ptr [rbp]
       test      r8b,80
       jne       short M01_L01
       and       r8d,1F
       shl       r8d,10
       movzx     ecx,byte ptr [rbp+1]
       shl       ecx,8
       add       r8d,ecx
       movzx     ecx,byte ptr [rbp+2]
       add       r8d,ecx
       movsxd    r8,r8d
       mov       ecx,esi
       cmp       r8,rcx
       jne       short M01_L01
       lea       r13,[rbp+7]
       movzx     r12d,byte ptr [r13]
       mov       r8d,[rdi+8]
       cmp       r12d,r8d
       jne       short M01_L01
       lea       rcx,[r13+1]
       mov       rdx,[rdi]
       call      qword ptr [7FF8F8D35068]; System.SpanHelpers.SequenceEqual(Byte ByRef, Byte ByRef, UIntPtr)
       test      eax,eax
       je        short M01_L01
       inc       r12d
       movsxd    rax,r12d
       add       rax,r13
       mov       [rbx],rbp
       mov       [rbx+8],rax
       mov       rax,rbx
       add       rsp,28
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r12
       pop       r13
       pop       r14
       pop       r15
       ret
M01_L01:
       mov       ebp,[rbp+3]
       test      ebp,ebp
       jne       near ptr M01_L00
       xor       eax,eax
       mov       [rbx],rax
       mov       [rbx+8],rax
       mov       rax,rbx
       add       rsp,28
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r12
       pop       r13
       pop       r14
       pop       r15
       ret
M01_L02:
       xor       eax,eax
       mov       [rbx],rax
       mov       [rbx+8],rax
       mov       rax,rbx
       add       rsp,28
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r12
       pop       r13
       pop       r14
       pop       r15
       ret
M01_L03:
       xor       r14d,r14d
       xor       r15d,r15d
       jmp       near ptr M01_L00
M01_L04:
       call      qword ptr [7FF8F8E1E9A0]
       int       3
M01_L05:
       test      r15d,r15d
       jne       short M01_L04
       xor       r14d,r14d
       xor       r15d,r15d
       jmp       near ptr M01_L00
M01_L06:
       call      CORINFO_HELP_RNGCHKFAIL
       int       3
; Total bytes of code 391
```

#### Stage 2 - After introduction of entries

```assembly
       push      r14
       push      rdi
       push      rsi
       push      rbp
       push      rbx
       sub       rsp,30
       mov       rbx,rdx
       mov       rsi,r8
       lea       r8,[rcx+40]
       mov       edx,esi
       and       edx,3FFF
       mov       eax,edx
       sar       eax,1F
       and       eax,3FF
       add       eax,edx
       sar       eax,0A
       mov       r10d,eax
       shl       r10d,0A
       sub       edx,r10d
       cmp       [r8],r8b
       cdqe
       mov       r8,[r8+rax*8]
       movsxd    rdx,edx
       mov       edi,[r8+rdx*4]
       mov       r8,[rcx+10]
       test      r8,r8
       je        near ptr M01_L07
       mov       rbp,[r8+8]
       mov       r14d,[r8+10]
       test      rbp,rbp
       je        near ptr M01_L05
       cmp       [rbp+8],r14d
       jb        near ptr M01_L06
       add       rbp,10
M01_L00:
       test      edi,edi
       je        near ptr M01_L03
M01_L01:
       mov       r8d,edi
       sar       r8d,1F
       and       r8d,0FF
       add       r8d,edi
       sar       r8d,8
       mov       ecx,r8d
       shl       ecx,8
       sub       edi,ecx
       movsxd    r8,r8d
       movsxd    r14,edi
       add       r14,[rbp+r8*8]
       cmp       [r14],rsi
       jne       short M01_L02
       mov       r8d,[r14+0C]
       mov       ecx,r8d
       shr       ecx,0C
       mov       edx,ecx
       shl       edx,0C
       sub       r8d,edx
       add       r8,[rbp+rcx*8]
       test      byte ptr [r8],80
       jne       short M01_L02
       movzx     ecx,byte ptr [r8+1]
       add       r8,2
       mov       [rsp+28],r8
       mov       rdx,[rbx]
       mov       eax,[rbx+8]
       cmp       ecx,eax
       jne       short M01_L02
       mov       r8d,eax
       mov       rcx,[rsp+28]
       call      qword ptr [7FF8C2AF5068]; System.SpanHelpers.SequenceEqual(Byte ByRef, Byte ByRef, UIntPtr)
       test      eax,eax
       jne       short M01_L04
M01_L02:
       mov       edi,[r14+8]
       test      edi,edi
       jne       short M01_L01
M01_L03:
       xor       eax,eax
       add       rsp,30
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r14
       ret
M01_L04:
       mov       rax,r14
       add       rsp,30
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r14
       ret
M01_L05:
       test      r14d,r14d
       jne       short M01_L06
       xor       ebp,ebp
       jmp       near ptr M01_L00
M01_L06:
       call      qword ptr [7FF8C2BDE9A0]
       int       3
M01_L07:
       xor       ebp,ebp
       jmp       near ptr M01_L00
; Total bytes of code 298
```

#### Stage 3 - Going pointers

```assembly
; Paprika.Chain.PooledSpanDictionary.TryGetImpl(System.ReadOnlySpan`1<Byte>, UInt64)
       push      rdi
       push      rsi
       push      rbx
       sub       rsp,20
       mov       rbx,rdx
       mov       rsi,r8
       add       rcx,40
       mov       r8d,esi
       and       r8d,3FFF
       mov       edx,r8d
       sar       edx,1F
       and       edx,1FF
       add       edx,r8d
       sar       edx,9
       mov       eax,edx
       shl       eax,9
       sub       r8d,eax
       cmp       [rcx],cl
       movsxd    rdx,edx
       mov       rcx,[rcx+rdx*8]
       shl       r8d,3
       movsxd    r8,r8d
       mov       rdi,[rcx+r8]
       test      rdi,rdi
       je        short M01_L02
M01_L00:
       cmp       [rdi],rsi
       jne       short M01_L01
       mov       rcx,[rdi+10]
       test      byte ptr [rcx],80
       jne       short M01_L01
       movzx     r8d,byte ptr [rcx+1]
       add       rcx,2
       mov       rdx,[rbx]
       mov       eax,[rbx+8]
       cmp       r8d,eax
       jne       short M01_L01
       mov       r8d,eax
       call      qword ptr [7FF8F8D45068]; System.SpanHelpers.SequenceEqual(Byte ByRef, Byte ByRef, UIntPtr)
       test      eax,eax
       jne       short M01_L03
M01_L01:
       mov       rdi,[rdi+8]
       test      rdi,rdi
       jne       short M01_L00
M01_L02:
       xor       eax,eax
       add       rsp,20
       pop       rbx
       pop       rsi
       pop       rdi
       ret
M01_L03:
       mov       rax,rdi
       add       rsp,20
       pop       rbx
       pop       rsi
       pop       rdi
       ret
```

</details>