### PR TITLE
Fixing dangling transaction of block starting failure

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -362,7 +362,16 @@ public class Blockchain : IAsyncDisposable
             var batch = _db.BeginReadOnlyBatchOrLatest(parentKeccak, "Blockchain dependency");
 
             // batch matches the parent, return
-            return (batch, FindAncestors(parentKeccak, batch));
+            try
+            {
+                var ancestors = FindAncestors(parentKeccak, batch);
+                return (batch, ancestors);
+            }
+            catch
+            {
+                batch.Dispose();
+                throw;
+            }
         }
     }
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -207,6 +207,14 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         }
     }
 
+    public int CountReadOnlyBatches()
+    {
+        lock (_batchLock)
+        {
+            return _batchesReadOnly.Count;
+        }
+    }
+
     private ReadOnlyBatch BeginReadOnlyBatch(string name, in RootPage root)
     {
         var copy = new RootPage(_pooledRoots.Rent(false));


### PR DESCRIPTION
This PR fixes a case, where one of the block dependencies is missing and the created read only transaction is left dangling due to this case.