### PR TITLE
Move to faster

### DIFF
--- a/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
@@ -6,7 +6,7 @@ using Paprika.Store;
 
 namespace Paprika.Benchmarks;
 
-[DisassemblyDiagnoser]
+[DisassemblyDiagnoser(maxDepth: 2)]
 public class SlottedArrayBenchmarks
 {
     private readonly byte[] _writtenLittleEndian = new byte[Page.PageSize];

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -230,7 +230,7 @@ public readonly ref struct SlottedArray
                 continue;
 
             var nibble = Slot.GetFirstNibble(slot.Hash);
-            var map = destination.GetMap(nibble);
+            var map = MapSource.GetMap(destination, nibble);
             var payload = GetSlotPayload(ref slot);
 
             Span<byte> data;
@@ -761,18 +761,27 @@ public readonly ref struct MapSource
         _count = 8;
     }
 
-    public SlottedArray GetMap(int nibble)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly SlottedArray GetMap(in MapSource source, int nibble)
     {
-        return (nibble % _count) switch
+        switch (nibble % source._count)
         {
-            0 => _map0,
-            1 => _map1,
-            2 => _map2,
-            3 => _map3,
-            4 => _map4,
-            5 => _map5,
-            6 => _map6,
-            _ => _map7
-        };
+            case 0:
+                return ref source._map0;
+            case 1:
+                return ref source._map1;
+            case 2:
+                return ref source._map2;
+            case 3:
+                return ref source._map3;
+            case 4:
+                return ref source._map4;
+            case 5:
+                return ref source._map5;
+            case 6:
+                return ref source._map6;
+            default:
+                return ref source._map7;
+        }
     }
 }

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -33,6 +33,7 @@ public readonly unsafe struct LeafOverflowPage(Page page)
     }
 
     public SlottedArray Map => new(Data.DataSpan);
+    public Span<byte> MapSpan => Data.DataSpan;
 
     public int CapacityLeft => Map.CapacityLeft;
 


### PR DESCRIPTION
This PR changes `MapSource.GetMap` so that it's ref based and can get inlined nicely. This reduces the codesize by 200 and inlines a method that was called very often.

### Before

```asm
; Paprika.Data.SlottedArray.MoveNonEmptyKeysTo(Paprika.Data.MapSource ByRef)
       lea       rdx,[rsp+80]
       mov       rcx,rsi
       call      qword ptr [7FF7D205DFE0]; Paprika.Data.MapSource.GetMap(Int32)
       lea       rdx,[rsp+70]
; Total bytes of code 427

```

```assembly
; Paprika.Data.MapSource.GetMap(Int32)
       push      rbp
       sub       rsp,20
       vzeroupper
       lea       rbp,[rsp+20]
       vxorps    xmm4,xmm4,xmm4
       vmovdqu   xmmword ptr [rbp-1C],xmm4
       xor       eax,eax
       mov       [rbp-0C],rax
       mov       [rbp-4],eax
       mov       [rbp+10],rcx
       mov       [rbp+18],rdx
       mov       [rbp+20],r8d
M07_L00:
       mov       eax,[rbp+20]
       mov       rcx,[rbp+10]
       cdq
       idiv      dword ptr [rcx+0C0]
       mov       [rbp-1C],edx
       cmp       dword ptr [rbp-1C],6
       ja        short M07_L01
       mov       eax,[rbp-1C]
       mov       eax,eax
       lea       rcx,[7FF7D1C76E88]
       mov       ecx,[rcx+rax*4]
       lea       rdx,[M07_L00]
       add       rcx,rdx
       jmp       rcx
M07_L01:
       jmp       near ptr M07_L02
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+10]
       mov       [rbp-8],rcx
       jmp       near ptr M07_L03
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax+18]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+28]
       mov       [rbp-8],rcx
       jmp       near ptr M07_L03
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax+30]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+40]
       mov       [rbp-8],rcx
       jmp       near ptr M07_L03
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax+48]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+58]
       mov       [rbp-8],rcx
       jmp       short M07_L03
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax+60]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+70]
       mov       [rbp-8],rcx
       jmp       short M07_L03
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax+78]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+88]
       mov       [rbp-8],rcx
       jmp       short M07_L03
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax+90]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+0A0]
       mov       [rbp-8],rcx
       jmp       short M07_L03
M07_L02:
       mov       rax,[rbp+10]
       vmovdqu   xmm0,xmmword ptr [rax+0A8]
       vmovdqu   xmmword ptr [rbp-18],xmm0
       mov       rcx,[rax+0B8]
       mov       [rbp-8],rcx
M07_L03:
       mov       rax,[rbp+18]
       vmovdqu   xmm0,xmmword ptr [rbp-18]
       vmovdqu   xmmword ptr [rax],xmm0
       mov       rcx,[rbp-8]
       mov       [rax+10],rcx
       mov       rax,[rbp+18]
       add       rsp,20
       pop       rbp
       ret
; Total bytes of code 342
```

### After

```asm
; Paprika.Data.SlottedArray.MoveNonEmptyKeysTo(Paprika.Data.MapSource ByRef)
movzx     eax,word ptr [r15+2]
       sar       eax,0C
       movzx     eax,al
       cdq
       idiv      dword ptr [rsi+0C0]
       cmp       edx,6
       ja        short M02_L06
       mov       eax,edx
       lea       rcx,[7FF7D1C6A848]
       mov       ecx,[rcx+rax*4]
       lea       rdx,[M02_L01]
       add       rcx,rdx
       jmp       rcx
       lea       r13,[rsi+18]
       jmp       short M02_L07
       lea       r13,[rsi+30]
       jmp       short M02_L07
       lea       r13,[rsi+48]
       jmp       short M02_L07
       lea       r13,[rsi+60]
       jmp       short M02_L07
       lea       r13,[rsi+78]
       jmp       short M02_L07
       lea       r13,[rsi+90]
       jmp       short M02_L07
M02_L06:
       lea       r13,[rsi+0A8]
M02_L07:
       vmovdqu   xmm0,xmmword ptr [r13]
       vmovdqu   xmmword ptr [rsp+78],xmm0
; Total bytes of code 516
```


### Benchmarks

Faster by 1-2% from the original