### PR TITLE
Merkle Prefetcher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   tests:
-    timeout-minutes: 15
+    timeout-minutes: 20
     name: "Run Paprika tests"
     runs-on: ubuntu-latest
     permissions:

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -14,10 +14,10 @@ namespace Paprika.Tests.Chain;
 
 public class PrefetchingTests
 {
-    [Test]
+    //[Test]
     public async Task Prefetches_properly_on_not_changed_structure()
     {
-        using var original = PagedDb.NativeMemoryDb(32 * 1024 * 1024, 2);
+        using var original = PagedDb.NativeMemoryDb(8 * 1024 * 1024, 2);
         var db = new ReadForbiddingDb(original);
 
         var merkle = new ComputeMerkleBehavior(ComputeMerkleBehavior.ParallelismNone);

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -14,7 +14,7 @@ namespace Paprika.Tests.Chain;
 
 public class PrefetchingTests
 {
-    [Test]
+    //[Test]
     public async Task Prefetches_properly_on_not_changed_structure()
     {
         using var original = PagedDb.NativeMemoryDb(32 * 1024 * 1024, 2);
@@ -74,8 +74,8 @@ public class PrefetchingTests
     }
 
     [Explicit]
-    [TestCase(true)]
-    [TestCase(false)]
+    [TestCase(true, Category = Categories.LongRunning)]
+    [TestCase(false, Category = Categories.LongRunning)]
     public async Task Spin(bool prefetch)
     {
         var commits = new Stopwatch();

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -14,7 +14,7 @@ namespace Paprika.Tests.Chain;
 
 public class PrefetchingTests
 {
-    //[Test]
+    [Test]
     public async Task Prefetches_properly_on_not_changed_structure()
     {
         using var original = PagedDb.NativeMemoryDb(8 * 1024 * 1024, 2);

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -1,0 +1,97 @@
+﻿using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Paprika.Chain;
+using Paprika.Crypto;
+using Paprika.Merkle;
+using Paprika.Store;
+
+namespace Paprika.Tests.Chain;
+
+[ReportTime]
+public class PrefetchingTests
+{
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Test(bool prefetch)
+    {
+        const int parallelism = ComputeMerkleBehavior.ParallelismNone;
+        
+        const int accounts = 10_000;
+        const int blocks = 1000;
+        const int accountsPerBlock = 10;
+
+        var random = new Random(13);
+        var keccaks = new Keccak[accounts];
+
+        random.NextBytes(MemoryMarshal.Cast<Keccak, byte>(keccaks));
+        
+        using var db = PagedDb.NativeMemoryDb(128 * 1024 * 1024, 2);
+        var merkle = new ComputeMerkleBehavior(parallelism);
+        await using var blockchain = new Blockchain(db, merkle);
+        var at = 0;
+        var parent = Keccak.EmptyTreeHash;
+        var finality = new Queue<Keccak>();
+        var prefetchFailures = 0;
+        
+        for (uint i = 1; i < blocks; i++)
+        {
+            using var block = blockchain.StartNew(parent);
+
+            var slice = keccaks.AsMemory(at % accounts, accountsPerBlock);
+            at += accountsPerBlock;
+            
+            // Execution delay
+            var task = !prefetch
+                ? Task.FromResult(true)
+                : Task.Factory.StartNew(() =>
+                {
+                    var prefetcher = block.OpenPrefetcher();
+                    if (prefetcher == null)
+                        return true;
+
+                    foreach (var keccak in slice.Span)
+                    {
+                        if (prefetcher.CanPrefetchFurther == false)
+                        {
+                            return false;
+                        }
+
+                        prefetcher.PrefetchAccount(keccak);
+                    }
+
+                    return true;
+                });
+            
+            await Task.WhenAll(Task.Delay(20), task);
+
+            if ((await task) == false)
+                prefetchFailures++;
+            
+            SetAccounts(slice, block, i);
+            
+            parent = block.Commit(i);
+            
+            finality.Enqueue(parent);
+            if (finality.Count > 32)
+            {
+                blockchain.Finalize(finality.Dequeue());
+            }
+        }
+
+        while (finality.TryDequeue(out var k))
+        {
+            blockchain.Finalize(k);
+        }
+        
+        Console.WriteLine($"Prefetch failures: {prefetchFailures}");
+    }
+
+    private static void SetAccounts(ReadOnlyMemory<Keccak> slice, IWorldState block, uint i)
+    {
+        foreach (var keccak in slice.Span)
+        {
+            block.SetAccount(keccak, new Account(i,i));
+        }
+    }
+}

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -14,7 +14,7 @@ namespace Paprika.Tests.Chain;
 
 public class PrefetchingTests
 {
-    //[Test]
+    [Test]
     public async Task Prefetches_properly_on_not_changed_structure()
     {
         using var original = PagedDb.NativeMemoryDb(32 * 1024 * 1024, 2);

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
+using FluentAssertions;
+using Nethermind.Int256;
 using Paprika.Chain;
 using Paprika.Crypto;
 using Paprika.Merkle;
@@ -7,18 +9,73 @@ using Paprika.Store;
 
 namespace Paprika.Tests.Chain;
 
-[Explicit]
+
 public class PrefetchingTests
 {
+    [Test]
+    public async Task Prefetches_properly_on_not_changed_structure()
+    {
+        using var original = PagedDb.NativeMemoryDb(32 * 1024 * 1024, 2);
+        var db = new ReadForbiddingDb(original);
+
+        var merkle = new ComputeMerkleBehavior(ComputeMerkleBehavior.ParallelismNone);
+        await using var blockchain = new Blockchain(db, merkle);
+
+        const int blocks = 100;
+        var bigNonce = new UInt256(100, 100, 100, 100);
+
+        var random = new Random(13);
+        var accounts = new Keccak[blocks];
+        random.NextBytes(MemoryMarshal.Cast<Keccak, byte>(accounts));
+        
+        // Create structure first
+        var parent = Keccak.EmptyTreeHash;
+
+        using var start = blockchain.StartNew(parent);
+
+        for (uint account = 0; account < blocks; account++)
+        {
+            
+            start.SetAccount(accounts[account], new Account(13, bigNonce));
+        }
+
+        parent = start.Commit(1);
+        blockchain.Finalize(parent);
+        await blockchain.WaitTillFlush(1);
+
+        for (uint i = 2; i < blocks; i++)
+        {
+            var keccak = accounts[i];
+            using var block = blockchain.StartNew(parent);
+
+            db.MerkleReadsForbid(false);
+            
+            // prefetch first
+            var p = block.OpenPrefetcher();
+            p!.CanPrefetchFurther.Should().BeTrue();
+            p.PrefetchAccount(keccak);
+            
+            // forbid reads
+            db.MerkleReadsForbid(true);
+
+            block.SetAccount(keccak, new Account(i, bigNonce));
+            parent = block.Commit(i);
+            
+            blockchain.Finalize(parent);
+            await blockchain.WaitTillFlush(i);
+        }
+    }
+    
+    [Explicit]
     [TestCase(true)]
     [TestCase(false)]
-    public async Task Test(bool prefetch)
+    public async Task Spin(bool prefetch)
     {
         var commits = new Stopwatch();
 
         const int parallelism = ComputeMerkleBehavior.ParallelismNone;
         const int finalityLength = 16;
-        const int accounts = 500_000;
+        const int accounts = 1_000_000;
         const int accountsPerBlock = 50;
         const int blocks = accounts / accountsPerBlock;
 
@@ -27,7 +84,7 @@ public class PrefetchingTests
 
         random.NextBytes(MemoryMarshal.Cast<Keccak, byte>(keccaks));
 
-        using var db = PagedDb.NativeMemoryDb(512 * 1024 * 1024, 2);
+        using var db = PagedDb.NativeMemoryDb(1024 * 1024 * 1024, 2);
         var merkle = new ComputeMerkleBehavior(parallelism);
         await using var blockchain = new Blockchain(db, merkle);
         var at = 0;

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -47,8 +47,8 @@ public class RootHashFuzzyTests
     }
 
     [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue)]
-    [TestCase(nameof(Accounts_1000_Storage_1000), int.MaxValue)]
     [TestCase(nameof(Accounts_1_Storage_100), 11)]
+    [TestCase(nameof(Accounts_1000_Storage_1000), int.MaxValue, Category = Categories.LongRunning)]
     public async Task In_memory_run(string test, int commitEvery)
     {
         var generator = Build(test);

--- a/src/Paprika.Tests/ReadForbiddingDb.cs
+++ b/src/Paprika.Tests/ReadForbiddingDb.cs
@@ -6,7 +6,7 @@ namespace Paprika.Tests;
 
 public class ReadForbiddingDb(IDb db) : IDb
 {
-    private bool _merkleReadsForbidden;
+    private Key.Predicate? _forbidden;
     public IBatch BeginNextBatch() => db.BeginNextBatch();
 
     public IReadOnlyBatch BeginReadOnlyBatch(string name = "") => new ReadOnlyBatch(db.BeginReadOnlyBatch(name), this);
@@ -25,21 +25,26 @@ public class ReadForbiddingDb(IDb db) : IDb
         public bool TryGet(scoped in Key key, out ReadOnlySpan<byte> result)
         {
             parent.OnTryGet(key, this);
-            
+
             return batch.TryGet(in key, out result);
         }
 
         public void Dispose() => batch.Dispose();
     }
 
-    public void MerkleReadsForbid(bool forbidden)
+    public void ForbidReads(Key.Predicate predicate)
     {
-        _merkleReadsForbidden = forbidden;
+        _forbidden = predicate;
+    }
+
+    public void AllowAllReads()
+    {
+        _forbidden = null;
     }
 
     private void OnTryGet(in Key key, IReadOnlyBatch reads)
     {
-        if (key.Type == DataType.Merkle && _merkleReadsForbidden)
+        if (_forbidden != null && _forbidden(key))
         {
             throw new Exception($"The key {key.ToString()} cannot be get as reads have been forbidden. At {reads.Metadata.BlockNumber}");
         }

--- a/src/Paprika.Tests/ReadForbiddingDb.cs
+++ b/src/Paprika.Tests/ReadForbiddingDb.cs
@@ -1,0 +1,47 @@
+﻿using Paprika.Crypto;
+using Paprika.Data;
+using Paprika.Store;
+
+namespace Paprika.Tests;
+
+public class ReadForbiddingDb(IDb db) : IDb
+{
+    private bool _merkleReadsForbidden;
+    public IBatch BeginNextBatch() => db.BeginNextBatch();
+
+    public IReadOnlyBatch BeginReadOnlyBatch(string name = "") => new ReadOnlyBatch(db.BeginReadOnlyBatch(name), this);
+
+    public void Flush() => db.Flush();
+
+    public IReadOnlyBatch BeginReadOnlyBatchOrLatest(in Keccak stateHash, string name = "") =>
+        new ReadOnlyBatch(db.BeginReadOnlyBatchOrLatest(in stateHash, name), this);
+
+    public bool HasState(in Keccak keccak) => db.HasState(in keccak);
+
+    private class ReadOnlyBatch(IReadOnlyBatch batch, ReadForbiddingDb parent) : IReadOnlyBatch
+    {
+        public Metadata Metadata => batch.Metadata;
+
+        public bool TryGet(scoped in Key key, out ReadOnlySpan<byte> result)
+        {
+            parent.OnTryGet(key, this);
+            
+            return batch.TryGet(in key, out result);
+        }
+
+        public void Dispose() => batch.Dispose();
+    }
+
+    public void MerkleReadsForbid(bool forbidden)
+    {
+        _merkleReadsForbidden = forbidden;
+    }
+
+    private void OnTryGet(in Key key, IReadOnlyBatch reads)
+    {
+        if (key.Type == DataType.Merkle && _merkleReadsForbidden)
+        {
+            throw new Exception($"The key {key.ToString()} cannot be get as reads have been forbidden. At {reads.Metadata.BlockNumber}");
+        }
+    }
+}

--- a/src/Paprika.Tests/ReportTime.cs
+++ b/src/Paprika.Tests/ReportTime.cs
@@ -1,0 +1,26 @@
+﻿using System.Diagnostics;
+using NUnit.Framework.Interfaces;
+
+namespace Paprika.Tests;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class |
+                AttributeTargets.Interface | AttributeTargets.Assembly,
+    AllowMultiple = true)]
+public sealed class ReportTime : Attribute, ITestAction
+{
+    private const string Key = "ReportTime";
+
+    public void BeforeTest(ITest test)
+    {
+        test.Properties.Set(Key, Stopwatch.StartNew());
+    }
+
+    public void AfterTest(ITest test)
+    {
+        var sw = (Stopwatch)test.Properties.Get(Key)!;
+
+        Console.WriteLine($"Took: {sw.Elapsed:g}");
+    }
+
+    public ActionTargets Targets => ActionTargets.Test | ActionTargets.Suite;
+}

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -695,10 +695,9 @@ public class Blockchain : IAsyncDisposable
                     _prefetchPossible = false;
                 }
 
-                foreach (var kvp in cache)
+                foreach (var key in _cached)
                 {
-                    Key.ReadFrom(kvp.Key, out var key);
-                    parent._bloom.Add(GetHash(key));
+                    parent._bloom.Add(key);
                 }
             }
 

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -41,6 +41,20 @@ public interface IPreCommitBehavior
     void OnAccountDestroyed(in Keccak address, ICommit commit)
     {
     }
+
+    /// <summary>
+    /// Whether this allows prefetching behavior.
+    /// </summary>
+    bool CanPrefetch => false;
+
+    /// <summary>
+    /// Runs the prefetch for the given account
+    /// </summary>
+    /// <param name="account"></param>
+    /// <param name="accessor"></param>
+    void Prefetch(in Keccak account, IPrefetcherContext accessor)
+    {
+    }
 }
 
 /// <summary>

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -1,0 +1,52 @@
+﻿using Paprika.Crypto;
+using Paprika.Data;
+
+namespace Paprika.Chain;
+
+/// <summary>
+/// The prefetcher that can be used to prefetch data for <see cref="IPreCommitBehavior"/>
+/// to help it with a faster commitment when <see cref="IWorldState.Commit"/> happens.
+/// </summary>
+public interface IPreCommitPrefetcher
+{
+    /// <summary>
+    /// Whether this prefetcher is still capable of prefetching data.
+    /// </summary>
+    bool CanPrefetchFurther { get; }
+
+    /// <summary>
+    /// Prefetches data needed for the account.
+    /// </summary>
+    /// <param name="account">The account to be prefetched.</param>
+    void PrefetchAccount(in Keccak account);
+
+    /// <summary>
+    /// Prefetches data needed for the account.
+    /// </summary>
+    /// <param name="account">The account to be prefetched.</param>
+    /// <param name="storage">The storage slot</param>
+    void PrefetchStorage(in Keccak account, in Keccak storage)
+    {
+        // currently, only accounts have their data prefetched.
+        PrefetchAccount(account);
+    }
+}
+
+/// <summary>
+/// Allows <see cref="IPreCommitBehavior.Prefetch"/> to access ancestors data.
+/// </summary>
+public interface IPrefetcherContext
+{
+    /// <summary>
+    /// Tries to retrieve the result stored under the given key.
+    /// </summary>
+    /// <remarks>
+    /// Returns a result as an owner that must be disposed properly (using var owner = Get)
+    /// </remarks>
+    public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key);
+
+    /// <summary>
+    /// Sets the value under the given key.
+    /// </summary>
+    void Set(in Key key, in ReadOnlySpan<byte> payload);
+}

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -25,11 +25,7 @@ public interface IPreCommitPrefetcher
     /// </summary>
     /// <param name="account">The account to be prefetched.</param>
     /// <param name="storage">The storage slot</param>
-    void PrefetchStorage(in Keccak account, in Keccak storage)
-    {
-        // currently, only accounts have their data prefetched.
-        PrefetchAccount(account);
-    }
+    void PrefetchStorage(in Keccak account, in Keccak storage);
 }
 
 /// <summary>
@@ -48,5 +44,5 @@ public interface IPrefetcherContext
     /// <summary>
     /// Sets the value under the given key.
     /// </summary>
-    void Set(in Key key, in ReadOnlySpan<byte> payload);
+    void Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type = EntryType.Persistent);
 }

--- a/src/Paprika/Chain/IWorldState.cs
+++ b/src/Paprika/Chain/IWorldState.cs
@@ -42,6 +42,8 @@ public interface IWorldState : IDisposable
     void Reset();
 
     public IStateStats Stats { get; }
+
+    public IPreCommitPrefetcher? OpenPrefetcher();
 }
 
 public interface IReadOnlyWorldState : IReadOnlyCommit, IDisposable

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -148,11 +148,12 @@ public class PooledSpanDictionary : IDisposable
         {
             if (metadataWhere(kvp.Metadata))
             {
+                Key.ReadType(kvp.Key);
                 destination.SetImpl(kvp.Key, kvp.Hash, kvp.Value, ReadOnlySpan<byte>.Empty, kvp.Metadata, append);
             }
         }
     }
-
+    
     private static int GetLeftover(ref byte sliced) =>
         ((sliced & Byte0Mask) << 16) +
         (Unsafe.Add(ref sliced, 1) << 8) +

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -153,7 +153,7 @@ public class PooledSpanDictionary : IDisposable
             }
         }
     }
-    
+
     private static int GetLeftover(ref byte sliced) =>
         ((sliced & Byte0Mask) << 16) +
         (Unsafe.Add(ref sliced, 1) << 8) +

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -93,6 +93,8 @@ public readonly ref partial struct Key
         return leftover;
     }
 
+    public static DataType ReadType(ReadOnlySpan<byte> source) => (DataType)source[0];
+
     public bool IsState => Type == DataType.Account ||
                            (Type == DataType.Merkle && Path.Length < NibblePath.KeccakNibbleCount);
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1426,6 +1426,12 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                 // A leaf will be created here.
                 return;
             }
+            
+            if (owner.QueryDepth > 0)
+            {
+                // data came from the depth
+                context.Set(key, owner.Span);
+            }
 
             // read the existing one
             Node.ReadFrom(out var type, out _, out var ext, out var branch, owner.Span);
@@ -1450,12 +1456,13 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                         return;
                     }
                 case Node.Type.Branch:
-                    if (owner.QueryDepth > 0)
+                    var nibble = path[i];
+                    if (branch.Children[nibble] == false)
                     {
-                        // data came from the depth
-                        context.Set(key, owner.Span);
+                        // no children set, will be created
+                        return;
                     }
-
+                    
                     if (LeafCanBeOmitted(i + 1))
                     {
                         // no need to store leaf on the last level

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -39,9 +39,6 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     internal const string HistogramStorageProcessing = "Storage processing";
     internal const string TotalMerkle = "Total Merkle";
 
-    public const int DefaultMinimumTreeLevelToMemoizeKeccak = 1;
-    public const int MemoizeKeccakEveryNLevel = 1;
-
     private readonly int _maxDegreeOfParallelism;
 
     // metrics
@@ -632,7 +629,6 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
         if (memoize && !isOwnedByThisCommit && memoizedUpdated)
         {
-
             //
             ctx.Commit.SetBranch(key, branch.Children, rlpMemoization, EntryType.Persistent);
         }
@@ -1403,6 +1399,72 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                 // The storage root should be empty, otherwise, it's wrong
                 Debug.Assert(storageRoot == Keccak.EmptyTreeHash,
                     $"Non-existent account with hash of {keccak.ToString()} should have the storage root empty");
+            }
+        }
+    }
+
+
+    public bool CanPrefetch => true;
+
+    public void Prefetch(in Keccak account, IPrefetcherContext context)
+    {
+        // Use a similar algorithm to walking through as the MarkPathAsDirty.
+        // Preload only branches
+        // Flag forcing the leaf creation, that saves one get of the non-existent value.
+        var path = NibblePath.FromKey(account);
+
+        for (var i = 0; i <= path.Length; i++)
+        {
+            var slice = path.SliceTo(i);
+            var key = Key.Merkle(slice);
+            var leftoverPath = path.SliceFrom(i);
+
+            // Query for the node
+            using var owner = context.Get(key);
+            if (owner.IsEmpty)
+            {
+                // A leaf will be created here.
+                return;
+            }
+
+            // read the existing one
+            Node.ReadFrom(out var type, out _, out var ext, out var branch, owner.Span);
+            switch (type)
+            {
+                case Node.Type.Leaf:
+                    // No copy for leaf atm
+                    return;
+                case Node.Type.Extension:
+                    {
+                        var diffAt = ext.Path.FindFirstDifferentNibble(leftoverPath);
+                        if (diffAt == ext.Path.Length)
+                        {
+                            // The path overlaps with what is there, move forward
+                            i += ext.Path.Length - 1;
+
+                            // Consider adding the extension here?
+                            continue;
+                        }
+
+                        // The paths are different, handle by MarkPathAsDirty
+                        return;
+                    }
+                case Node.Type.Branch:
+                    if (owner.QueryDepth > 0)
+                    {
+                        // data came from the depth
+                        context.Set(key, owner.Span);
+                    }
+
+                    if (LeafCanBeOmitted(i + 1))
+                    {
+                        // no need to store leaf on the last level
+                        return;
+                    }
+
+                    break;
+                default:
+                    return;
             }
         }
     }

--- a/src/Paprika/Merkle/RlpMemo.cs
+++ b/src/Paprika/Merkle/RlpMemo.cs
@@ -118,13 +118,13 @@ public readonly ref struct RlpMemo
 
     public static int Compress(in Key key, scoped in ReadOnlySpan<byte> memoizedRlp, NibbleSet.Readonly children, scoped in Span<byte> writeTo)
     {
-        // Optimization, omitting some of the branches to memoize.
-        // It omits only these with two children where the cost of the recompute is not big.
-        // To prevent an attack of spawning multiple levels of such branches, only even are skipped
-        if (children.SetCount == 2 && (key.Path.Length + key.StoragePath.Length) % 2 == 0)
-        {
-            return 0;
-        }
+        // // Optimization, omitting some of the branches to memoize.
+        // // It omits only these with two children where the cost of the recompute is not big.
+        // // To prevent an attack of spawning multiple levels of such branches, only even are skipped
+        // if (children.SetCount == 2 && (key.Path.Length + key.StoragePath.Length) % 2 == 0)
+        // {
+        //     return 0;
+        // }
 
         var memo = new RlpMemo(ComputeMerkleBehavior.MakeRlpWritable(memoizedRlp));
         var at = 0;

--- a/src/Paprika/Merkle/RlpMemo.cs
+++ b/src/Paprika/Merkle/RlpMemo.cs
@@ -118,13 +118,13 @@ public readonly ref struct RlpMemo
 
     public static int Compress(in Key key, scoped in ReadOnlySpan<byte> memoizedRlp, NibbleSet.Readonly children, scoped in Span<byte> writeTo)
     {
-        // // Optimization, omitting some of the branches to memoize.
-        // // It omits only these with two children where the cost of the recompute is not big.
-        // // To prevent an attack of spawning multiple levels of such branches, only even are skipped
-        // if (children.SetCount == 2 && (key.Path.Length + key.StoragePath.Length) % 2 == 0)
-        // {
-        //     return 0;
-        // }
+        // Optimization, omitting some of the branches to memoize.
+        // It omits only these with two children where the cost of the recompute is not big.
+        // To prevent an attack of spawning multiple levels of such branches, only even are skipped
+        if (children.SetCount == 2 && (key.Path.Length + key.StoragePath.Length) % 2 == 0)
+        {
+            return 0;
+        }
 
         var memo = new RlpMemo(ComputeMerkleBehavior.MakeRlpWritable(memoizedRlp));
         var at = 0;


### PR DESCRIPTION
This PR introduces another iteration of Merkle prefetcher. The prefetcher is meant to be opened and then used by a separate thread to prefetch data while processing blocks.  The API usage:

```csharp

// Get prefetcher from the world state
var p = block.OpenPrefetcher();

// In a separate thread, after noticing that some accounts or storage will be accessed
// Prefetch the Merkle data for the account from another thread
if (p != null && p.CanPrefetchFurther)
{
   p?.PrefetchAccount(keccak);
}

// Prefetch the Merkle data for the storage from another thread
if (p != null && p.CanPrefetchFurther)
{
   p?.PrefetchStorage(keccakOfAddress, keccakOfStorageSlot);
}
```

As this API accepts already calculated hashes, it could be the case that storing `StorageCell` and `Address` in the queue should be used so that hashing is delegated to another thread as well.

### Benchmarks

Using a syntethic test that simluates block execution in 50ms time slot (in other words, giving prefetcher 50 ms to run) and

```csharp
const int parallelism = ComputeMerkleBehavior.ParallelismNone;
const int finalityLength = 16;
const int accounts = 1_000_000;
const int accountsPerBlock = 50;
const int blocks = accounts / accountsPerBlock;
```

Total commit time of prefetching one is `0:00:37.981639` while the non-prefetching `0:00:43.2565164`. This is ~13%, but should be much bigger for bigger databases as this was merely 1GB in memory. No page faults, no disk IO 👁️ 