### PR TITLE
DataPage.TryFlushDownToExistingChildren should delete on flushing down

### DIFF
--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -153,6 +153,7 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
                 {
                     var data = new DataPage(child);
                     @new = data.Set(sliced, item.RawData, batch);
+                    map.Delete(item);
                 }
 
                 // Check if the page requires the update, if yes, update


### PR DESCRIPTION
This PR fixes the flush down behavior for child `DataPage`s. If a value is pushed down, it should always be deleted. This drastically speeds up the execution (no double loop over map in DataPage) and potentially saves some space in there.

Test is needed.