### PR TITLE
CPU prefetch

### DIFF
--- a/src/Paprika.Tests/Store/BasePageTests.cs
+++ b/src/Paprika.Tests/Store/BasePageTests.cs
@@ -27,6 +27,9 @@ public abstract class BasePageTests
 
         public override Page GetAt(DbAddress address) => _address2Page[address];
 
+        public override void Prefetch(DbAddress address)
+        { }
+
         public override DbAddress GetAddress(Page page) => _page2Address[page.Raw];
 
         public override Page GetNewPage(out DbAddress addr, bool clear)

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -10,6 +10,7 @@ abstract class BatchContextBase(uint batchId) : IBatchContext
     public uint BatchId { get; } = batchId;
 
     public abstract Page GetAt(DbAddress address);
+    public abstract void Prefetch(DbAddress address);
 
     public abstract DbAddress GetAddress(Page page);
 

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -103,4 +103,5 @@ public interface IPageResolver
     /// Gets the page at given address.
     /// </summary>
     Page GetAt(DbAddress address);
+    void Prefetch(DbAddress address);
 }

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -6,7 +6,7 @@ using Paprika.Utils;
 
 namespace Paprika.Store.PageManagers;
 
-public class MemoryMappedPageManager : PointerPageManager
+public sealed class MemoryMappedPageManager : PointerPageManager
 {
     private readonly PersistenceOptions _options;
 

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace Paprika.Store.PageManagers;
 
-public unsafe class NativeMemoryPageManager : PointerPageManager
+public sealed unsafe class NativeMemoryPageManager : PointerPageManager
 {
     private readonly void* _ptr;
 


### PR DESCRIPTION
As the CPU does not auto-prefetch across page boundaries, 
Prefetch child page in case we go there next to reduce CPU stalls