### PR TITLE
Abandoned tests and reordering

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -41,7 +41,7 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(18, 1, 10_000)]
     [TestCase(641, 100, 10_000)]
-    [TestCase(200_000, 4000, 20,
+    [TestCase(26875, 4000, 200,
         Description = "2000 to breach AbandonedPage capacity",
         Category = Categories.LongRunning)]
     public async Task Reuse_in_limited_environment(int pageCount, int accounts, int repeats)

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -180,7 +180,7 @@ public class AbandonedTests : BasePageTests
 
         byte[] value = [13];
 
-        using var db = PagedDb.NativeMemoryDb(1024 * Page.PageSize);
+        using var db = PagedDb.NativeMemoryDb(2048 * Page.PageSize);
 
         for (var i = 0; i < repeats; i++)
         {


### PR DESCRIPTION
This PR introduces a new suite to test the abandonment. Also, it changes how the pages are reused. It makes the `AbandonedList` to use a simple FIFO approach, with addition to respecting the min batch. Effectively, readers should be less likely to take a lock on a batchId that can be reused as we always reuse the oldest first.