### PR TITLE
Mertrics - moved length reporting

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -160,6 +160,9 @@ public class Blockchain : IAsyncDisposable
 
                     // If there's something in the queue, don't flush. Flush here only where there's nothing to read from the reader.
                     var readerCount = reader.Count;
+
+                    _flusherQueueCount.Set(readerCount);
+
                     var level = readerCount switch
                     {
                         0 => CommitOptions.FlushDataOnly, // see: CommitOptions.FlushDataOnly
@@ -205,8 +208,6 @@ public class Blockchain : IAsyncDisposable
                     // nothing
                     continue;
                 }
-
-                _flusherQueueCount.Set(reader.Count);
 
                 var flushWatch = Stopwatch.StartNew();
 


### PR DESCRIPTION
A minor to report read count on every spin of the flusher. If the queue is reported only once the application of data is over, it is never reported in a congested scenarios.