### PR TITLE
squeeze more

### DIFF
--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -518,9 +518,8 @@ public readonly ref struct NibblePath
         return source.Slice(GetSpanLength(odd, length));
     }
 
-    public static Span<byte> ReadFromWithLength(Span<byte> source, int length, bool isOdd, out NibblePath nibblePath)
+    public static Span<byte> ReadFromWithLength(Span<byte> source, int length, byte odd, out NibblePath nibblePath)
     {
-        var odd = isOdd ? OddBit : 0;
         nibblePath = new NibblePath(source, odd, length);
         return source.Slice(GetSpanLength(odd, length));
     }
@@ -548,12 +547,11 @@ public readonly ref struct NibblePath
         return actualKey.Equals(expected);
     }
 
-    public static bool TryReadFromWithLength(Span<byte> source, in NibblePath expected, int length, bool isOdd, out Span<byte> leftover)
+    public static bool TryReadFromWithLength(Span<byte> source, in NibblePath expected, int length, byte isOdd, out Span<byte> leftover)
     {
         leftover = ReadFromWithLength(source, length, isOdd, out var actualKey);
         return actualKey.Equals(expected);
     }
-
 
     public int FindFirstDifferentNibble(in NibblePath other)
     {


### PR DESCRIPTION
A few amendments to #341 to make it a bit faster under `Hash_collisions`

### Benchmarks

#### Main

| Method          | Mean     | Error    | StdDev   | Code Size |
|---------------- |---------:|---------:|---------:|----------:|
| Hash_collisions | 13.94 us | 0.105 us | 0.093 us |   3,462 B |

#### SlottedArray

| Method          | Mean     | Error    | StdDev   | Code Size |
|---------------- |---------:|---------:|---------:|----------:|
| Hash_collisions | 14.54 us | 0.147 us | 0.123 us |   3,630 B |

#### This PR

| Method          | Mean     | Error    | StdDev   | Code Size |
|---------------- |---------:|---------:|---------:|----------:|
| Hash_collisions | 13.99 us | 0.111 us | 0.098 us |   3,389 B |