### PR TITLE
Tombstone handling in overflows

### DIFF
--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -92,7 +92,7 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
             batch.Stats?.LeafPageAllocatesOverflows(1);
 
             var overflow = AllocOverflow(batch, out Data.Buckets[0]);
-            Map.MoveNonEmptyKeysTo(new MapSource(overflow.Map));
+            Map.MoveNonEmptyKeysTo(new MapSource(overflow.Map), true);
             return true;
         }
 
@@ -184,7 +184,7 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
             }
         }
 
-        Map.MoveNonEmptyKeysTo(source);
+        Map.MoveNonEmptyKeysTo(source, true);
         return true;
     }
 


### PR DESCRIPTION
This PR fixes the bug where a tombstone was not removed from the overflow but just pushed down to it. This means that deletes were not propagated properly down, which could result in having them accumulate in leaf pages and filling them up.