### PR TITLE
Optimize Serializer.ReadFrom

### DIFF
--- a/src/Paprika.Benchmarks/SerializerBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SerializerBenchmarks.cs
@@ -1,0 +1,60 @@
+﻿using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Int256;
+using Paprika.Crypto;
+using Paprika.Data;
+
+namespace Paprika.Benchmarks;
+
+[MemoryDiagnoser]
+[DisassemblyDiagnoser]
+public class SerializerBenchmarks
+{
+    private static ReadOnlySpan<byte> SmallSpan => new byte[] { 0, 1, 2, 3 };
+
+    [Benchmark(OperationsPerInvoke = 4)]
+    public ulong Read_uint256_full()
+    {
+        var span = Keccak.Zero.Span;
+
+        Unsafe.SkipInit(out UInt256 value);
+
+        ulong count = 0;
+
+        Serializer.ReadFrom(span, out value);
+        count += value.u1;
+
+        Serializer.ReadFrom(span, out value);
+        count += value.u1;
+
+        Serializer.ReadFrom(span, out value);
+        count += value.u1;
+
+        Serializer.ReadFrom(span, out value);
+        count += value.u1;
+
+        return count;
+    }
+
+    [Benchmark(OperationsPerInvoke = 4)]
+    public ulong Read_uint256_small()
+    {
+        Unsafe.SkipInit(out UInt256 value);
+
+        ulong count = 0;
+
+        Serializer.ReadFrom(SmallSpan, out value);
+        count += value.u1;
+
+        Serializer.ReadFrom(SmallSpan, out value);
+        count += value.u1;
+
+        Serializer.ReadFrom(SmallSpan, out value);
+        count += value.u1;
+
+        Serializer.ReadFrom(SmallSpan, out value);
+        count += value.u1;
+
+        return count;
+    }
+}

--- a/src/Paprika/Data/Serializer.cs
+++ b/src/Paprika/Data/Serializer.cs
@@ -1,4 +1,7 @@
 using Nethermind.Int256;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace Paprika.Data;
 
@@ -38,11 +41,18 @@ public static class Serializer
         return destination.Slice(length);
     }
 
+    [SkipLocalsInit]
     public static void ReadFrom(ReadOnlySpan<byte> source, out UInt256 value)
     {
-        Span<byte> uint256 = stackalloc byte[Uint256Size];
+        if (source.Length != Uint256Size)
+        {
+            // Clear the vector as we might not fill all of it
+            Vector256<byte> data = default;
+            Span<byte> uint256 = MemoryMarshal.CreateSpan(ref Unsafe.As<Vector256<byte>, byte>(ref data), Vector256<byte>.Count);
+            source.CopyTo(uint256.Slice(Uint256Size - source.Length));
+            source = uint256;
+        }
 
-        source.CopyTo(uint256.Slice(Uint256Size - source.Length));
-        value = new UInt256(uint256, BigEndian);
+        value = new UInt256(source, BigEndian);
     }
 }


### PR DESCRIPTION
### Benchmarks

#### Before

| Method             | Mean      | Error     | StdDev    | Code Size | Allocated |
|------------------- |----------:|----------:|----------:|----------:|----------:|
| Read_uint256_full  |  9.157 ns | 0.1001 ns | 0.0887 ns |     429 B |         - |
| Read_uint256_small | 11.382 ns | 0.1541 ns | 0.1366 ns |     431 B |         - |

#### After

| Method             | Mean      | Error     | StdDev    | Code Size | Allocated |
|------------------- |----------:|----------:|----------:|----------:|----------:|
| Read_uint256_full  |  6.548 ns | 0.0619 ns | 0.0579 ns |     533 B |         - |
| Read_uint256_small | 10.832 ns | 0.1238 ns | 0.1097 ns |     479 B |         - |

### Assembly

Before
```
; Total bytes of code: 232
```
After
```
; Total bytes of code: 161
```

Before
```asm
; Method Paprika.Data.Serializer:ReadFrom(System.ReadOnlySpan`1[ubyte],byref) (FullOpts)
G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 120
       vzeroupper 
       vxorps   xmm4, xmm4, xmm4
       vmovdqa  xmmword ptr [rsp+0x20], xmm4
       vmovdqa  xmmword ptr [rsp+0x30], xmm4
       vmovdqa  xmmword ptr [rsp+0x40], xmm4
       vmovdqa  xmmword ptr [rsp+0x50], xmm4
       vmovdqa  xmmword ptr [rsp+0x60], xmm4
       mov      rax, 0xA302924B2652
       mov      qword ptr [rsp+0x70], rax

G_M000_IG02:                ;; offset=0x003A
       mov      rbx, rdx
       mov      edx, dword ptr [rcx+0x08]
       lea      rsi, [rsp+0x20]
       mov      r8d, edx
       neg      r8d
       add      r8d, 32
       cmp      r8d, 32
       ja       G_M000_IG06
       mov      eax, r8d
       add      rax, rsi
       mov      r10d, 32
       sub      r10d, r8d
       cmp      edx, r10d
       ja       SHORT G_M000_IG07

G_M000_IG03:                ;; offset=0x006D
       mov      r8, bword ptr [rcx]
       mov      r10d, edx
       mov      rcx, rax
       mov      rdx, r8
       mov      r8, r10
       call     [System.Buffer:Memmove(byref,byref,ulong)]
       mov      bword ptr [rsp+0x60], rsi
       mov      dword ptr [rsp+0x68], 32
       vxorps   ymm0, ymm0, ymm0
       vmovdqu  ymmword ptr [rsp+0x40], ymm0
       lea      rcx, [rsp+0x40]
       lea      rdx, [rsp+0x60]
       mov      r8d, 1
       call     [Nethermind.Int256.UInt256:.ctor(byref,bool):this]
       vmovdqu  ymm0, ymmword ptr [rsp+0x40]
       vmovdqu  ymmword ptr [rbx], ymm0
       mov      rcx, 0xA302924B2652
       cmp      qword ptr [rsp+0x70], rcx
       je       SHORT G_M000_IG04
       call     CORINFO_HELP_FAIL_FAST

G_M000_IG04:                ;; offset=0x00CF
       nop      

G_M000_IG05:                ;; offset=0x00D0
       vzeroupper 
       add      rsp, 120
       pop      rbx
       pop      rsi
       ret      

G_M000_IG06:                ;; offset=0x00DA
       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
       int3     

G_M000_IG07:                ;; offset=0x00E1
       call     [System.ThrowHelper:ThrowArgumentException_DestinationTooShort()]
       int3     
; Total bytes of code: 232

```
After
```asm
; Method Paprika.Data.Serializer:ReadFrom(System.ReadOnlySpan`1[ubyte],byref) (FullOpts)
G_M000_IG01:                ;; offset=0x0000
       push     rdi
       push     rsi
       push     rbx
       sub      rsp, 96
       vzeroupper 
       mov      rbx, rcx
       mov      rsi, rdx

G_M000_IG02:                ;; offset=0x0010
       cmp      dword ptr [rbx+0x08], 32
       je       SHORT G_M000_IG05

G_M000_IG03:                ;; offset=0x0016
       vxorps   ymm0, ymm0, ymm0
       vmovups  ymmword ptr [rsp+0x40], ymm0
       lea      rdi, bword ptr [rsp+0x40]
       mov      ecx, dword ptr [rbx+0x08]
       mov      edx, ecx
       neg      edx
       add      edx, 32
       cmp      edx, 32
       ja       SHORT G_M000_IG07
       mov      r8d, edx
       add      r8, rdi
       mov      eax, 32
       sub      eax, edx
       cmp      ecx, eax
       ja       SHORT G_M000_IG08

G_M000_IG04:                ;; offset=0x0045
       mov      rdx, bword ptr [rbx]
       mov      eax, ecx
       mov      rcx, r8
       mov      r8, rax
       call     [System.Buffer:Memmove(byref,byref,ulong)]
       mov      bword ptr [rbx], rdi
       mov      dword ptr [rbx+0x08], 32

G_M000_IG05:                ;; offset=0x0060
       vxorps   ymm0, ymm0, ymm0
       vmovdqu  ymmword ptr [rsp+0x20], ymm0
       lea      rcx, [rsp+0x20]
       mov      rdx, rbx
       mov      r8d, 1
       call     [Nethermind.Int256.UInt256:.ctor(byref,bool):this]
       vmovdqu  ymm0, ymmword ptr [rsp+0x20]
       vmovdqu  ymmword ptr [rsi], ymm0

G_M000_IG06:                ;; offset=0x0088
       vzeroupper 
       add      rsp, 96
       pop      rbx
       pop      rsi
       pop      rdi
       ret      

G_M000_IG07:                ;; offset=0x0093
       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
       int3     

G_M000_IG08:                ;; offset=0x009A
       call     [System.ThrowHelper:ThrowArgumentException_DestinationTooShort()]
       int3     
; Total bytes of code: 161
```