### PR TITLE
Prefetching for Report in pages

### DIFF
--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -303,6 +303,11 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
 
     public void Report(IReporter reporter, IPageResolver resolver, int pageLevel, int trimmedNibbles)
     {
+        resolver.Prefetch(Data.Buckets);
+
+        var slotted = new SlottedArray(Data.DataSpan);
+        reporter.ReportDataUsage(Header.PageType, pageLevel, trimmedNibbles, slotted);
+
         foreach (var bucket in Data.Buckets)
         {
             if (!bucket.IsNull)
@@ -315,8 +320,7 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>
             }
         }
 
-        var slotted = new SlottedArray(Data.DataSpan);
-        reporter.ReportDataUsage(Header.PageType, pageLevel, trimmedNibbles, slotted);
+
     }
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver, DbAddress addr)

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -145,5 +145,17 @@ public interface IPageResolver
     /// Gets the page at given address.
     /// </summary>
     Page GetAt(DbAddress address);
+
     void Prefetch(DbAddress address);
+
+    void Prefetch(ReadOnlySpan<DbAddress> addresses)
+    {
+        foreach (var bucket in addresses)
+        {
+            if (!bucket.IsNull)
+            {
+                Prefetch(bucket);
+            }
+        }
+    }
 }

--- a/src/Paprika/Store/LeafPage.cs
+++ b/src/Paprika/Store/LeafPage.cs
@@ -294,6 +294,8 @@ public readonly unsafe struct LeafPage(Page page) : IPageWithData<LeafPage>
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
     {
+        resolver.Prefetch(Data.Buckets);
+
         using var scope = visitor.On(this, addr);
 
         foreach (var bucket in Data.Buckets)

--- a/src/Paprika/Store/StorageFanOutPage.cs
+++ b/src/Paprika/Store/StorageFanOutPage.cs
@@ -108,6 +108,8 @@ public readonly unsafe struct StorageFanOutPage<TNext>(Page page) : IPageWithDat
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
     {
+        resolver.Prefetch(Data.Addresses);
+
         using var scope = visitor.On(this, addr);
 
         foreach (var bucket in Data.Addresses)


### PR DESCRIPTION
This PR introduces `.Prefetch` for `.Report` functions used by `Paprika.Cli`. This should help in saturating IO fully and running `stats` much faster.