### PR TITLE
Bit map filter

### DIFF
--- a/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
+++ b/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
@@ -23,31 +23,31 @@ public class BitMapFilterBenchmarks
     {
         var a = new BitMapFilter<BitMapFilter.Of1>(new BitMapFilter.Of1(_pages1A[0]));
         var b = new BitMapFilter<BitMapFilter.Of1>(new BitMapFilter.Of1(_pages1B[0]));
-        
-        a.OrWith(b);
-        a.OrWith(b);
-        a.OrWith(b);
-        a.OrWith(b);
-    }   
-    
-    [Benchmark(OperationsPerInvoke = 4)]
-    public void Or_BitMapFilter_Of2()
-    {
-        var a = new BitMapFilter<BitMapFilter.Of2>(new BitMapFilter.Of2(_pages2A[0], _pages2A[1]));
-        var b = new BitMapFilter<BitMapFilter.Of2>(new BitMapFilter.Of2(_pages2B[0], _pages2B[1]));
-        
+
         a.OrWith(b);
         a.OrWith(b);
         a.OrWith(b);
         a.OrWith(b);
     }
-    
+
+    [Benchmark(OperationsPerInvoke = 4)]
+    public void Or_BitMapFilter_Of2()
+    {
+        var a = new BitMapFilter<BitMapFilter.Of2>(new BitMapFilter.Of2(_pages2A[0], _pages2A[1]));
+        var b = new BitMapFilter<BitMapFilter.Of2>(new BitMapFilter.Of2(_pages2B[0], _pages2B[1]));
+
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+    }
+
     [Benchmark(OperationsPerInvoke = 4)]
     public void Or_BitMapFilter_OfN_128()
     {
         var a = new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16A));
         var b = new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16B));
-        
+
         a.OrWith(b);
         a.OrWith(b);
         a.OrWith(b);
@@ -60,8 +60,8 @@ public class BitMapFilterBenchmarks
 
         for (int i = 0; i < pageCount; i++)
         {
-            pages[i] = new Page( (byte*)NativeMemory.AlignedAlloc( Page.PageSize, Page.PageSize));
-            
+            pages[i] = new Page((byte*)NativeMemory.AlignedAlloc(Page.PageSize, Page.PageSize));
+
             // make data more interesting
             pages[i].Span.Fill((byte)(1 << (i & 7)));
         }

--- a/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
+++ b/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
@@ -1,0 +1,71 @@
+﻿using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Paprika.Data;
+using Paprika.Store;
+
+namespace Paprika.Benchmarks;
+
+[DisassemblyDiagnoser]
+[MemoryDiagnoser]
+public class BitMapFilterBenchmarks
+{
+    private readonly Page[] _pages1A = AlignedAlloc(1);
+    private readonly Page[] _pages1B = AlignedAlloc(1);
+
+    private readonly Page[] _pages2A = AlignedAlloc(2);
+    private readonly Page[] _pages2B = AlignedAlloc(2);
+
+    private readonly Page[] _pages16A = AlignedAlloc(128);
+    private readonly Page[] _pages16B = AlignedAlloc(128);
+
+    [Benchmark(OperationsPerInvoke = 4)]
+    public void Or_BitMapFilter_Of1()
+    {
+        var a = new BitMapFilter<BitMapFilter.Of1>(new BitMapFilter.Of1(_pages1A[0]));
+        var b = new BitMapFilter<BitMapFilter.Of1>(new BitMapFilter.Of1(_pages1B[0]));
+        
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+    }   
+    
+    [Benchmark(OperationsPerInvoke = 4)]
+    public void Or_BitMapFilter_Of2()
+    {
+        var a = new BitMapFilter<BitMapFilter.Of2>(new BitMapFilter.Of2(_pages2A[0], _pages2A[1]));
+        var b = new BitMapFilter<BitMapFilter.Of2>(new BitMapFilter.Of2(_pages2B[0], _pages2B[1]));
+        
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+    }
+    
+    [Benchmark(OperationsPerInvoke = 4)]
+    public void Or_BitMapFilter_OfN_128()
+    {
+        var a = new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16A));
+        var b = new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16B));
+        
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+        a.OrWith(b);
+    }
+
+    private static unsafe Page[] AlignedAlloc(int pageCount)
+    {
+        var pages = new Page[pageCount];
+
+        for (int i = 0; i < pageCount; i++)
+        {
+            pages[i] = new Page( (byte*)NativeMemory.AlignedAlloc( Page.PageSize, Page.PageSize));
+            
+            // make data more interesting
+            pages[i].Span.Fill((byte)(1 << (i & 7)));
+        }
+
+        return pages;
+    }
+}

--- a/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
+++ b/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
@@ -54,6 +54,17 @@ public class BitMapFilterBenchmarks
         a.OrWith(b);
     }
 
+    [Benchmark(OperationsPerInvoke = 4)]
+    public int MayContainAny_BitMapFilter_OfN_128()
+    {
+        var a = new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16A));
+
+        return (a.MayContainAny(13, 17) ? 1 : 0) +
+               (a.MayContainAny(2342, 2345) ? 1 : 0) +
+               (a.MayContainAny(3453453, 8789345) ? 1 : 0) +
+               (a.MayContainAny(2346345, 432509) ? 1 : 0);
+    }
+
     private static unsafe Page[] AlignedAlloc(int pageCount)
     {
         var pages = new Page[pageCount];

--- a/src/Paprika.Tests/Data/BitMapFilterTests.cs
+++ b/src/Paprika.Tests/Data/BitMapFilterTests.cs
@@ -5,7 +5,7 @@ using Paprika.Data;
 namespace Paprika.Tests.Data;
 
 public abstract class BitMapFilterTests<TAccessor> : IDisposable
-    where TAccessor : struct, BitMapFilter.IAccessor
+    where TAccessor : struct, BitMapFilter.IAccessor<TAccessor>
 {
     private readonly BufferPool _pool = new(32);
 

--- a/src/Paprika.Tests/Data/BitMapFilterTests.cs
+++ b/src/Paprika.Tests/Data/BitMapFilterTests.cs
@@ -4,7 +4,7 @@ using Paprika.Data;
 
 namespace Paprika.Tests.Data;
 
-public abstract class BitMapFilterTests<TAccessor>
+public abstract class BitMapFilterTests<TAccessor> : IDisposable
     where TAccessor : struct, BitMapFilter.IAccessor
 {
     private readonly BufferPool _pool = new(32);

--- a/src/Paprika.Tests/Data/BitMapFilterTests.cs
+++ b/src/Paprika.Tests/Data/BitMapFilterTests.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+using Paprika.Chain;
+using Paprika.Data;
+
+namespace Paprika.Tests.Data;
+
+public abstract class BitMapFilterTests<TAccessor>
+    where TAccessor : struct, BitMapFilter.IAccessor
+{
+    private readonly BufferPool _pool = new(32);
+
+    protected abstract BitMapFilter<TAccessor> Build(BufferPool pool);
+
+    [Test]
+    public void Non_colliding_set()
+    {
+        var filter = Build(_pool);
+
+        var count = (ulong)filter.BucketCount;
+
+        for (ulong i = 0; i < count; i++)
+        {
+            filter[i].Should().BeFalse();
+            filter[i] = true;
+            filter[i].Should().BeTrue();
+        }
+
+        filter.Return(_pool);
+    }
+
+    public void Dispose() => _pool.Dispose();
+}
+
+[TestFixture]
+public class BitMapFilterTestsOf1 : BitMapFilterTests<BitMapFilter.Of1>
+{
+    protected override BitMapFilter<BitMapFilter.Of1> Build(BufferPool pool) => BitMapFilter.CreateOf1(pool);
+}
+
+[TestFixture]
+public class BitMapFilterTestsOf2 : BitMapFilterTests<BitMapFilter.Of2>
+{
+    protected override BitMapFilter<BitMapFilter.Of2> Build(BufferPool pool) => BitMapFilter.CreateOf2(pool);
+}
+
+[TestFixture]
+public class BitMapFilterTestsOf4 : BitMapFilterTests<BitMapFilter.OfN>
+{
+    protected override BitMapFilter<BitMapFilter.OfN> Build(BufferPool pool) => BitMapFilter.CreateOfN(pool, 4);
+}
+
+
+

--- a/src/Paprika.Tests/Data/BitMapFilterTests.cs
+++ b/src/Paprika.Tests/Data/BitMapFilterTests.cs
@@ -28,6 +28,28 @@ public abstract class BitMapFilterTests<TAccessor> : IDisposable
         filter.Return(_pool);
     }
 
+    [Test]
+    public void Or_with()
+    {
+        var filter1 = Build(_pool);
+        var filter2 = Build(_pool);
+
+        const ulong v1 = 1;
+        const ulong v2 = 4213798855897314219;
+
+        filter1.Add(v1);
+        filter2.Add(v2);
+
+        filter1.OrWith(filter2);
+
+        filter1.MayContain(v1).Should().BeTrue();
+        filter1.MayContain(v2).Should().BeTrue();
+        filter1.MayContainAny(v1, v2).Should().BeTrue();
+
+        filter1.Return(_pool);
+        filter2.Return(_pool);
+    }
+
     public void Dispose() => _pool.Dispose();
 }
 

--- a/src/Paprika.Tests/Data/PageExtensionsTests.cs
+++ b/src/Paprika.Tests/Data/PageExtensionsTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.InteropServices;
+using FluentAssertions;
+using Paprika.Data;
+using Paprika.Store;
+
+namespace Paprika.Tests.Data;
+
+public class PageExtensionsTests
+{
+    [Test]
+    public void Or_with()
+    {
+        var page0 = Page.DevOnlyNativeAlloc();
+        page0.Clear();
+
+        var page1 = Page.DevOnlyNativeAlloc();
+        const byte fill = 0xFF;
+        page1.Span.Fill(fill); // fill whole page with FFFFF
+
+        const int notFound = -1;
+        page0.Span.IndexOfAnyExcept((byte)0).Should().Be(notFound);
+
+        page0.OrWith(page1);
+
+        page0.Span.IndexOfAnyExcept(fill).Should().Be(notFound);
+    }
+}

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -1127,7 +1127,6 @@ public class Blockchain : IAsyncDisposable
             if (_ancestorsFilter.MayContainAny(keyHash, destroyedHash))
             {
                 // Walk through the ancestors only if the filter shows that they may contain the value
-
                 foreach (var ancestor in _ancestors)
                 {
                     var owner = ancestor.TryGetLocal(key, keyWritten, keyHash, destroyedHash, out var succeeded);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -497,6 +497,7 @@ public class Blockchain : IAsyncDisposable
 
         private readonly ReadOnlyBatchCountingRefs _batch;
         private readonly CommittedBlockState[] _ancestors;
+        private readonly BitFilter _ancestorsFilter;
 
         private readonly Blockchain _blockchain;
 
@@ -525,7 +526,6 @@ public class Blockchain : IAsyncDisposable
         private Keccak? _hash;
 
         private int _dbReads;
-        private BitFilter _ancestorsFilter;
 
         public BlockState(Keccak parentStateRoot, IReadOnlyBatch batch, CommittedBlockState[] ancestors,
             Blockchain blockchain)
@@ -535,7 +535,7 @@ public class Blockchain : IAsyncDisposable
             _ancestors = ancestors;
 
             // ancestors filter
-            _ancestorsFilter = _blockchain.CreateBitFilter();
+            _ancestorsFilter = blockchain.CreateBitFilter();
             foreach (var ancestor in ancestors)
             {
                 _ancestorsFilter.OrWith(ancestor.Filter);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -1398,10 +1398,10 @@ public class Blockchain : IAsyncDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsAccountDestroyed(scoped in Key key, ulong destroyed)
         {
-            if (destroyed == NonDestroyable)
+            if (destroyed == NonDestroyable || _destroyed == null)
                 return false;
 
-            return Filter.MayContain(destroyed) && _destroyed!.Contains(key.Path.UnsafeAsKeccak);
+            return Filter.MayContain(destroyed) && _destroyed.Contains(key.Path.UnsafeAsKeccak);
         }
 
         protected override void CleanUp()

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -144,7 +144,20 @@ public class PooledSpanDictionary : IDisposable
         {
             if (metadataWhere(kvp.Metadata))
             {
-                Key.ReadType(kvp.Key);
+                destination.SetImpl(kvp.Key, kvp.Hash, kvp.Value, ReadOnlySpan<byte>.Empty, kvp.Metadata, append);
+            }
+        }
+    }
+
+    public void CopyTo<TAccessor>(PooledSpanDictionary destination, Predicate<byte> metadataWhere, in BitMapFilter<TAccessor> filter, bool append = false)
+        where TAccessor : struct, BitMapFilter.IAccessor
+    {
+        foreach (var kvp in this)
+        {
+            if (metadataWhere(kvp.Metadata))
+            {
+                Key.ReadFrom(kvp.Key, out var key);
+                filter.Add(Blockchain.GetHash(key));
                 destination.SetImpl(kvp.Key, kvp.Hash, kvp.Value, ReadOnlySpan<byte>.Empty, kvp.Metadata, append);
             }
         }

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -150,7 +150,7 @@ public class PooledSpanDictionary : IDisposable
     }
 
     public void CopyTo<TAccessor>(PooledSpanDictionary destination, Predicate<byte> metadataWhere, in BitMapFilter<TAccessor> filter, bool append = false)
-        where TAccessor : struct, BitMapFilter.IAccessor
+        where TAccessor : struct, BitMapFilter.IAccessor<TAccessor>
     {
         foreach (var kvp in this)
         {

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -1,0 +1,155 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Paprika.Chain;
+using Paprika.Store;
+
+namespace Paprika.Data;
+
+public static class BitMapFilter
+{
+    public static BitMapFilter<Of1> CreateOf1(Page page) => new(new Of1(page));
+    public static BitMapFilter<Of1> CreateOf1(BufferPool pool) => new(new Of1(pool.Rent(true)));
+
+    public static BitMapFilter<Of2> CreateOf2(Page page0, Page page1) => new(new Of2(page0, page1));
+    public static BitMapFilter<Of2> CreateOf2(BufferPool pool) => new(new Of2(pool.Rent(true), pool.Rent(true)));
+
+    public static BitMapFilter<OfN> CreateOfN(BufferPool pool, int n)
+    {
+        var pages = new Page[n];
+        for (var i = 0; i < n; i++)
+        {
+            pages[i] = pool.Rent(true);
+        }
+
+        return new BitMapFilter<OfN>(new OfN(pages));
+    }
+
+
+    public interface IAccessor
+    {
+        public const int BitsPerByteShift = 3;
+        public const int BitsPerByte = 1 << BitsPerByteShift;
+        public const int BitMask = BitsPerByte - 1;
+        public const ulong PageMask = Page.PageSize - 1;
+
+        [Pure]
+        unsafe byte* GetBit(ulong hash, out byte bit);
+
+        [Pure]
+        public void Return(BufferPool pool);
+
+        public int BucketCount { get; }
+    }
+
+    public readonly struct Of1(Page page) : IAccessor
+    {
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe byte* GetBit(ulong hash, out byte bit)
+        {
+            bit = (byte)(1 << (int)(hash & IAccessor.BitMask));
+            return (byte*)page.Raw.ToPointer() + ((hash >> IAccessor.BitsPerByteShift) & IAccessor.PageMask);
+        }
+
+        public void Return(BufferPool pool) => pool.Return(page);
+        public int BucketCount => Page.PageSize * IAccessor.BitsPerByte;
+    }
+
+    public readonly struct Of2(Page page0, Page page1) : IAccessor
+    {
+        private const int PageMask = 1;
+        private const int PageMaskShift = 1;
+
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe byte* GetBit(ulong hash, out byte bit)
+        {
+            bit = (byte)(1 << (int)(hash & IAccessor.BitMask));
+            var h = hash >> IAccessor.BitsPerByteShift;
+            var page = (h & PageMask) == PageMask ? page1 : page0;
+            h >>= PageMaskShift;
+
+            return (byte*)page.Raw.ToPointer() + (h & IAccessor.PageMask);
+        }
+
+        public void Return(BufferPool pool)
+        {
+            pool.Return(page0);
+            pool.Return(page1);
+        }
+
+        public int BucketCount => Page.PageSize * IAccessor.BitsPerByte * 2;
+    }
+
+    public readonly struct OfN : IAccessor
+    {
+        private readonly Page[] _pages;
+        private readonly byte _pageMask;
+        private readonly byte _pageMaskShift;
+
+        public OfN(Page[] pages)
+        {
+            _pages = pages;
+            Debug.Assert(BitOperations.IsPow2(pages.Length));
+            _pageMask = (byte)(pages.Length - 1);
+            _pageMaskShift = (byte)BitOperations.Log2((uint)pages.Length);
+        }
+
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe byte* GetBit(ulong hash, out byte bit)
+        {
+            bit = (byte)(1 << (int)(hash & IAccessor.BitMask));
+            var h = hash >> IAccessor.BitsPerByteShift;
+            var page = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_pages), (int)(h & _pageMask));
+            h >>= _pageMaskShift;
+
+            return (byte*)page.Raw.ToPointer() + (h & IAccessor.PageMask);
+        }
+
+        public void Return(BufferPool pool)
+        {
+            foreach (var page in _pages)
+            {
+                pool.Return(page);
+            }
+        }
+
+        public int BucketCount => Page.PageSize * IAccessor.BitsPerByte * (_pageMask + 1);
+    }
+}
+
+/// <summary>
+/// Represents a simple bitmap based filter.
+/// </summary>
+public readonly struct BitMapFilter<TAccessor>(TAccessor accessor)
+    where TAccessor : struct, BitMapFilter.IAccessor
+{
+    public unsafe bool this[ulong hash]
+    {
+        get
+        {
+            var ptr = accessor.GetBit(hash, out var bit);
+            return (*ptr & bit) == bit;
+        }
+        set
+        {
+            var ptr = accessor.GetBit(hash, out var bit);
+            if (value)
+            {
+                *ptr = (byte)(*ptr | bit);
+            }
+            else
+            {
+                *ptr = (byte)(*ptr & ~bit);
+            }
+        }
+    }
+
+    public int BucketCount => accessor.BucketCount;
+
+    public void Return(BufferPool pool) => accessor.Return(pool);
+}

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -206,10 +206,12 @@ public readonly struct BitMapFilter<TAccessor>
     /// <summary>
     /// Checks whether the filter may contain any of the hashes.
     /// </summary>
-    public bool MayContainAny(ulong hash0, ulong hash1)
+    public unsafe bool MayContainAny(ulong hash0, ulong hash1)
     {
-        // TODO: optimize
-        return this[hash0] || this[hash1];
+        var ptr0 = _accessor.GetBit(Mix(hash0), out var bit0);
+        var ptr1 = _accessor.GetBit(Mix(hash1), out var bit1);
+
+        return ((*ptr0 & bit0) | (*ptr1 & bit1)) != 0;
     }
 
     public void Clear() => _accessor.Clear();

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -83,19 +83,19 @@ public static class BitMapFilter
             _page1 = page1;
         }
 
-        private const int PageMask = 1;
-        private const int PageMaskShift = 1;
-
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe byte* GetBit(ulong hash, out byte bit)
         {
+            const int pageMask = 1;
+            const int pageMaskShift = 1;
+
             bit = (byte)(1 << (int)(hash & BitMask));
             var h = hash >> BitsPerByteShift;
-            var page = (h & PageMask) == PageMask ? _page1 : _page0;
-            h >>= PageMaskShift;
+            var page = (h & pageMask) == pageMask ? _page1 : _page0;
+            h >>= pageMaskShift;
 
-            return (byte*)page.Raw.ToPointer() + (h & BitMapFilter.PageMask);
+            return (byte*)page.Raw.ToPointer() + (h & PageMask);
         }
 
         public void Clear()

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -44,6 +44,7 @@ public static class BitMapFilter
 
         int BucketCount { get; }
 
+        [Pure]
         void OrWith(in TAccessor other);
     }
 

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -10,6 +10,11 @@ namespace Paprika.Data;
 
 public static class BitMapFilter
 {
+    private const int BitsPerByteShift = 3;
+    private const int BitsPerByte = 1 << BitsPerByteShift;
+    private const int BitMask = BitsPerByte - 1;
+    private const ulong PageMask = Page.PageSize - 1;
+
     public static BitMapFilter<Of1> CreateOf1(BufferPool pool) => new(new Of1(pool.Rent(true)));
 
     public static BitMapFilter<Of2> CreateOf2(BufferPool pool) => new(new Of2(pool.Rent(true), pool.Rent(true)));
@@ -25,14 +30,9 @@ public static class BitMapFilter
         return new BitMapFilter<OfN>(new OfN(pages));
     }
 
-
-    public interface IAccessor
+    public interface IAccessor<TAccessor>
+        where TAccessor : struct, IAccessor<TAccessor>
     {
-        public const int BitsPerByteShift = 3;
-        public const int BitsPerByte = 1 << BitsPerByteShift;
-        public const int BitMask = BitsPerByte - 1;
-        public const ulong PageMask = Page.PageSize - 1;
-
         [Pure]
         unsafe byte* GetBit(ulong hash, out byte bit);
 
@@ -43,26 +43,46 @@ public static class BitMapFilter
         void Return(BufferPool pool);
 
         int BucketCount { get; }
+
+        void OrWith(in TAccessor other);
     }
 
-    public readonly struct Of1(Page page) : IAccessor
+    public readonly struct Of1 : IAccessor<Of1>
     {
+        private readonly Page _page;
+
+        public Of1(Page page)
+        {
+            _page = page;
+        }
+
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe byte* GetBit(ulong hash, out byte bit)
         {
-            bit = (byte)(1 << (int)(hash & IAccessor.BitMask));
-            return (byte*)page.Raw.ToPointer() + ((hash >> IAccessor.BitsPerByteShift) & IAccessor.PageMask);
+            bit = (byte)(1 << (int)(hash & BitMask));
+            return (byte*)_page.Raw.ToPointer() + ((hash >> BitsPerByteShift) & PageMask);
         }
 
-        public void Clear() => page.Clear();
+        public void Clear() => _page.Clear();
 
-        public void Return(BufferPool pool) => pool.Return(page);
-        public int BucketCount => Page.PageSize * IAccessor.BitsPerByte;
+        public void Return(BufferPool pool) => pool.Return(_page);
+        public int BucketCount => Page.PageSize * BitsPerByte;
+
+        public void OrWith(in Of1 other) => _page.OrWith(other._page);
     }
 
-    public readonly struct Of2(Page page0, Page page1) : IAccessor
+    public readonly struct Of2 : IAccessor<Of2>
     {
+        private readonly Page _page0;
+        private readonly Page _page1;
+
+        public Of2(Page page0, Page page1)
+        {
+            _page0 = page0;
+            _page1 = page1;
+        }
+
         private const int PageMask = 1;
         private const int PageMaskShift = 1;
 
@@ -70,30 +90,36 @@ public static class BitMapFilter
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe byte* GetBit(ulong hash, out byte bit)
         {
-            bit = (byte)(1 << (int)(hash & IAccessor.BitMask));
-            var h = hash >> IAccessor.BitsPerByteShift;
-            var page = (h & PageMask) == PageMask ? page1 : page0;
+            bit = (byte)(1 << (int)(hash & BitMask));
+            var h = hash >> BitsPerByteShift;
+            var page = (h & PageMask) == PageMask ? _page1 : _page0;
             h >>= PageMaskShift;
 
-            return (byte*)page.Raw.ToPointer() + (h & IAccessor.PageMask);
+            return (byte*)page.Raw.ToPointer() + (h & BitMapFilter.PageMask);
         }
 
         public void Clear()
         {
-            page0.Clear();
-            page1.Clear();
+            _page0.Clear();
+            _page1.Clear();
         }
 
         public void Return(BufferPool pool)
         {
-            pool.Return(page0);
-            pool.Return(page1);
+            pool.Return(_page0);
+            pool.Return(_page1);
         }
 
-        public int BucketCount => Page.PageSize * IAccessor.BitsPerByte * 2;
+        public int BucketCount => Page.PageSize * BitsPerByte * 2;
+
+        public void OrWith(in Of2 other)
+        {
+            _page0.OrWith(other._page0);
+            _page1.OrWith(other._page1);
+        }
     }
 
-    public readonly struct OfN : IAccessor
+    public readonly struct OfN : IAccessor<OfN>
     {
         private readonly Page[] _pages;
         private readonly byte _pageMask;
@@ -111,12 +137,12 @@ public static class BitMapFilter
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe byte* GetBit(ulong hash, out byte bit)
         {
-            bit = (byte)(1 << (int)(hash & IAccessor.BitMask));
-            var h = hash >> IAccessor.BitsPerByteShift;
+            bit = (byte)(1 << (int)(hash & BitMask));
+            var h = hash >> BitsPerByteShift;
             var page = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_pages), (int)(h & _pageMask));
             h >>= _pageMaskShift;
 
-            return (byte*)page.Raw.ToPointer() + (h & IAccessor.PageMask);
+            return (byte*)page.Raw.ToPointer() + (h & PageMask);
         }
 
         public void Clear()
@@ -135,32 +161,59 @@ public static class BitMapFilter
             }
         }
 
-        public int BucketCount => Page.PageSize * IAccessor.BitsPerByte * (_pageMask + 1);
+        public void OrWith(in OfN other)
+        {
+            var count = PageCount;
+
+            Debug.Assert(other.PageCount == count);
+
+            ref var a = ref MemoryMarshal.GetArrayDataReference(_pages);
+            ref var b = ref MemoryMarshal.GetArrayDataReference(other._pages);
+
+            for (var i = 0; i < count; i++)
+            {
+                Unsafe.Add(ref a, i).OrWith(Unsafe.Add(ref b, i));
+            }
+        }
+
+        public int BucketCount => Page.PageSize * BitsPerByte * PageCount;
+
+        private int PageCount => _pageMask + 1;
     }
 }
 
 /// <summary>
 /// Represents a simple bitmap based filter.
 /// </summary>
-public readonly struct BitMapFilter<TAccessor>(TAccessor accessor)
-    where TAccessor : struct, BitMapFilter.IAccessor
+public readonly struct BitMapFilter<TAccessor>
+    where TAccessor : struct, BitMapFilter.IAccessor<TAccessor>
 {
+    private readonly TAccessor _accessor;
+
+    /// <summary>
+    /// Represents a simple bitmap based filter.
+    /// </summary>
+    public BitMapFilter(TAccessor accessor)
+    {
+        _accessor = accessor;
+    }
+
     public void Add(ulong hash) => this[hash] = true;
 
     public bool MayContain(ulong hash) => this[hash];
 
-    public void Clear() => accessor.Clear();
+    public void Clear() => _accessor.Clear();
 
     public unsafe bool this[ulong hash]
     {
         get
         {
-            var ptr = accessor.GetBit(hash, out var bit);
+            var ptr = _accessor.GetBit(hash, out var bit);
             return (*ptr & bit) == bit;
         }
         set
         {
-            var ptr = accessor.GetBit(hash, out var bit);
+            var ptr = _accessor.GetBit(hash, out var bit);
             if (value)
             {
                 *ptr = (byte)(*ptr | bit);
@@ -172,7 +225,16 @@ public readonly struct BitMapFilter<TAccessor>(TAccessor accessor)
         }
     }
 
-    public int BucketCount => accessor.BucketCount;
+    /// <summary>
+    /// Applies or operation with <paramref name="other"/> bitmap filter and stores it in this one.
+    /// </summary>
+    /// <param name="other"></param>
+    public void OrWith(in BitMapFilter<TAccessor> other)
+    {
+        _accessor.OrWith(other._accessor);
+    }
 
-    public void Return(BufferPool pool) => accessor.Return(pool);
+    public int BucketCount => _accessor.BucketCount;
+
+    public void Return(BufferPool pool) => _accessor.Return(pool);
 }

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -93,7 +93,7 @@ public static class BitMapFilter
 
             mask = (byte)(1 << (int)(hash & BitMask));
             var h = hash >> BitsPerByteShift;
-            var page = (h & pageMask) == pageMask ? _page1 : _page0;
+            var page = (h & pageMask) != pageMask ? _page0 : _page1;
             h >>= pageMaskShift;
 
             return (byte*)page.Raw.ToPointer() + (h & PageMask);

--- a/src/Paprika/Data/PageExtensions.cs
+++ b/src/Paprika/Data/PageExtensions.cs
@@ -12,86 +12,54 @@ public static class PageExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static unsafe void OrWith(this Page @this, Page other)
     {
+        const int bitsPerByte = 8;
+
         ref var a = ref Unsafe.AsRef<byte>(@this.Raw.ToPointer());
         ref var b = ref Unsafe.AsRef<byte>(other.Raw.ToPointer());
 
         if (Vector512.IsHardwareAccelerated)
         {
-            const int size = 512;
-            const int unroll = 2;
+            const int size = 512 / bitsPerByte;
 
-            for (var i = 0; i < Page.PageSize / size / unroll; i += unroll)
+            for (UIntPtr i = 0; i < Page.PageSize; i += size)
             {
-                var va = Vector512.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
-                var vb = Vector512.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
-
+                var va = Vector512.LoadUnsafe(ref a, i);
+                var vb = Vector512.LoadUnsafe(ref b, i);
                 var vc = Vector512.BitwiseOr(va, vb);
-                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
 
-                va = Vector512.LoadUnsafe(ref Unsafe.Add(ref a, (i + 1) * size));
-                vb = Vector512.LoadUnsafe(ref Unsafe.Add(ref b, (i + 1) * size));
-
-                vc = Vector512.BitwiseOr(va, vb);
-                vc.StoreUnsafe(ref Unsafe.Add(ref a, (i + 1) * size));
+                vc.StoreUnsafe(ref a, i);
             }
         }
         else if (Vector256.IsHardwareAccelerated)
         {
-            const int size = 256;
-            const int unroll = 2;
-            const int count = Page.PageSize / size / unroll;
+            const int size = 256 / bitsPerByte;
 
-            for (var i = 0; i < count; i += unroll)
+            for (UIntPtr i = 0; i < Page.PageSize; i += size)
             {
-                var va = Vector256.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
-                var vb = Vector256.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
-
+                var va = Vector256.LoadUnsafe(ref a, i);
+                var vb = Vector256.LoadUnsafe(ref b, i);
                 var vc = Vector256.BitwiseOr(va, vb);
-                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
 
-                va = Vector256.LoadUnsafe(ref Unsafe.Add(ref a, (i + 1) * size));
-                vb = Vector256.LoadUnsafe(ref Unsafe.Add(ref b, (i + 1) * size));
-
-                vc = Vector256.BitwiseOr(va, vb);
-                vc.StoreUnsafe(ref Unsafe.Add(ref a, (i + 1) * size));
+                vc.StoreUnsafe(ref a, i);
             }
         }
         else if (Vector128.IsHardwareAccelerated)
         {
-            const int size = 128;
-            const int unroll = 2;
-            const int count = Page.PageSize / size / unroll;
+            const int size = 128 / bitsPerByte;
 
-            for (var i = 0; i < count; i += unroll)
+            for (UIntPtr i = 0; i < Page.PageSize; i += size)
             {
-                var va = Vector128.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
-                var vb = Vector128.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
-
+                var va = Vector128.LoadUnsafe(ref a, i);
+                var vb = Vector128.LoadUnsafe(ref b, i);
                 var vc = Vector128.BitwiseOr(va, vb);
-                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
 
-                va = Vector128.LoadUnsafe(ref Unsafe.Add(ref a, (i + 1) * size));
-                vb = Vector128.LoadUnsafe(ref Unsafe.Add(ref b, (i + 1) * size));
-
-                vc = Vector128.BitwiseOr(va, vb);
-                vc.StoreUnsafe(ref Unsafe.Add(ref a, (i + 1) * size));
-            }
-        }
-        else if (Vector64.IsHardwareAccelerated)
-        {
-            const int size = 64;
-            for (var i = 0; i < Page.PageSize / size; i++)
-            {
-                var va = Vector64.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
-                var vb = Vector64.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
-
-                var vc = Vector64.BitwiseOr(va, vb);
-                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
+                vc.StoreUnsafe(ref a, i);
             }
         }
         else
         {
-            const int size = 8;
+            const int size = sizeof(long);
+
             for (var i = 0; i < Page.PageSize / size; i++)
             {
                 ref var va = ref Unsafe.As<byte, long>(ref Unsafe.Add(ref a, i * size));

--- a/src/Paprika/Data/PageExtensions.cs
+++ b/src/Paprika/Data/PageExtensions.cs
@@ -1,0 +1,77 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Paprika.Store;
+
+namespace Paprika.Data;
+
+/// <summary>
+/// Provides extensions for <see cref="Page"/> that are data related.
+/// </summary>
+public static class PageExtensions
+{
+    public static unsafe void OrWith(this Page @this, Page other)
+    {
+        ref var a = ref Unsafe.AsRef<byte>(@this.Raw.ToPointer());
+        ref var b = ref Unsafe.AsRef<byte>(other.Raw.ToPointer());
+
+        if (Vector512.IsHardwareAccelerated)
+        {
+            const int size = 512;
+            for (var i = 0; i < Page.PageSize / size; i++)
+            {
+                var va = Vector512.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
+                var vb = Vector512.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
+
+                var vc = Vector512.BitwiseOr(va, vb);
+                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
+            }
+        }
+        else if (Vector256.IsHardwareAccelerated)
+        {
+            const int size = 256;
+            for (var i = 0; i < Page.PageSize / size; i++)
+            {
+                var va = Vector256.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
+                var vb = Vector256.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
+
+                var vc = Vector256.BitwiseOr(va, vb);
+                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
+            }
+        }
+        else if (Vector128.IsHardwareAccelerated)
+        {
+            const int size = 128;
+            for (var i = 0; i < Page.PageSize / size; i++)
+            {
+                var va = Vector128.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
+                var vb = Vector128.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
+
+                var vc = Vector128.BitwiseOr(va, vb);
+                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
+            }
+        }
+        else if (Vector64.IsHardwareAccelerated)
+        {
+            const int size = 64;
+            for (var i = 0; i < Page.PageSize / size; i++)
+            {
+                var va = Vector64.LoadUnsafe(ref Unsafe.Add(ref a, i * size));
+                var vb = Vector64.LoadUnsafe(ref Unsafe.Add(ref b, i * size));
+
+                var vc = Vector64.BitwiseOr(va, vb);
+                vc.StoreUnsafe(ref Unsafe.Add(ref a, i * size));
+            }
+        }
+        else
+        {
+            const int size = 8;
+            for (var i = 0; i < Page.PageSize / size; i++)
+            {
+                ref var va = ref Unsafe.As<byte, long>(ref Unsafe.Add(ref a, i * size));
+                var vb = Unsafe.As<byte, long>(ref Unsafe.Add(ref b, i * size));
+
+                va = va | vb;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a `BitMapFilter` that replaces `Xor` filter when getting the information about whether a block contains a given key. The additional property is the fact that bitmap filter can be easily or-ed which allows to combine it and issue a simple query whether any of the ancestors contains the given key.

`BitMapFilter`  can wrap an arbitrary set of `Page`s as a backing memory. It uses one bit per `Key` ulong hash to store information. Currently, it sets the bitmap size to 512kb which gives ~4million buckets. This clearly won't allow us to not have any collisions (see: [Eric Lippert's great entry](https://ericlippert.com/2010/03/22/socks-birthdays-and-hash-collisions/)), but should help in getting information whether it's worth to query the ancestor blocks at all when getting the data.

#### OR implementation

After several trials, the `OR` operations is implemented as a hardware detecting loop (decides on what vector sized is supported) and is pretty tight resulting in the following implementation for the filter with 128 pages

```assembly
; Paprika.Data.BitMapFilter+OfN.OrWith(OfN ByRef)
       vzeroupper
       movzx     eax,byte ptr [rcx+8]
       inc       eax
       mov       rcx,[rcx]
       cmp       [rcx],cl
       add       rcx,10
       mov       rdx,[rdx]
       cmp       [rdx],dl
       add       rdx,10
       xor       r8d,r8d
       test      eax,eax
       jle       short M01_L02
M01_L00:
       movsxd    r10,r8d
       mov       r9,[rcx+r10*8]
       mov       r10,[rdx+r10*8]
       xor       r11d,r11d
M01_L01:
       vmovups   ymm0,[r9+r11]
       vpor      ymm0,ymm0,[r10+r11]
       vmovups   [r9+r11],ymm0
       add       r11,20
       cmp       r11,1000
       jb        short M01_L01
       inc       r8d
       cmp       r8d,eax
       jl        short M01_L00
M01_L02:
       vzeroupper
       ret
; Total bytes of code 91
```

### Benchmarks

| Method                  | Mean        | Error      | StdDev     | Median      | Code Size | Allocated |
|------------------------ |------------:|-----------:|-----------:|------------:|----------:|----------:|
| Or_BitMapFilter_Of1     |    45.18 ns |   0.900 ns |   1.319 ns |    45.32 ns |     235 B |         - |
| Or_BitMapFilter_Of2     |    88.13 ns |   1.682 ns |   4.281 ns |    86.66 ns |     459 B |         - |
| Or_BitMapFilter_OfN_128 | 9,977.88 ns | 136.468 ns | 127.652 ns | 9,992.83 ns |     332 B |         - |

For blocks we want to use 128 of 4kb pages. Applying `OR` on one costs ~10 microseconds. This means that even for 100 blocks we should be able to use not more than 1 milisecond for 