### PR TITLE
Finalized blocks can be squashed

### DIFF
--- a/src/Paprika.Tests/ReadForbiddingDb.cs
+++ b/src/Paprika.Tests/ReadForbiddingDb.cs
@@ -17,6 +17,7 @@ public class ReadForbiddingDb(IDb db) : IDb
         new ReadOnlyBatch(db.BeginReadOnlyBatchOrLatest(in stateHash, name), this);
 
     public bool HasState(in Keccak keccak) => db.HasState(in keccak);
+    public int HistoryDepth => db.HistoryDepth;
 
     private class ReadOnlyBatch(IReadOnlyBatch batch, ReadForbiddingDb parent) : IReadOnlyBatch
     {

--- a/src/Paprika/IDb.cs
+++ b/src/Paprika/IDb.cs
@@ -30,4 +30,9 @@ public interface IDb
     /// Whether there's a state with the given keccak.
     /// </summary>
     bool HasState(in Keccak keccak);
+
+    /// <summary>
+    /// Gets the history depth for the given db.
+    /// </summary>
+    int HistoryDepth { get; }
 }

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -17,6 +17,8 @@ public sealed unsafe class NativeMemoryPageManager : PointerPageManager
         }
     }
 
+    public void Clear() => NativeMemory.Clear(_ptr, (UIntPtr)DbAddress.Page((uint)MaxPage).FileOffset);
+
     protected override void* Ptr => _ptr;
 
     public override void Flush()

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -298,6 +298,8 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         return false;
     }
 
+    public int HistoryDepth => _historyDepth;
+
     public void Accept(IPageVisitor visitor)
     {
         var i = 0U;


### PR DESCRIPTION
This PR introduces a capability of squashing blocks which are finalized, if the queue of the finalized blocks is long enough. This should help in two cases:

1. Importing, with the queue size set to at least `blockchain.BlockCountForMaxCatchingUp`
2. Node, catching up with blocks that are applied one after another