### PR TITLE
Optimize KeccakOrRlp

### DIFF
--- a/src/Paprika.Benchmarks/KeccakOrRlpBenchmarks.cs
+++ b/src/Paprika.Benchmarks/KeccakOrRlpBenchmarks.cs
@@ -1,0 +1,32 @@
+﻿using BenchmarkDotNet.Attributes;
+using Paprika.Crypto;
+using Paprika.RLP;
+
+namespace Paprika.Benchmarks;
+
+[MemoryDiagnoser]
+[DisassemblyDiagnoser]
+public class KeccakOrRlpBenchmarks
+{
+    private static ReadOnlySpan<byte> RlpSpan => new byte[] { 0, 1, 2, 3, 4, 5, 7, 8 };
+    
+    [Benchmark(OperationsPerInvoke = 4)]
+    public int From_span_rlp()
+    {
+        return KeccakOrRlp.FromSpan(RlpSpan).Span.Length +
+            KeccakOrRlp.FromSpan(RlpSpan).Span.Length +
+            KeccakOrRlp.FromSpan(RlpSpan).Span.Length +
+            KeccakOrRlp.FromSpan(RlpSpan).Span.Length;
+    }
+    
+    [Benchmark(OperationsPerInvoke = 4)]
+    public int From_span_keccak()
+    {
+        var span = Keccak.EmptyTreeHash.Span;
+
+        return KeccakOrRlp.FromSpan(span).Span.Length +
+               KeccakOrRlp.FromSpan(span).Span.Length +
+               KeccakOrRlp.FromSpan(span).Span.Length +
+               KeccakOrRlp.FromSpan(span).Span.Length;
+    }
+}

--- a/src/Paprika.Benchmarks/KeccakOrRlpBenchmarks.cs
+++ b/src/Paprika.Benchmarks/KeccakOrRlpBenchmarks.cs
@@ -9,7 +9,7 @@ namespace Paprika.Benchmarks;
 public class KeccakOrRlpBenchmarks
 {
     private static ReadOnlySpan<byte> RlpSpan => new byte[] { 0, 1, 2, 3, 4, 5, 7, 8 };
-    
+
     [Benchmark(OperationsPerInvoke = 4)]
     public int From_span_rlp()
     {
@@ -18,7 +18,7 @@ public class KeccakOrRlpBenchmarks
             KeccakOrRlp.FromSpan(RlpSpan).Span.Length +
             KeccakOrRlp.FromSpan(RlpSpan).Span.Length;
     }
-    
+
     [Benchmark(OperationsPerInvoke = 4)]
     public int From_span_keccak()
     {

--- a/src/Paprika/RLP/KeccakOrRlp.cs
+++ b/src/Paprika/RLP/KeccakOrRlp.cs
@@ -34,7 +34,7 @@ public readonly struct KeccakOrRlp
     public static implicit operator KeccakOrRlp(in Keccak keccak) => new(in keccak);
 
     [SkipLocalsInit]
-    public static KeccakOrRlp FromSpan(scoped Span<byte> data)
+    public static KeccakOrRlp FromSpan(scoped ReadOnlySpan<byte> data)
     {
         KeccakOrRlp keccak;
         Unsafe.SkipInit(out keccak);

--- a/src/Paprika/RLP/KeccakOrRlp.cs
+++ b/src/Paprika/RLP/KeccakOrRlp.cs
@@ -1,4 +1,5 @@
 using Paprika.Crypto;
+using System.Runtime.CompilerServices;
 using SpanExtensions = Paprika.Crypto.SpanExtensions;
 
 namespace Paprika.RLP;
@@ -9,7 +10,7 @@ namespace Paprika.RLP;
 /// </summary>
 public readonly struct KeccakOrRlp
 {
-    private const int NonKeccakOffset = 1;
+    private const int KeccakLength = 32;
 
     public enum Type : byte
     {
@@ -17,35 +18,45 @@ public readonly struct KeccakOrRlp
         Rlp = 1,
     }
 
-    public readonly Type DataType;
     private readonly Keccak _keccak;
+    private readonly int _length;
 
-    public Span<byte> Span => DataType == Type.Keccak
-        ? _keccak.BytesAsSpan
-        : _keccak.BytesAsSpan.Slice(NonKeccakOffset, _keccak.BytesAsSpan[0]);
+    public readonly Type DataType => _length == KeccakLength ? Type.Keccak : Type.Rlp;
 
-    private KeccakOrRlp(Type dataType, scoped Span<byte> data)
+    public Span<byte> Span => _keccak.BytesAsSpan[.._length];
+
+    private KeccakOrRlp(in Keccak keccak)
     {
-        DataType = dataType;
-        _keccak = new Keccak(data);
+        _keccak = keccak;
+        _length = KeccakLength;
     }
 
-    public static implicit operator KeccakOrRlp(Keccak keccak) => new(Type.Keccak, keccak.BytesAsSpan);
+    public static implicit operator KeccakOrRlp(in Keccak keccak) => new(in keccak);
 
+    [SkipLocalsInit]
     public static KeccakOrRlp FromSpan(scoped Span<byte> data)
     {
-        Span<byte> output = stackalloc byte[Keccak.Size];
+        KeccakOrRlp keccak;
+        Unsafe.SkipInit(out keccak);
 
-        if (data.Length < 32)
+        if (data.Length < KeccakLength)
         {
-            // encode length as the first byte
-            output[0] = (byte)data.Length;
-            data.CopyTo(output[NonKeccakOffset..]);
-            return new KeccakOrRlp(Type.Rlp, output);
+            // Zero out keccak as we might not use all of it
+            Unsafe.AsRef(in keccak._keccak) = default;
+            // Set length to the data length
+            Unsafe.AsRef(in keccak._length) = (byte)data.Length;
+            // Copy data to keccak space
+            data.CopyTo(keccak._keccak.BytesAsSpan);
+        }
+        else
+        {
+            // Compute hash directly to keccak
+            KeccakHash.ComputeHash(data, keccak._keccak.BytesAsSpan);
+            // Set length to KeccakLength
+            Unsafe.AsRef(in keccak._length) = (byte)KeccakLength;
         }
 
-        KeccakHash.ComputeHash(data, output);
-        return new KeccakOrRlp(Type.Keccak, output);
+        return keccak;
     }
 
     public override string ToString() => DataType == Type.Keccak


### PR DESCRIPTION
### Benchmarks

#### Before

| Method           | Mean       | Error     | StdDev    | Code Size | Allocated |
|----------------- |-----------:|----------:|----------:|----------:|----------:|
| From_span_rlp    |   8.079 ns | 0.1561 ns | 0.1383 ns |   1,085 B |         - |
| From_span_keccak | 221.261 ns | 3.6607 ns | 3.4242 ns |   1,163 B |         - |

#### After

| Method           | Mean       | Error     | StdDev    | Code Size | Allocated |
|----------------- |-----------:|----------:|----------:|----------:|----------:|
| From_span_rlp    |   6.205 ns | 0.0730 ns | 0.0750 ns |     431 B |         - |
| From_span_keccak | 213.702 ns | 4.2671 ns | 4.5658 ns |     429 B |         - |

### Assembly

For KeccakOrRlp:FromSpan

Before
```
; Total bytes of code: 447
```
After
```
; Total bytes of code: 181
```

Before
```asm
; Method Paprika.RLP.KeccakOrRlp:FromSpan(System.Span`1[ubyte]):Paprika.RLP.KeccakOrRlp (FullOpts)
G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 120
       vzeroupper 
       vxorps   xmm4, xmm4, xmm4
       vmovdqa  xmmword ptr [rsp+0x20], xmm4
       vmovdqa  xmmword ptr [rsp+0x30], xmm4
       vmovdqa  xmmword ptr [rsp+0x40], xmm4
       vmovdqa  xmmword ptr [rsp+0x50], xmm4
       vmovdqa  xmmword ptr [rsp+0x60], xmm4
       mov      rax, 0x3F48BEC3DD9
       mov      qword ptr [rsp+0x70], rax

G_M000_IG02:                ;; offset=0x003A
       mov      rbx, rcx
       mov      rax, bword ptr [rdx]
       mov      esi, dword ptr [rdx+0x08]
       lea      rcx, [rsp+0x20]
       mov      bword ptr [rsp+0x60], rcx
       mov      dword ptr [rsp+0x68], 32
       cmp      esi, 32
       jge      G_M000_IG09

G_M000_IG03:                ;; offset=0x005E
       cmp      dword ptr [rsp+0x68], 0
       jbe      G_M000_IG21
       mov      rcx, bword ptr [rsp+0x60]
       mov      byte  ptr [rcx], sil
       lea      rcx, bword ptr [rsp+0x60]
       mov      edx, dword ptr [rcx+0x08]
       lea      r8d, [rdx-0x01]
       mov      r10d, r8d
       inc      r10
       cmp      r10, rdx
       ja       G_M000_IG17
       mov      rcx, bword ptr [rcx]
       inc      rcx
       cmp      esi, r8d
       ja       G_M000_IG18
       mov      r8d, esi
       mov      rdx, rax
       call     [System.Buffer:Memmove(byref,byref,ulong)]
       mov      rax, bword ptr [rsp+0x60]
       mov      ecx, dword ptr [rsp+0x68]
       test     ecx, ecx
       jne      SHORT G_M000_IG05
       test     byte  ptr [(reloc 0x7ffccc95156a)], 1
       je       G_M000_IG19

G_M000_IG04:                ;; offset=0x00C1
       mov      rax, 0x235800015C0
       vmovups  ymm0, ymmword ptr [rax]
       jmp      SHORT G_M000_IG06

G_M000_IG05:                ;; offset=0x00D1
       vmovups  ymm0, ymmword ptr [rax]

G_M000_IG06:                ;; offset=0x00D5
       mov      byte  ptr [rbx], 1
       vmovups  ymmword ptr [rbx+0x20], ymm0
       mov      rax, rbx
       mov      rcx, 0x3F48BEC3DD9
       cmp      qword ptr [rsp+0x70], rcx
       je       SHORT G_M000_IG07
       call     CORINFO_HELP_FAIL_FAST

G_M000_IG07:                ;; offset=0x00F6
       nop      

G_M000_IG08:                ;; offset=0x00F7
       vzeroupper 
       add      rsp, 120
       pop      rbx
       pop      rsi
       ret      

G_M000_IG09:                ;; offset=0x0101
       mov      bword ptr [rsp+0x50], rax
       mov      dword ptr [rsp+0x58], esi

G_M000_IG10:                ;; offset=0x010A
       vmovdqu  xmm0, xmmword ptr [rsp+0x60]
       vmovdqu  xmmword ptr [rsp+0x40], xmm0

G_M000_IG11:                ;; offset=0x0116
       lea      rcx, [rsp+0x50]
       lea      rdx, [rsp+0x40]
       call     [Paprika.Crypto.KeccakHash:ComputeHash(System.ReadOnlySpan`1[ubyte],System.Span`1[ubyte])]
       mov      rax, bword ptr [rsp+0x60]
       mov      ecx, dword ptr [rsp+0x68]
       test     ecx, ecx
       jne      SHORT G_M000_IG13
       test     byte  ptr [(reloc 0x7ffccc95156a)], 1
       je       SHORT G_M000_IG20

G_M000_IG12:                ;; offset=0x013C
       mov      rax, 0x235800015C0
       vmovups  ymm0, ymmword ptr [rax]
       jmp      SHORT G_M000_IG14

G_M000_IG13:                ;; offset=0x014C
       vmovups  ymm0, ymmword ptr [rax]

G_M000_IG14:                ;; offset=0x0150
       mov      byte  ptr [rbx], 0
       vmovups  ymmword ptr [rbx+0x20], ymm0
       mov      rax, rbx
       mov      rcx, 0x3F48BEC3DD9
       cmp      qword ptr [rsp+0x70], rcx
       je       SHORT G_M000_IG15
       call     CORINFO_HELP_FAIL_FAST

G_M000_IG15:                ;; offset=0x0171
       nop      

G_M000_IG16:                ;; offset=0x0172
       vzeroupper 
       add      rsp, 120
       pop      rbx
       pop      rsi
       ret      

G_M000_IG17:                ;; offset=0x017C
       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
       int3     

G_M000_IG18:                ;; offset=0x0183
       call     [System.ThrowHelper:ThrowArgumentException_DestinationTooShort()]
       int3     

G_M000_IG19:                ;; offset=0x018A
       mov      rcx, 0x7FFCCC9514E8
       mov      edx, 82
       call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       jmp      G_M000_IG04

G_M000_IG20:                ;; offset=0x01A3
       mov      rcx, 0x7FFCCC9514E8
       mov      edx, 82
       call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       jmp      SHORT G_M000_IG12

G_M000_IG21:                ;; offset=0x01B9
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 447
```

After
```asm
; Method Paprika.RLP.KeccakOrRlp:FromSpan(System.Span`1[ubyte]):Paprika.RLP.KeccakOrRlp (FullOpts)
G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 136
       vzeroupper 
       xor      eax, eax
       mov      qword ptr [rsp+0x28], rax
       vxorps   xmm4, xmm4, xmm4
       vmovdqa  xmmword ptr [rsp+0x30], xmm4
       mov      qword ptr [rsp+0x40], rax
       mov      rbx, rcx

G_M000_IG02:                ;; offset=0x0025
       mov      rax, bword ptr [rdx]
       mov      esi, dword ptr [rdx+0x08]
       cmp      esi, 32
       jge      SHORT G_M000_IG06

G_M000_IG03:                ;; offset=0x0030
       vxorps   ymm0, ymm0, ymm0
       vmovdqu  ymmword ptr [rsp+0x48], ymm0
       movzx    rcx, sil
       mov      dword ptr [rsp+0x68], ecx
       lea      rcx, bword ptr [rsp+0x48]
       cmp      esi, 32
       ja       SHORT G_M000_IG07
       mov      r8d, esi
       mov      rdx, rax
       call     [System.Buffer:Memmove(byref,byref,ulong)]

G_M000_IG04:                ;; offset=0x0058
       vmovdqu32 zmm0, zmmword ptr [rsp+0x48]
       vmovdqu32 zmmword ptr [rbx], zmm0
       mov      rax, rbx

G_M000_IG05:                ;; offset=0x006C
       vzeroupper 
       add      rsp, 136
       pop      rbx
       pop      rsi
       ret      

G_M000_IG06:                ;; offset=0x0079
       lea      rcx, bword ptr [rsp+0x48]
       mov      bword ptr [rsp+0x38], rax
       mov      dword ptr [rsp+0x40], esi
       mov      bword ptr [rsp+0x28], rcx
       mov      dword ptr [rsp+0x30], 32
       lea      rcx, [rsp+0x38]
       lea      rdx, [rsp+0x28]
       call     [Paprika.Crypto.KeccakHash:ComputeHash(System.ReadOnlySpan`1[ubyte],System.Span`1[ubyte])]
       mov      dword ptr [rsp+0x68], 32
       jmp      SHORT G_M000_IG04

G_M000_IG07:                ;; offset=0x00AE
       call     [System.ThrowHelper:ThrowArgumentException_DestinationTooShort()]
       int3     
; Total bytes of code: 181
```



