### PR TITLE
Page management tests

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -45,7 +45,7 @@ public class AbandonedTests : BasePageTests
 
         byte[] value = [13];
 
-        using var db = PagedDb.NativeMemoryDb(16 * Page.PageSize);
+        using var db = PagedDb.NativeMemoryDb(24 * Page.PageSize);
 
         for (var i = 0; i < repeats; i++)
         {

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -55,8 +55,10 @@ public struct AbandonedList
                 Debug.Assert(at.IsNull == false);
 
                 Current = at;
-                var page = new AbandonedPage(batch.GetAt(at));
-                if (page.Next.IsNull)
+                var page = batch.GetAt(at);
+                Debug.Assert(page.Header.Tracking is not PageTracking.RegisteredForFutureReuse, $"The page is {PageTracking.RegisteredForFutureReuse} but should not be");
+                var abandoned = new AbandonedPage(page);
+                if (abandoned.Next.IsNull)
                 {
                     // no next, clear the slot
                     Addresses[i] = default;
@@ -66,7 +68,7 @@ public struct AbandonedList
                 }
                 else
                 {
-                    Addresses[i] = page.Next;
+                    Addresses[i] = abandoned.Next;
                 }
             }
         }
@@ -77,7 +79,10 @@ public struct AbandonedList
             return false;
         }
 
-        var current = new AbandonedPage(batch.GetAt(Current));
+        var pageAt = batch.GetAt(Current);
+        var current = new AbandonedPage(pageAt);
+        Debug.Assert(pageAt.Header.Tracking is not PageTracking.RegisteredForFutureReuse, $"The page is {PageTracking.RegisteredForFutureReuse} but should not be");
+
         if (current.BatchId != batch.BatchId)
         {
             // The current came from the previous batch.

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -83,13 +83,14 @@ public struct AbandonedList
         if (current.BatchId != batch.BatchId)
         {
             // The current came from the previous batch.
-            // Try to use its own data to copy it over.
-            // But first, register it for reuse
+            // First, register it for reuse
             batch.RegisterForFutureReuse(current.AsPage());
 
             if (current.TryPeek(out var newAt))
             {
+                // If current has a child, we can use the child and COW to it
                 var dest = batch.GetAt(newAt);
+                batch.NoticeAbandonedPageReused(dest);
                 current.CopyTo(dest);
                 batch.AssignBatchId(dest);
 

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -56,7 +56,6 @@ public struct AbandonedList
 
                 Current = at;
                 var page = batch.GetAt(at);
-                Debug.Assert(page.Header.Tracking is not PageTracking.RegisteredForFutureReuse, $"The page is {PageTracking.RegisteredForFutureReuse} but should not be");
                 var abandoned = new AbandonedPage(page);
                 if (abandoned.Next.IsNull)
                 {
@@ -81,8 +80,6 @@ public struct AbandonedList
 
         var pageAt = batch.GetAt(Current);
         var current = new AbandonedPage(pageAt);
-        Debug.Assert(pageAt.Header.Tracking is not PageTracking.RegisteredForFutureReuse, $"The page is {PageTracking.RegisteredForFutureReuse} but should not be");
-
         if (current.BatchId != batch.BatchId)
         {
             // The current came from the previous batch.

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -117,12 +117,10 @@ public struct AbandonedList
             return true;
         }
 
-        // Nothing in the current, register the page for reuse and retry
-        // Previously, it was the page that was reused again, but it led to hard to assert error of page requse
-        batch.RegisterForFutureReuse(current.AsPage());
+        // Nothing in the current. It has been COWed already so can be used as a reusable one
+        reused = batch.GetAddress(current.AsPage());
         Current = DbAddress.Null;
-
-        return TryGet(out reused, minBatchId, batch);
+        return true;
 
         [DoesNotReturn]
         [StackTraceHidden]

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -117,7 +117,6 @@ public struct AbandonedList
 
         // Nothing in the current, register the page for reuse and retry
         // Previously, it was the page that was reused again, but it led to hard to assert error of page requse
-
         batch.RegisterForFutureReuse(current.AsPage());
         Current = DbAddress.Null;
 

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -22,6 +22,8 @@ public readonly struct AbandonedPage(Page page) : IPage
     public uint BatchId => Header.BatchId;
     public DbAddress Next => Data.Next;
 
+    public int Count => Data.Count;
+
     private unsafe ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
     [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -46,6 +46,8 @@ abstract class BatchContextBase(uint batchId) : IBatchContext
 
     public abstract void RegisterForFutureReuse(Page page);
 
+    public virtual void NoticeAbandonedPageReused(Page page) { }
+
     public abstract IDictionary<Keccak, uint> IdCache { get; }
 
     /// <summary>

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -27,11 +27,12 @@ abstract class BatchContextBase(uint batchId) : IBatchContext
         if (page.Header.BatchId == BatchId)
             return page;
 
-        RegisterForFutureReuse(page);
-
         var @new = GetNewPage(out _, false);
         page.CopyTo(@new);
         AssignBatchId(@new);
+
+        // register as the last because registering can amend the tracking 
+        RegisterForFutureReuse(page);
 
         return @new;
     }

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -43,6 +43,12 @@ public interface IBatchContext : IReadOnlyBatchContext
     }
 
     /// <summary>
+    /// Informs the batch, that the given page was abandoned before and is manually reused.
+    /// </summary>
+    /// <param name="page">The page that will be reused.</param>
+    public void NoticeAbandonedPageReused(Page page);
+
+    /// <summary>
     /// Checks whether the page was written during this batch.
     /// </summary>
     bool WasWritten(DbAddress addr);

--- a/src/Paprika/Store/IPageManager.cs
+++ b/src/Paprika/Store/IPageManager.cs
@@ -25,13 +25,4 @@ public interface IPageManager : IDisposable, IPageResolver
     /// Forces to flush the underlying no matter what flags they are
     /// </summary>
     void ForceFlush();
-
-    /// <summary>
-    /// Provides information whether the page manager uses the persistent paging using
-    /// actual IO methods (<see cref="RandomAccess"/> and others).
-    ///
-    /// If it uses paging not based on the actual IO, this means that pages are never flushed manually and
-    /// can be altered just like they were in memory. 
-    /// </summary>
-    bool UsesPersistentPaging { get; }
 }

--- a/src/Paprika/Store/IPageManager.cs
+++ b/src/Paprika/Store/IPageManager.cs
@@ -25,4 +25,13 @@ public interface IPageManager : IDisposable, IPageResolver
     /// Forces to flush the underlying no matter what flags they are
     /// </summary>
     void ForceFlush();
+
+    /// <summary>
+    /// Provides information whether the page manager uses the persistent paging using
+    /// actual IO methods (<see cref="RandomAccess"/> and others).
+    ///
+    /// If it uses paging not based on the actual IO, this means that pages are never flushed manually and
+    /// can be altered just like they were in memory. 
+    /// </summary>
+    bool UsesPersistentPaging { get; }
 }

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -82,9 +82,9 @@ public struct PageHeader
     public byte Level;
 
     /// <summary>
-    /// Internal metadata of the given page.
+    /// Don't use unless for the <see cref="PagedDb.Batch"/> tracking.
     /// </summary>
-    public byte Metadata;
+    public byte PageTracking;
 }
 
 /// <summary>

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -81,10 +81,18 @@ public struct PageHeader
     /// </summary>
     public byte Level;
 
-    /// <summary>
-    /// Don't use unless for the <see cref="PagedDb.Batch"/> tracking.
-    /// </summary>
-    public byte PageTracking;
+    public PageTracking Tracking;
+}
+
+/// <summary>
+/// Used for tracking purposes.
+/// </summary>
+public enum PageTracking : byte
+{
+    NotSet = 0,
+    UsedForTheFirstTime = 1,
+    RegisteredForFutureReuse = 2,
+    ReusedAsNew = 3,
 }
 
 /// <summary>

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -81,18 +81,7 @@ public struct PageHeader
     /// </summary>
     public byte Level;
 
-    public PageTracking Tracking;
-}
-
-/// <summary>
-/// Used for tracking purposes.
-/// </summary>
-public enum PageTracking : byte
-{
-    NotSet = 0,
-    UsedForTheFirstTime = 1,
-    RegisteredForFutureReuse = 2,
-    ReusedAsNew = 3,
+    public byte Metadata;
 }
 
 /// <summary>

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -173,6 +173,8 @@ public sealed class MemoryMappedPageManager : PointerPageManager
         _file.Flush(true);
     }
 
+    public override bool UsesPersistentPaging => _options == PersistenceOptions.FlushFile;
+
     public override void Dispose()
     {
         _meter.Dispose();

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -27,6 +27,8 @@ public sealed unsafe class NativeMemoryPageManager : PointerPageManager
     {
     }
 
+    public override bool UsesPersistentPaging => false;
+
     public override void Dispose() => NativeMemory.AlignedFree(_ptr);
 
     public override ValueTask FlushPages(ICollection<DbAddress> addresses, CommitOptions options) =>

--- a/src/Paprika/Store/PageManagers/PointerPageManager.cs
+++ b/src/Paprika/Store/PageManagers/PointerPageManager.cs
@@ -59,6 +59,7 @@ public abstract unsafe class PointerPageManager(long size) : IPageManager
     public abstract void Flush();
 
     public abstract void ForceFlush();
+    public abstract bool UsesPersistentPaging { get; }
 
     public abstract void Dispose();
 }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -631,8 +631,9 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
             if (reused)
             {
-                Debug.Assert(page.Header.BatchId <= BatchId - _db._historyDepth,
-                    $"The page at {addr} is reused at batch {BatchId} even though it was recently written at {page.Header.BatchId}");
+                Debug.Assert(page.Header.PageType == PageType.Abandoned || page.Header.BatchId <= BatchId - _db._historyDepth,
+                    $"The page at {addr} is reused at batch {BatchId} even though it was recently written at {page.Header.BatchId}. " +
+                    $"Only {nameof(PageType.Abandoned)} can be reused in that manner.");
             }
 
             if (clear)

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -1,4 +1,4 @@
-#define TRACKING_REUSED_PAGES
+//#define TRACKING_REUSED_PAGES
 
 using NonBlocking;
 using System.Diagnostics;

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -687,7 +687,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
                 ref var tracking = ref page.Header.Tracking;
 
                 Debug.Assert(tracking is PageTracking.UsedForTheFirstTime or PageTracking.ReusedAsNew,
-                    $"The page should be either {nameof(PageTracking.ReusedAsNew)} or {nameof(PageTracking.UsedForTheFirstTime)}");
+                    $"The page is {tracking} but should be either {nameof(PageTracking.ReusedAsNew)} or {nameof(PageTracking.UsedForTheFirstTime)}");
 
                 tracking = PageTracking.RegisteredForFutureReuse;
             }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -631,6 +631,11 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
                 Debug.Assert(page.Header.BatchId <= BatchId - _db._historyDepth,
                     $"The page at {addr} is reused at batch {BatchId} even though it was recently written at {page.Header.BatchId}");
             }
+            else if (CanAmendPagesInMemory)
+            {
+                // this is a new page, write down the meta
+                page.Header.PageTracking = Tracking.UsedForTheFirstTime;
+            }
 
             if (clear)
             {

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -667,7 +667,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
                 if (_db._registeredForReuse.Remove(found) == false)
                 {
                     throw new Exception(
-                        $"The page {found} is not registered as reusable. Must have been taken before. It's tried to be reused again");
+                        $"The page {found} is not registered as reusable. Must have been taken before. It's tried to be reused again at batch {BatchId}.");
                 }
             }
 
@@ -690,6 +690,15 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
             batchId = BatchId;
             _abandoned.Add(addr);
+        }
+
+        public override void NoticeAbandonedPageReused(Page page)
+        {
+            var addr = _db.GetAddress(page);
+            if (_db._registeredForReuse.Remove(addr) == false)
+            {
+                throw new Exception($"The page {addr} should have been registered as registered for the reuse but it has not.");
+            }
         }
 
         public override Dictionary<Keccak, uint> IdCache { get; }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -680,7 +680,14 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             var addr = _db.GetAddress(page);
 
             // register at this batch
-            _db._registeredForReuse.Add(addr, BatchId);
+            ref var batchId = ref CollectionsMarshal.GetValueRefOrAddDefault(_db._registeredForReuse, addr, out var exists);
+            if (exists)
+            {
+                throw new Exception(
+                    $"The page {addr} that is tried to be registered for reuse at batch {BatchId} has already been registered at batch {batchId}");
+            }
+
+            batchId = BatchId;
             _abandoned.Add(addr);
         }
 


### PR DESCRIPTION
This PR introduces various asserts and tests to assess the state of the memory management. They can be enabled with setting the `TRACKING_REUSED_PAGES`.