### PR TITLE
Faster dictionary

### DIFF
--- a/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
+++ b/src/Paprika.Benchmarks/PooledSpanDictionaryBenchmarks.cs
@@ -1,12 +1,125 @@
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using Paprika.Chain;
 
 namespace Paprika.Benchmarks;
 
 [MemoryDiagnoser]
+[DisassemblyDiagnoser]
 public class PooledSpanDictionaryBenchmarks
 {
     private readonly BufferPool _pool = new(1, false);
+    private readonly PooledSpanDictionary _bigDict;
+
+    private const int BigDictCount = 32_000;
+
+    private static ReadOnlySpan<byte> Value32Bytes => new byte[]
+    {
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+    };
+
+    private readonly PooledSpanDictionary _varLengthKeys;
+    private const int VarLengthKeyCollisions = 8;
+    private const ulong VarLengthKeyCollisionHash = 2348598349058394;
+
+    private static ReadOnlySpan<byte> VarLengthKey => new byte[]
+    {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    };
+
+    public PooledSpanDictionaryBenchmarks()
+    {
+        _bigDict = new PooledSpanDictionary(new BufferPool(128, false, null));
+
+        Span<byte> key = stackalloc byte[4];
+
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i);
+            _bigDict.Set(key, i, Value32Bytes, 1);
+        }
+
+        _varLengthKeys = new PooledSpanDictionary(new BufferPool(32, false, null));
+
+        for (uint i = 0; i < VarLengthKeyCollisions; i++)
+        {
+            _bigDict.Set(VarLengthKey[..VarLengthKeyCollisions], VarLengthKeyCollisionHash, Value32Bytes, 1);
+        }
+    }
+
+    [Benchmark]
+    public int Read_from_big_dict()
+    {
+        Span<byte> key = stackalloc byte[4];
+
+        var count = 0;
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i);
+            if (_bigDict.TryGet(key, i, out var data))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int Enumerate_big_dict()
+    {
+        var count = 0;
+
+        foreach (var item in _bigDict)
+        {
+            count += item.Metadata;
+        }
+
+        return count;
+    }
+
+
+    [Benchmark]
+    public int Read_missing_with_hash_collisions()
+    {
+        Span<byte> key = stackalloc byte[4];
+
+        var count = 0;
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i + 1_000_000);
+            if (_bigDict.TryGet(key, i, out var data))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int Read_missing_with_no_hash_collisions()
+    {
+        Span<byte> key = stackalloc byte[4];
+
+        var count = 0;
+        for (uint i = 0; i < BigDictCount; i++)
+        {
+            Unsafe.WriteUnaligned(ref key[0], i);
+            if (_bigDict.TryGet(key, i + 1_000_000, out var data))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
 
     [Benchmark]
     public int Read_write_small()
@@ -15,18 +128,27 @@ public class PooledSpanDictionaryBenchmarks
 
         Span<byte> key = stackalloc byte[2];
 
-        for (byte i = 0; i < 255; i++)
-        {
-            key[0] = i;
-            dict.Set(key, i, key, 1);
-        }
-
         var count = 0;
         for (byte i = 0; i < 255; i++)
         {
             key[0] = i;
-            dict.TryGet(key, (ulong)i, out var result);
+            dict.Set(key, i, key, 1);
+            dict.TryGet(key, i, out var result);
             count += result[0];
+        }
+
+        return count;
+    }
+
+    [Benchmark(OperationsPerInvoke = VarLengthKeyCollisions)]
+    public int Read_colliding_hashes_different_lengths()
+    {
+        var count = 0;
+
+        for (var i = 0; i < VarLengthKeyCollisions; i++)
+        {
+            _varLengthKeys.TryGet(VarLengthKey[..(i + 1)], VarLengthKeyCollisionHash, out var data);
+            count += data.Length;
         }
 
         return count;

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Net.Sockets;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -94,7 +93,7 @@ public class PooledSpanDictionary : IDisposable
         Debug.Assert(BitOperations.LeadingZeroCount(leftover) >= 11, "First 10 bits should be left unused");
 
         var address = _root[(int)bucket];
-        if (address == 0) return default;
+        if (address == 0) goto NotFound;
 
         ref var pages = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(_pages));
         do
@@ -113,15 +112,14 @@ public class PooledSpanDictionary : IDisposable
                 {
                     ref var payload = ref Unsafe.Add(ref at, PreambleLength + AddressLength);
 
-                    var storedKeyLength = payload;
+                    var storedKeyLength = (int)payload;
                     if (storedKeyLength == key.Length)
                     {
                         var storedKey = MemoryMarshal.CreateSpan(ref Unsafe.Add(ref payload, KeyLengthLength),
                             storedKeyLength);
                         if (storedKey.SequenceEqual(key))
                         {
-                            ref var data = ref Unsafe.Add(ref payload, KeyLengthLength + storedKeyLength);
-                            return new SearchResult(ref at, ref data);
+                            return new SearchResult(ref at);
                         }
                     }
                 }
@@ -130,6 +128,7 @@ public class PooledSpanDictionary : IDisposable
             // Decode next entry address
             address = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref at, PreambleLength));
         } while (address != 0);
+    NotFound:
         return default;
     }
 
@@ -160,11 +159,17 @@ public class PooledSpanDictionary : IDisposable
         public bool IsFound => !Unsafe.IsNullRef(ref _header);
 
         private readonly ref byte _header;
-        private readonly ref byte _data;
-
-        public SearchResult(ref byte header, ref byte data)
+        private readonly ref byte GetData
         {
-            _data = ref data;
+            get
+            {
+                ref var payload = ref Unsafe.Add(ref _header, PreambleLength + AddressLength);
+                return ref Unsafe.Add(ref payload, KeyLengthLength + payload);
+            }
+        }
+
+        public SearchResult(ref byte header)
+        {
             _header = ref header;
         }
 
@@ -176,8 +181,9 @@ public class PooledSpanDictionary : IDisposable
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref _data, ValueLengthLength),
-                Unsafe.ReadUnaligned<ushort>(ref _data));
+                ref var data = ref GetData;
+                return MemoryMarshal.CreateSpan(ref Unsafe.Add(ref data, ValueLengthLength),
+                Unsafe.ReadUnaligned<ushort>(ref data));
             }
         }
 
@@ -187,15 +193,16 @@ public class PooledSpanDictionary : IDisposable
                 return false;
 
             var length = data0.Length + data1.Length;
-            if (Unsafe.ReadUnaligned<ushort>(ref _data) >= length)
+            ref var data = ref GetData;
+            if (Unsafe.ReadUnaligned<ushort>(ref data) >= length)
             {
                 // update metadata bit
                 _header = (byte)((_header & ~MetadataBits) | (metadata << MetadataShift));
 
                 // There's the place to have it update in place
-                Unsafe.WriteUnaligned(ref _data, (ushort)length);
+                Unsafe.WriteUnaligned(ref data, (ushort)length);
 
-                var destination = MemoryMarshal.CreateSpan(ref Unsafe.Add(ref _data, ValueLengthLength), length);
+                var destination = MemoryMarshal.CreateSpan(ref Unsafe.Add(ref data, ValueLengthLength), length);
                 data0.CopyTo(destination);
                 if (data1.IsEmpty == false)
                 {
@@ -216,7 +223,7 @@ public class PooledSpanDictionary : IDisposable
     }
 
     public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data, byte metadata) =>
-        SetImpl(key, Mix(hash), data, ReadOnlySpan<byte>.Empty, metadata);
+        SetImpl(key, Mix(hash), data, default, metadata);
 
     public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1,
         byte metadata) => SetImpl(key, Mix(hash), data0, data1, metadata);


### PR DESCRIPTION
Much simpler take than #298 on the performance of the `PooledSpanDictionary`. `TryGetImpl` method has all the bound checks removed dropping from `; Total bytes of code 359` to `; Total bytes of code 345`. This makes this method inlineable in a few call sites.

Probably the heaviest thing left is the actual:

```asm
 call      qword ptr [7FF8F8D45068]; System.SpanHelpers.SequenceEqual(Byte ByRef, Byte ByRef, UIntPtr)
```

that could be tried to be optimized for cases of small lengths later if needed.

### Dissassembly

```assembly
; Paprika.Chain.PooledSpanDictionary.TryGetImpl(System.ReadOnlySpan`1<Byte>, UInt32, UInt32)
       push      r15
       push      r14
       push      r13
       push      rdi
       push      rsi
       push      rbp
       push      rbx
       sub       rsp,20
       mov       rsi,rdx
       mov       rbx,r8
       mov       edi,r9d
       mov       eax,[rsp+80]
       mov       r8,[rcx+28]
       cmp       [r8],r8b
       mov       edx,eax
       sar       edx,0A
       movsxd    rdx,edx
       mov       r8,[r8+rdx*8+10]
       and       eax,3FF
       cdqe
       mov       ebp,[r8+rax*4]
       test      ebp,ebp
       je        near ptr M01_L02
       mov       r8,[rcx+10]
       test      r8,r8
       je        near ptr M01_L04
       mov       r14,[r8+8]
       mov       r15d,[r8+10]
       test      r14,r14
       je        near ptr M01_L05
       cmp       [r14+8],r15d
       jb        near ptr M01_L03
       add       r14,10
M01_L00:
       mov       r8d,ebp
       shr       r8d,0C
       mov       ecx,r8d
       shl       ecx,0C
       sub       ebp,ecx
       mov       r15d,ebp
       add       r15,[r14+r8*8]
       movzx     r8d,byte ptr [r15]
       test      r8b,80
       jne       short M01_L01
       and       r8d,1F
       shl       r8d,10
       movzx     ecx,byte ptr [r15+1]
       shl       ecx,8
       add       r8d,ecx
       movzx     ecx,byte ptr [r15+2]
       add       r8d,ecx
       movsxd    r8,r8d
       mov       ecx,edi
       cmp       r8,rcx
       jne       short M01_L01
       lea       rbp,[r15+7]
       movzx     r13d,byte ptr [rbp]
       mov       r8d,[rbx+8]
       cmp       r13d,r8d
       jne       short M01_L01
       lea       rcx,[rbp+1]
       mov       rdx,[rbx]
       call      qword ptr [7FF8F8D45068]; System.SpanHelpers.SequenceEqual(Byte ByRef, Byte ByRef, UIntPtr)
       test      eax,eax
       je        short M01_L01
       inc       r13d
       movsxd    rax,r13d
       add       rax,rbp
       mov       [rsi],r15
       mov       [rsi+8],rax
       mov       rax,rsi
       add       rsp,20
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r13
       pop       r14
       pop       r15
       ret
M01_L01:
       mov       ebp,[r15+3]
       test      ebp,ebp
       jne       near ptr M01_L00
       xor       eax,eax
       mov       [rsi],rax
       mov       [rsi+8],rax
       mov       rax,rsi
       add       rsp,20
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r13
       pop       r14
       pop       r15
       ret
M01_L02:
       xor       eax,eax
       mov       [rsi],rax
       mov       [rsi+8],rax
       mov       rax,rsi
       add       rsp,20
       pop       rbx
       pop       rbp
       pop       rsi
       pop       rdi
       pop       r13
       pop       r14
       pop       r15
       ret
M01_L03:
       call      qword ptr [7FF8F8E2E9A0]
       int       3
M01_L04:
       xor       r14d,r14d
       jmp       near ptr M01_L00
M01_L05:
       test      r15d,r15d
       jne       short M01_L03
       xor       r14d,r14d
       jmp       near ptr M01_L00
; Total bytes of code 345
```
