### PR TITLE
Merkle nodes with even-length paths made shorter

### DIFF
--- a/src/Paprika.Tests/Merkle/NodeTests.cs
+++ b/src/Paprika.Tests/Merkle/NodeTests.cs
@@ -176,9 +176,13 @@ public class NodeTests
         decoded.Equals(leaf).Should().BeTrue($"Expected {leaf.ToString()}, got {decoded.ToString()}");
     }
 
-    [TestCase(new byte[] { 253, 137 }, 0, 2, 2)]
-    [TestCase(new byte[] { 253, 137 }, 1, 1, 1)]
-    [TestCase(new byte[] { 253, 137 }, 1, 3, 2)]
+    [TestCase(new byte[] { 129, 137 }, 0, 2, 2)]
+    [TestCase(new byte[] { 129, 137 }, 1, 1, 1)]
+    [TestCase(new byte[] { 129, 137 }, 1, 3, 2)]
+    [TestCase(new byte[] { 0b1100_0000, 137 }, 0, 4, 2)]
+    [TestCase(new byte[] { 0b1100_0001, 137 }, 0, 4, 2, TestName = "Even path - special 1st nibble (1)")]
+    [TestCase(new byte[] { 0b1100_1001, 137 }, 0, 4, 2, TestName = "Even path - special 1st nibble (2)")]
+    [TestCase(new byte[] { 0b1101_0001, 137 }, 0, 4, 2, TestName = "Even path - special 1st nibble (3)")]
     public void Leaf_paths(byte[] raw, int odd, int length, int expectedLength)
     {
         var path = NibblePath.FromKey(raw).SliceFrom(odd).SliceTo(length);


### PR DESCRIPTION
This PR amends the way `Leaf`s of Merkle trie with even paths are stored, so that if the path starts with a nibble in form of `0b11__` it will be one byte shorter to store. As `0b11` is a one of four prefixes, with a uniform distribution 1/4 of even paths should require one byte less to store.

The optimization uses the fact that `Type.Leaf` is encoded in first byte as `0b1000_0000`. This plus the fact that other higher bits are not used by other cases, allows to use `0b11` as a discriminator of a leaf that has some property. In that case it's the property that the path starts with `0b11` which allows us to not store any additional data beside the leaf's `NibblePath`. The leaf type is encoded in the path itself.

### Benchmark

`Paprika.Cli` stats for `Sepolia` db.

#### Before 

![image](https://github.com/NethermindEth/Paprika/assets/519707/931cb900-8f54-41e1-9127-799af43d185a)


#### After
