### PR TITLE
Add more detailed comment for clearing the last nibble for odd-len NibblePath

### DIFF
--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -255,8 +255,9 @@ public readonly ref struct NibblePath
             MemoryMarshal.CreateSpan(ref _span, spanLength).CopyTo(destination.Slice(PreambleLength));
         }
 
-        // clearing the oldest nibble, if needed
-        // yes, it can be branch free
+        // If the path length is odd, clear the lower nibble of the last byte.
+        // This ensures that truncated nibble paths (like 0xAB.SliceTo(1)) are stored unambiguously.
+        // For instance, 0xAB.SliceTo(1) should result in 0xA0, so it can be distinguished from other paths.
         if (((odd + length) & 1) != 0)
         {
             ref var oldest = ref destination[spanLength];


### PR DESCRIPTION
```
if (((odd + length) & 1) != 0)
    {
        ref var oldest = ref destination[spanLength];
        oldest = (byte)(oldest & 0b1111_0000);
    }

return spanLength + PreambleLength;
```

This portion of `WriteImpl` was doing an operation which was difficult to understand at first glance and needed a more detailed comment to explain.


Reference :-

If the sum of odd and length is odd, the function clears the lower nibble of the last byte in the written path.

`ref var oldest = ref destination[spanLength];` 
gets a reference to the byte at position spanLength in the destination buffer.

`oldest = (byte)(oldest & 0b1111_0000);` 
clears the lower nibble of this byte by performing a bitwise AND with 0b1111_0000 (which is 0xF0).
