### PR TITLE
AbandonedList size fix

### DIFF
--- a/src/Paprika.Tests/Store/MemoryFencingTests.cs
+++ b/src/Paprika.Tests/Store/MemoryFencingTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using Paprika.Store;
+
+namespace Paprika.Tests.Store;
+
+/// <summary>
+/// Tests ensuring that unmanaged structs do no leak out beyond their sizes.
+/// </summary>
+public class MemoryFencingTests
+{
+    [Test]
+    public void Int_for_sanity()
+    {
+        Alloc<int>(sizeof(int)).Should().Be(0);
+    }
+
+    [Test]
+    public void AbandonedPage()
+    {
+        ref var list = ref Alloc<AbandonedList>(AbandonedList.Size);
+        list.IsFullyEmpty.Should().BeTrue();
+    }
+
+    [TearDown]
+    public unsafe void TearDown()
+    {
+        while (_alignedAllocations.TryPop(out var alloc))
+        {
+            NativeMemory.AlignedFree(alloc.ToPointer());
+        }
+    }
+
+    private readonly Stack<UIntPtr> _alignedAllocations = new();
+
+    private unsafe ref T Alloc<T>(int size, int alignment = sizeof(int))
+        where T : struct
+    {
+        const int fenceSize = 32;
+
+        var sizeTotal = (UIntPtr)size + fenceSize * 2;
+        var memory = NativeMemory.AlignedAlloc(sizeTotal, (UIntPtr)alignment);
+        NativeMemory.Clear(memory, sizeTotal);
+
+        _alignedAllocations.Push((UIntPtr)memory);
+
+        var actualStart = new UIntPtr(memory) + fenceSize;
+
+        Fence(memory);
+        Fence((actualStart + (uint)size).ToPointer());
+
+        return ref Unsafe.AsRef<T>(actualStart.ToPointer());
+
+        static void Fence(void* ptr)
+        {
+            var span = new Span<byte>(ptr, fenceSize);
+            const byte fenceFilling = 0xFF;
+            span.Fill(fenceFilling);
+        }
+    }
+}

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -11,15 +11,17 @@ namespace Paprika.Store;
 [StructLayout(LayoutKind.Explicit, Size = Size)]
 public struct AbandonedList
 {
+    /// <summary>
+    /// The start for spans of <see cref="BatchIds"/> and <see cref="Addresses"/>.
+    /// </summary>
     private const int EntriesStart = DbAddress.Size + sizeof(uint);
 
-    private const int Size = Page.PageSize - PageHeader.Size - RootPage.Payload.AbandonedStart - EntriesStart;
+    public const int Size = Page.PageSize - PageHeader.Size - RootPage.Payload.AbandonedStart - EntriesStart;
     private const int EntrySize = sizeof(uint) + DbAddress.Size;
-    private const int MaxCount = Size / EntrySize;
+    private const int MaxCount = (Size - EntriesStart) / EntrySize;
 
     [FieldOffset(0)] private DbAddress Current;
-
-    [FieldOffset(4)] private uint EntriesCount;
+    [FieldOffset(DbAddress.Size)] private uint EntriesCount;
 
     [FieldOffset(EntriesStart)] private uint BatchIdStart;
 
@@ -27,8 +29,6 @@ public struct AbandonedList
 
     [FieldOffset(MaxCount * sizeof(uint) + EntriesStart)]
     private DbAddress AddressStart;
-
-    private const int NotFound = -1;
 
     private Span<DbAddress> Addresses => MemoryMarshal.CreateSpan(ref AddressStart, MaxCount);
 
@@ -228,5 +228,18 @@ public struct AbandonedList
         }
 
         return count;
+    }
+
+    public bool IsFullyEmpty
+    {
+        get
+        {
+            const int notFound = -1;
+
+            return Addresses.IndexOfAnyExcept(DbAddress.Null) == notFound &&
+                   BatchIds.IndexOfAnyExcept(default(uint)) == notFound &&
+                   EntriesCount == 0 &&
+                   Current == DbAddress.Null;
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a sizing bug that was hidden in the AbandonedList and surfaced only when a lot of pages was registered in it. It was noticed in #346 but treated as some garbage left in the list that was not cleared. It resurfaced again when working on Snap. This PR adds a memory fencing test and asserts that `AbandonedList` does not reach beyond its size. The same same approach can be done for other structures.