### PR TITLE
Leaf pages different layout

### DIFF
--- a/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
@@ -18,6 +18,9 @@ public class SlottedArrayBenchmarks
     private readonly int _hashCollisionsLength;
     private static readonly byte[] HashCollisionValue = new byte[13];
 
+    private readonly byte[] _copy0 = new byte[Page.PageSize];
+    private readonly byte[] _copy1 = new byte[Page.PageSize];
+
     public SlottedArrayBenchmarks()
     {
         var little = new SlottedArray(_writtenLittleEndian);
@@ -175,5 +178,21 @@ public class SlottedArrayBenchmarks
         }
 
         return length;
+    }
+
+    [Benchmark]
+    public int Move_to_keys()
+    {
+        var map = new SlottedArray(_writtenLittleEndian);
+
+        _copy0.AsSpan().Clear();
+        _copy1.AsSpan().Clear();
+
+        var map0 = new SlottedArray(_copy0);
+        var map1 = new SlottedArray(_copy1);
+
+        map.MoveNonEmptyKeysTo(new MapSource(map0, map1));
+
+        return map.Count + map0.Count + map1.Count;
     }
 }

--- a/src/Paprika.Tests/Data/SlottedArrayTests.cs
+++ b/src/Paprika.Tests/Data/SlottedArrayTests.cs
@@ -218,6 +218,250 @@ public class SlottedArrayTests
         return Verify(span.ToArray());
     }
 
+    private static ReadOnlySpan<byte> Data(byte key) => new[] { key };
+
+    [Test]
+    public void Move_to_1()
+    {
+        var original = new SlottedArray(stackalloc byte[256]);
+        var copy0 = new SlottedArray(stackalloc byte[256]);
+
+        var key1 = NibblePath.Parse("1");
+        var key2 = NibblePath.Parse("23");
+        var key3 = NibblePath.Parse("345");
+        var key4 = NibblePath.Parse("4567");
+        var key5 = NibblePath.Parse("56789");
+
+        original.SetAssert(NibblePath.Empty, Data(0));
+        original.SetAssert(key1, Data(1));
+        original.SetAssert(key2, Data(2));
+        original.SetAssert(key3, Data(3));
+        original.SetAssert(key4, Data(4));
+        original.SetAssert(key5, Data(5));
+
+        original.MoveNonEmptyKeysTo(new(copy0));
+
+        // original should have only empty
+        original.Count.Should().Be(1);
+        original.GetAssert(NibblePath.Empty, Data(0));
+        original.GetShouldFail(key1);
+        original.GetShouldFail(key2);
+        original.GetShouldFail(key3);
+        original.GetShouldFail(key4);
+        original.GetShouldFail(key5);
+
+        // copy should have all but empty
+        copy0.Count.Should().Be(5);
+        copy0.GetShouldFail(NibblePath.Empty);
+        copy0.GetAssert(key1, Data(1));
+        copy0.GetAssert(key2, Data(2));
+        copy0.GetAssert(key3, Data(3));
+        copy0.GetAssert(key4, Data(4));
+        copy0.GetAssert(key5, Data(5));
+    }
+
+    [Test]
+    public void Move_to_2()
+    {
+        var original = new SlottedArray(stackalloc byte[256]);
+        var copy0 = new SlottedArray(stackalloc byte[256]);
+        var copy1 = new SlottedArray(stackalloc byte[256]);
+
+        var key0 = NibblePath.Empty;
+        var key1 = NibblePath.Parse("1");
+        var key2 = NibblePath.Parse("23");
+        var key3 = NibblePath.Parse("345");
+        var key4 = NibblePath.Parse("4567");
+        var key5 = NibblePath.Parse("56789");
+
+        original.SetAssert(key0, Data(0));
+        original.SetAssert(key1, Data(1));
+        original.SetAssert(key2, Data(2));
+        original.SetAssert(key3, Data(3));
+        original.SetAssert(key4, Data(4));
+        original.SetAssert(key5, Data(5));
+
+        original.MoveNonEmptyKeysTo(new(copy0, copy1));
+
+        // original should have only empty
+        original.Count.Should().Be(1);
+        original.GetAssert(key0, Data(0));
+        original.GetShouldFail(key1);
+        original.GetShouldFail(key2);
+        original.GetShouldFail(key3);
+        original.GetShouldFail(key4);
+        original.GetShouldFail(key5);
+
+        // copy0 should have key2 and key4 and nothing else
+        copy0.Count.Should().Be(2);
+        copy0.GetShouldFail(key0);
+        copy0.GetShouldFail(key1);
+        copy0.GetAssert(key2, Data(2));
+        copy0.GetShouldFail(key3);
+        copy0.GetAssert(key4, Data(4));
+        copy0.GetShouldFail(key5);
+
+        // copy1 should have key1 and key3 and key5 and nothing else
+        copy1.Count.Should().Be(3);
+        copy1.GetShouldFail(key0);
+        copy1.GetAssert(key1, Data(1));
+        copy1.GetShouldFail(key2);
+        copy1.GetAssert(key3, Data(3));
+        copy1.GetShouldFail(key4);
+        copy1.GetAssert(key5, Data(5));
+    }
+
+    [Test]
+    public void Move_to_4()
+    {
+        var original = new SlottedArray(stackalloc byte[256]);
+        var copy0 = new SlottedArray(stackalloc byte[256]);
+        var copy1 = new SlottedArray(stackalloc byte[256]);
+        var copy2 = new SlottedArray(stackalloc byte[256]);
+        var copy3 = new SlottedArray(stackalloc byte[256]);
+
+        var key0 = NibblePath.Empty;
+        var key1 = NibblePath.Parse("1");
+        var key2 = NibblePath.Parse("23");
+        var key3 = NibblePath.Parse("345");
+        var key4 = NibblePath.Parse("4567");
+        var key5 = NibblePath.Parse("56789");
+
+        original.SetAssert(key0, Data(0));
+        original.SetAssert(key1, Data(1));
+        original.SetAssert(key2, Data(2));
+        original.SetAssert(key3, Data(3));
+        original.SetAssert(key4, Data(4));
+        original.SetAssert(key5, Data(5));
+
+        original.MoveNonEmptyKeysTo(new(copy0, copy1, copy2, copy3));
+
+        // original should have only empty
+        original.Count.Should().Be(1);
+        original.GetAssert(key0, Data(0));
+        original.GetShouldFail(key1);
+        original.GetShouldFail(key2);
+        original.GetShouldFail(key3);
+        original.GetShouldFail(key4);
+        original.GetShouldFail(key5);
+
+        // copy0 should have key4
+        copy0.Count.Should().Be(1);
+        copy0.GetShouldFail(key0);
+        copy0.GetShouldFail(key1);
+        copy0.GetShouldFail(key2);
+        copy0.GetShouldFail(key3);
+        copy0.GetAssert(key4, Data(4));
+        copy0.GetShouldFail(key5);
+
+        // copy1 should have key1 and key5 and nothing else
+        copy1.Count.Should().Be(2);
+        copy1.GetShouldFail(key0);
+        copy1.GetAssert(key1, Data(1));
+        copy1.GetShouldFail(key2);
+        copy1.GetShouldFail(key3);
+        copy1.GetShouldFail(key4);
+        copy1.GetAssert(key5, Data(5));
+
+        // copy1 should have key2 and nothing else
+        copy2.Count.Should().Be(1);
+        copy2.GetShouldFail(key0);
+        copy2.GetShouldFail(key1);
+        copy2.GetAssert(key2, Data(2));
+        copy2.GetShouldFail(key3);
+        copy2.GetShouldFail(key4);
+        copy2.GetShouldFail(key5);
+
+        // copy1 should have key2 and nothing else
+        copy3.Count.Should().Be(1);
+        copy3.GetShouldFail(key0);
+        copy3.GetShouldFail(key1);
+        copy3.GetShouldFail(key2);
+        copy3.GetAssert(key3, Data(3));
+        copy3.GetShouldFail(key4);
+        copy3.GetShouldFail(key5);
+    }
+
+    [Test]
+    public void Move_to_8()
+    {
+        var original = new SlottedArray(stackalloc byte[512]);
+        var copy0 = new SlottedArray(stackalloc byte[64]);
+        var copy1 = new SlottedArray(stackalloc byte[64]);
+        var copy2 = new SlottedArray(stackalloc byte[64]);
+        var copy3 = new SlottedArray(stackalloc byte[64]);
+        var copy4 = new SlottedArray(stackalloc byte[64]);
+        var copy5 = new SlottedArray(stackalloc byte[64]);
+        var copy6 = new SlottedArray(stackalloc byte[64]);
+        var copy7 = new SlottedArray(stackalloc byte[64]);
+
+        var key0 = NibblePath.Empty;
+        var key1 = NibblePath.Parse("1");
+        var key2 = NibblePath.Parse("23");
+        var key3 = NibblePath.Parse("345");
+        var key4 = NibblePath.Parse("4567");
+        var key5 = NibblePath.Parse("56789");
+        var key6 = NibblePath.Parse("6789AB");
+        var key7 = NibblePath.Parse("789ABCD");
+        var key8 = NibblePath.Parse("89ABCDEF");
+
+        original.SetAssert(key0, Data(0));
+        original.SetAssert(key1, Data(1));
+        original.SetAssert(key2, Data(2));
+        original.SetAssert(key3, Data(3));
+        original.SetAssert(key4, Data(4));
+        original.SetAssert(key5, Data(5));
+        original.SetAssert(key6, Data(6));
+        original.SetAssert(key7, Data(7));
+        original.SetAssert(key8, Data(8));
+
+        original.MoveNonEmptyKeysTo(new(copy0, copy1, copy2, copy3, copy4, copy5, copy6, copy7));
+
+        // original should have only empty
+        HasOnly(original, 0);
+
+        HasOnly(copy0, 8);
+        HasOnly(copy1, 1);
+        HasOnly(copy2, 2);
+        HasOnly(copy3, 3);
+        HasOnly(copy4, 4);
+        HasOnly(copy5, 5);
+        HasOnly(copy6, 6);
+        HasOnly(copy7, 7);
+
+        return;
+
+        static void HasOnly(in SlottedArray map, int key)
+        {
+            map.Count.Should().Be(1);
+
+            for (byte i = 0; i < 8; i++)
+            {
+                var k = i switch
+                {
+                    0 => NibblePath.Empty,
+                    1 => NibblePath.Parse("1"),
+                    2 => NibblePath.Parse("23"),
+                    3 => NibblePath.Parse("345"),
+                    4 => NibblePath.Parse("4567"),
+                    5 => NibblePath.Parse("56789"),
+                    6 => NibblePath.Parse("6789AB"),
+                    7 => NibblePath.Parse("789ABCD"),
+                    _ => NibblePath.Parse("89ABCDEF")
+                };
+
+                if (i == key)
+                {
+                    map.GetAssert(k, Data(i));
+                }
+                else
+                {
+                    map.GetShouldFail(k);
+                }
+            }
+        }
+    }
+
     [Test]
     public void Hashing()
     {
@@ -306,6 +550,11 @@ file static class FixedMapTestExtensions
 
     public static void GetShouldFail(this SlottedArray map, in ReadOnlySpan<byte> key)
     {
-        map.TryGet(NibblePath.FromKey(key), out var actual).Should().BeFalse("The key should not exist");
+        map.TryGet(NibblePath.FromKey(key), out _).Should().BeFalse("The key should not exist");
+    }
+
+    public static void GetShouldFail(this SlottedArray map, in NibblePath key)
+    {
+        map.TryGet(key, out _).Should().BeFalse("The key should not exist");
     }
 }

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -331,8 +331,11 @@ public readonly ref struct SlottedArray
         var array = ArrayPool<byte>.Shared.Rent(size);
         var span = array.AsSpan(0, size);
 
-        span.Clear();
+        // Create the slotted array over the dirty span and then clear it.
+        // It's much cheaper than clearing the whole span itself.
         var copy = new SlottedArray(span);
+        copy.Clear();
+
         var count = _header.Low / Slot.Size;
 
         for (int i = 0; i < count; i++)

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -211,26 +211,20 @@ public readonly ref struct SlottedArray
     }
 
     /// <summary>
-    /// Tries to move as many items as possible from this map to the destination map.
+    /// Moves all the items to the <paramref name="destination"/>, throwing on failure.
     /// </summary>
-    /// <remarks>
-    /// Returns how many items were moved.
-    /// </remarks>
-    public int MoveTo(in SlottedArray destination)
+    public void MoveTo(in SlottedArray destination)
     {
-        var count = 0;
-
         foreach (var item in EnumerateAll())
         {
             // try copy all, even if one is not copyable the other might
-            if (destination.TrySet(item.Key, item.RawData))
+            if (destination.TrySet(item.Key, item.RawData) == false)
             {
-                count++;
-                Delete(item);
+                throw new Exception("Not enough space in the destination map");
             }
         }
 
-        return count;
+        Clear();
     }
 
     public const int BucketCount = 16;

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -21,6 +21,8 @@ namespace Paprika.Data;
 /// </remarks>
 public readonly ref struct SlottedArray
 {
+    public const int Alignment = 8;
+
     private readonly ref Header _header;
     private readonly Span<byte> _data;
 
@@ -372,6 +374,14 @@ public readonly ref struct SlottedArray
 
         data = default;
         return false;
+    }
+
+    /// <summary>
+    /// Clears the map.
+    /// </summary>
+    public void Clear()
+    {
+        _header = default;
     }
 
     [OptimizationOpportunity(OptimizationType.CPU,

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -90,7 +90,7 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
         if (count == 0)
         {
             var overflow = AllocOverflow(batch, out Data.Buckets[0]);
-            Map.MoveTo(overflow.Map);
+            Map.MoveNonEmptyKeysTo(overflow.Map);
             return true;
         }
 
@@ -122,7 +122,7 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
             foreach (var item in new LeafOverflowPage(p).Map.EnumerateAll())
             {
                 Debug.Assert(item.Key.IsEmpty == false, "The key in overflow cannot be empty!");
-                
+
                 var at = item.Key.FirstNibble % newCount;
                 if (overflows[at].Map.TrySet(item.Key, item.RawData) == false)
                 {

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -1,5 +1,6 @@
 ﻿using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Paprika.Data;
@@ -153,14 +154,15 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
 
             var slot = item.Key.FirstNibble % count;
             var overflow = batch.EnsureWritableCopy(ref Data.Buckets[slot]);
+            var map = new LeafOverflowPage(overflow).Map;
 
             var isDelete = item.RawData.IsEmpty;
             if (isDelete)
             {
-                new LeafOverflowPage(overflow).Map.Delete(item.Key);
+                map.Delete(item.Key);
                 Map.Delete(item);
             }
-            else if (new LeafOverflowPage(overflow).Map.TrySet(item.Key, item.RawData))
+            else if (map.TrySet(item.Key, item.RawData))
             {
                 Map.Delete(item);
             }

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -88,7 +88,7 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
         if (count == 0)
         {
             var overflow = AllocOverflow(batch, out Data.Buckets[0]);
-            Map.MoveNonEmptyKeysTo(overflow.Map);
+            Map.MoveNonEmptyKeysTo(new MapSource(overflow.Map));
             return true;
         }
 
@@ -142,6 +142,8 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
         {
             return false;
         }
+
+
 
         foreach (var item in Map.EnumerateAll())
         {


### PR DESCRIPTION
This PR changes the way `LeafPages` spread the data across overflow pages. It does it in the following way:

1. a `LeafPage` can have now 0, 1, 2, 4 or 8 overflow pages
2. `OverflowPage` addressing is based on the first nibble modulo nubmer of overflow pages
3. `DataPage` when trying to flush to children will use `LeafPage.TrySet` that acts a bit differently now
4. `LeafPage.TrySet` will try to set in a local `SlottedArray` but when failing, will try to set in child `Overflow` pages
5. `LeafPage.TryGet` benefits from the modulo bucketing as well, as the search through the `LeafPage` now touches maximally 2 pages and no longer scans through all the overflows
6. `SlottedArray` has now a capability to push its content to another array(s) without using costly `EnumerateAll` that performs `UnprepareKey` operation. As hashes do not change between maps on the same level, neither preambles of entries, they are used as is to get data to another array.

### Benchmarks

#### Sepolia import

<img width="715" alt="Screenshot 2024-05-03 073321" src="https://github.com/NethermindEth/Paprika/assets/519707/338f9e9e-4025-4988-a128-c3520029128c">

<img width="1029" alt="Screenshot 2024-05-03 082357" src="https://github.com/NethermindEth/Paprika/assets/519707/7788a29a-65e6-4380-9ebb-3beb04a5000d">

![image](https://github.com/NethermindEth/Paprika/assets/519707/642fb7b1-5d34-40d5-91bd-87e3b5581907)

