### PR TITLE
Merkle extends prefetch to storage

### DIFF
--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -48,11 +48,16 @@ public interface IPreCommitBehavior
     bool CanPrefetch => false;
 
     /// <summary>
-    /// Runs the prefetch for the given account
+    /// Runs the prefetch for the given account.
     /// </summary>
-    /// <param name="account"></param>
-    /// <param name="accessor"></param>
     void Prefetch(in Keccak account, IPrefetcherContext accessor)
+    {
+    }
+
+    /// <summary>
+    /// Runs the prefetch for the given storage.
+    /// </summary>
+    void Prefetch(in Keccak account, in Keccak storage, IPrefetcherContext accessor)
     {
     }
 }

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1433,15 +1433,29 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
     public void Prefetch(in Keccak account, IPrefetcherContext context)
     {
+        PrefetchImpl(account, Unsafe.NullRef<Keccak>(), context);
+    }
+
+    public void Prefetch(in Keccak account, in Keccak storage, IPrefetcherContext context)
+    {
+        PrefetchImpl(account, storage, context);
+    }
+
+    [SkipLocalsInit]
+    private static void PrefetchImpl(in Keccak account, in Keccak storage, IPrefetcherContext context)
+    {
+        var isAccountPrefetch = Unsafe.IsNullRef(in storage);
+        var accountPath = NibblePath.FromKey(account);
+
         // Use a similar algorithm to walking through as the MarkPathAsDirty.
         // Preload only branches
         // Flag forcing the leaf creation, that saves one get of the non-existent value.
-        var path = NibblePath.FromKey(account);
+        var path = NibblePath.FromKey(isAccountPrefetch ? account : storage);
 
         for (var i = 0; i <= path.Length; i++)
         {
             var slice = path.SliceTo(i);
-            var key = Key.Merkle(slice);
+            var key = isAccountPrefetch ? Key.Merkle(slice) : Key.Raw(accountPath, DataType.Merkle, slice);
             var leftoverPath = path.SliceFrom(i);
 
             // Query for the node


### PR DESCRIPTION
This PR allows to prefetch storage as well. When a storage is prefetched it ensures that both state and storage paths are prefetched for the given key. This should be mostly visible in cases, where the data that are merklelized have not been touched for a while.

### Benchmarks

A simple spinning benchmark used

| Prefetch | Storage | Time  | Gain |
| ---|---|---|---|
| n | n | 21.6s | 
| y | n | 19.4s | 11% faster
| n | y | 24.1s |
| y | y | 22.1s | 9% faster
