### PR TITLE
Account serialization

### DIFF
--- a/src/Paprika.Benchmarks/AccountBenchmarks.cs
+++ b/src/Paprika.Benchmarks/AccountBenchmarks.cs
@@ -1,0 +1,35 @@
+﻿using BenchmarkDotNet.Attributes;
+using Paprika.Crypto;
+
+namespace Paprika.Benchmarks;
+
+[MemoryDiagnoser]
+[DisassemblyDiagnoser]
+public class AccountBenchmarks
+{
+    private static readonly Keccak CodeHash = Keccak.Compute(new byte[] { 0, 1, 2, 3 });
+    private static readonly Keccak StorageRoot = Keccak.Compute(new byte[] { 0, 1, 2, 5, 6, 8 });
+
+    private readonly byte[] _buffer = new byte[Account.MaxByteCount];
+
+    [Benchmark]
+    public int Small_contract_write_read()
+    {
+        var expected = new Account(100, 113, CodeHash, StorageRoot);
+        var data = expected.WriteTo(_buffer);
+        Account.ReadFrom(data, out var account);
+
+        return data.Length + account.Balance.BitLen;
+    }
+
+    [Benchmark]
+    public int Eoa_write_read()
+    {
+        var expected = new Account(100, 113);
+        var data = expected.WriteTo(_buffer);
+
+        Account.ReadFrom(data, out var account);
+
+        return data.Length + account.Balance.BitLen;
+    }
+}

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -42,7 +42,9 @@ public readonly struct Account : IEquatable<Account>
 
     public void WithChangedStorageRoot(in Keccak newStorageRoot, out Account account)
     {
+        // Fast copy to return buffer
         account = this;
+        // Overwrite the storage root hash
         Unsafe.AsRef(in account.StorageRootHash) = newStorageRoot;
     }
 

--- a/src/Paprika/Crypto/Keccak.cs
+++ b/src/Paprika/Crypto/Keccak.cs
@@ -67,18 +67,6 @@ public readonly struct Keccak : IEquatable<Keccak>
         Bytes = As<byte, Vector256<byte>>(ref MemoryMarshal.GetReference(bytes));
     }
 
-    public static ReadOnlySpan<byte> ReadFrom(ReadOnlySpan<byte> bytes, out Keccak keccak)
-    {
-        keccak = new Keccak(bytes.Slice(0, Size));
-        return bytes.Slice(Size);
-    }
-
-    public Span<byte> WriteToWithLeftover(Span<byte> output)
-    {
-        Bytes.CopyTo(output);
-        return output.Slice(Size);
-    }
-
     [DebuggerStepThrough]
     public static Keccak Compute(ReadOnlySpan<byte> input)
     {
@@ -136,4 +124,8 @@ public readonly struct Keccak : IEquatable<Keccak>
     public static bool operator ==(Keccak left, Keccak right) => left.Equals(right);
 
     public static bool operator !=(Keccak left, Keccak right) => !(left == right);
+    public static Vector256<byte> operator ^(Keccak left, Keccak right)
+    {
+        return left.Bytes ^ right.Bytes;
+    }
 }

--- a/src/Paprika/Crypto/Keccak.cs
+++ b/src/Paprika/Crypto/Keccak.cs
@@ -121,10 +121,10 @@ public readonly struct Keccak : IEquatable<Keccak>
 
     public string ToString(bool withZeroX) => Span.ToHexString(withZeroX);
 
-    public static bool operator ==(Keccak left, Keccak right) => left.Equals(right);
+    public static bool operator ==(in Keccak left, in Keccak right) => left.Equals(right);
 
-    public static bool operator !=(Keccak left, Keccak right) => !(left == right);
-    public static Vector256<byte> operator ^(Keccak left, Keccak right)
+    public static bool operator !=(in Keccak left, in Keccak right) => !(left == right);
+    public static Vector256<byte> operator ^(in Keccak left, in Keccak right)
     {
         return left.Bytes ^ right.Bytes;
     }

--- a/src/Paprika/Data/Serializer.cs
+++ b/src/Paprika/Data/Serializer.cs
@@ -17,7 +17,7 @@ public static class Serializer
     /// Writes <paramref name="value"/> without encoding the length, returning the leftover.
     /// The caller should store length elsewhere.
     /// </summary>
-    public static Span<byte> WriteWithLeftover(this UInt256 value, Span<byte> destination, out int length)
+    public static int WriteWithLeftover(in UInt256 value, Span<byte> destination)
     {
         var slice = destination.Slice(0, Uint256Size);
         value.ToBigEndian(slice);
@@ -26,16 +26,15 @@ public static class Serializer
         if (firstNonZero == NotFound)
         {
             // all zeros
-            length = 0;
-            return destination;
+            return 0;
         }
 
         // some non-zeroes
-        length = Uint256Size - firstNonZero;
+        var length = Uint256Size - firstNonZero;
 
         // move left
         destination.Slice(firstNonZero, length).CopyTo(destination.Slice(0, length));
-        return destination.Slice(length);
+        return length;
     }
 
     public static void ReadFrom(ReadOnlySpan<byte> source, out UInt256 value)

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1390,7 +1390,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                 Account.ReadFrom(accountOwner.Span, out var account);
 
                 // update it
-                account = account.WithChangedStorageRoot(storageRoot);
+                account.WithChangedStorageRoot(storageRoot, out account);
 
                 // set it in
                 using var pooled = ctx.Rent();


### PR DESCRIPTION
This PR amends the serialization of the Account slightly, making it faster by a few percent. The code is also a bit smaller. The decoding of the account showed up in the profiling, as some percentage and was a low hanging fruit.

### Benchmarks


| Method                    | Mean     | Error    | StdDev   | Code Size | Allocated |
|-------------------------- |---------:|---------:|---------:|----------:|----------:|
| Small_contract_write_read | 60.77 ns | 0.912 ns | 0.853 ns |   3,387 B |         - |
| Small_contract_write_read (after)| 56.32 ns | 1.003 ns | 0.938 ns |   3,201 B |         - |
| Eoa_write_read            | 67.29 ns | 0.864 ns | 0.808 ns |   3,493 B |         - |
| Eoa_write_read (after)           | 56.38 ns | 0.419 ns | 0.392 ns |   3,333 B |         - |

After 98bb3c0

| Method                    | Mean     | Error    | StdDev   | Code Size | Allocated |
|-------------------------- |---------:|---------:|---------:|----------:|----------:|
| Small_contract_write_read | 53.55 ns | 1.047 ns | 1.028 ns |   3,182 B |         - |
| Eoa_write_read            | 59.06 ns | 0.630 ns | 0.589 ns |   3,252 B |         - |

After a45ec1f


| Method                    | Mean     | Error    | StdDev   | Code Size | Allocated |
|-------------------------- |---------:|---------:|---------:|----------:|----------:|
| Small_contract_write_read | 55.79 ns | 0.597 ns | 0.559 ns |   2,759 B |         - |
| Eoa_write_read            | 57.40 ns | 0.582 ns | 0.516 ns |   2,779 B |         - |
