### PR TITLE
CLI for stats Gathering

### DIFF
--- a/src/Paprika.Cli/Paprika.Cli.csproj
+++ b/src/Paprika.Cli/Paprika.Cli.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Paprika.Runner\Paprika.Runner.csproj" />
       <ProjectReference Include="..\Paprika\Paprika.csproj" />
     </ItemGroup>
 

--- a/src/Paprika.sln
+++ b/src/Paprika.sln
@@ -32,6 +32,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Serialization.Rl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nethermind.Specs", "Nethermind\src\Nethermind\Nethermind.Specs\Nethermind.Specs.csproj", "{20C99460-C6B6-43FE-BD84-8BF81A2A05FA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paprika.Cli", "Paprika.Cli\Paprika.Cli.csproj", "{DD0B1FB7-6D29-47A1-B467-03F28B15FCAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -104,6 +106,10 @@ Global
 		{20C99460-C6B6-43FE-BD84-8BF81A2A05FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20C99460-C6B6-43FE-BD84-8BF81A2A05FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20C99460-C6B6-43FE-BD84-8BF81A2A05FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD0B1FB7-6D29-47A1-B467-03F28B15FCAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD0B1FB7-6D29-47A1-B467-03F28B15FCAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD0B1FB7-6D29-47A1-B467-03F28B15FCAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD0B1FB7-6D29-47A1-B467-03F28B15FCAE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E95BD608-D663-4103-A561-E6C7E1440B7A} = {C1CABFFA-4E4D-4A42-B40F-DC27FE50DFC6}

--- a/src/Paprika/Store/IPageVisitor.cs
+++ b/src/Paprika/Store/IPageVisitor.cs
@@ -14,5 +14,6 @@ public interface IPageVisitor
         where TNext : struct, IPageWithData<TNext>;
 
     IDisposable On(LeafOverflowPage page, DbAddress addr);
+
     IDisposable On(Merkle.StateRootPage data, DbAddress addr);
 }

--- a/src/Paprika/Store/Merkle.cs
+++ b/src/Paprika/Store/Merkle.cs
@@ -129,40 +129,44 @@ public static class Merkle
 
         public void Report(IReporter reporter, IPageResolver resolver, int pageLevel, int trimmedNibbles)
         {
-            // foreach (var bucket in Data.Buckets)
-            // {
-            //     if (!bucket.IsNull)
-            //     {
-            //         var child = resolver.GetAt(bucket);
-            //         if (child.Header.PageType == PageType.Leaf)
-            //             new LeafPage(child).Report(reporter, resolver, pageLevel + 1, trimmedNibbles + 1);
-            //         else
-            //             new DataPage(child).Report(reporter, resolver, pageLevel + 1, trimmedNibbles + 1);
-            //     }
-            // }
-            //
-            // var slotted = new SlottedArray(Data.DataSpan);
-            // reporter.ReportDataUsage(Header.PageType, pageLevel, trimmedNibbles, slotted);
+            foreach (var bucket in Data.Buckets)
+            {
+                if (!bucket.IsNull)
+                {
+                    var consumedNibbles = trimmedNibbles + ConsumedNibbles;
+                    var lvl = pageLevel + 1;
+
+                    var child = resolver.GetAt(bucket);
+
+                    if (child.Header.PageType == PageType.Leaf)
+                        new LeafPage(child).Report(reporter, resolver, lvl, consumedNibbles);
+                    else
+                        new DataPage(child).Report(reporter, resolver, lvl, consumedNibbles);
+                }
+            }
+
+            var slotted = new SlottedArray(Data.DataSpan);
+            reporter.ReportDataUsage(Header.PageType, pageLevel, trimmedNibbles, slotted);
         }
 
         public void Accept(IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
         {
-            // using (visitor.On(this, addr))
-            // {
-            //     foreach (var bucket in Data.Buckets)
-            //     {
-            //         if (bucket.IsNull)
-            //         {
-            //             continue;
-            //         }
-            //
-            //         var child = resolver.GetAt(bucket);
-            //         if (child.Header.PageType == PageType.Leaf)
-            //             new LeafPage(child).Accept(visitor, resolver, bucket);
-            //         else
-            //             new DataPage(child).Accept(visitor, resolver, bucket);
-            //     }
-            // }
+            using (visitor.On(this, addr))
+            {
+                foreach (var bucket in Data.Buckets)
+                {
+                    if (bucket.IsNull)
+                    {
+                        continue;
+                    }
+
+                    var child = resolver.GetAt(bucket);
+                    if (child.Header.PageType == PageType.Leaf)
+                        new LeafPage(child).Accept(visitor, resolver, bucket);
+                    else
+                        new DataPage(child).Accept(visitor, resolver, bucket);
+                }
+            }
         }
     }
 }

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -95,10 +95,10 @@ public readonly unsafe struct RootPage(Page root) : IPage
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver)
     {
-        if (Data.StateRoot.IsNull == false)
+        var stateRoot = Data.StateRoot;
+        if (stateRoot.IsNull == false)
         {
-            var data = new Merkle.StateRootPage(resolver.GetAt(Data.StateRoot));
-            using var scope = visitor.On(data, Data.StateRoot);
+            new Merkle.StateRootPage(resolver.GetAt(stateRoot)).Accept(visitor, resolver, stateRoot);
         }
 
         Data.Storage.Accept(visitor, resolver);


### PR DESCRIPTION
This PR revives the state `Paprika.Cli` and introduces a command of ` stats <path> <size> <historyDepth>` that can be executed as 

```bash
Paprika\src\Paprika.Cli dotnet run -c Release -- stats C:\Users\Szymon\ethereum\execution\nethermind_db 64 64
```

to gather stats of the Paprika tree. The output is the following:

![image](https://github.com/NethermindEth/Paprika/assets/519707/54a6d77f-a8cb-4302-9fe5-17cf873a8b56)
