### PR TITLE
Event more tight Move

### DIFF
--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -230,7 +230,7 @@ public readonly ref struct SlottedArray
                 continue;
 
             var nibble = Slot.GetFirstNibble(slot.Hash);
-            var map = MapSource.GetMap(destination, nibble);
+            ref readonly var map = ref MapSource.GetMap(destination, nibble);
             var payload = GetSlotPayload(ref slot);
 
             Span<byte> data;


### PR DESCRIPTION
A small change to ref passing eliminates one copy and makes the stack smaller by 16 bytes.

### Before

```asm
; Paprika.Data.SlottedArray.MoveNonEmptyKeysTo(Paprika.Data.MapSource ByRef)

       vmovdqu   xmm0,xmmword ptr [r13]
       vmovdqu   xmmword ptr [rsp+78],xmm0
       mov       rdx,[r13+10]
       mov       [rsp+88],rdx

; Total bytes of code 516
```

### After

```asm
; Paprika.Data.SlottedArray.MoveNonEmptyKeysTo(Paprika.Data.MapSource ByRef)

; the copy of the map from above is eliminated. This will be just a pointer here

; Total bytes of code 470
```