### PR TITLE
Branches with 3 or less children smaller

### DIFF
--- a/src/Paprika.Runner/StatisticsForPagedDb.cs
+++ b/src/Paprika.Runner/StatisticsForPagedDb.cs
@@ -69,7 +69,7 @@ public static class StatisticsForPagedDb
             "---\n" +
             $" Branches with small empty set: {reporter.MerkleBranchWithSmallEmpty}\n" +
             $" Branches with 15 children: {reporter.MerkleBranchWithOneChildMissing}\n" +
-            $" Branches with 2 children: {reporter.MerkleBranchWithTwoChildrenOnly}\n";
+            $" Branches with 3 or less children: {reporter.MerkleBranchWithThreeChildrenOrLess}\n";
 
         up.Update(new Panel(general).Header($"General stats for {name}").Expand());
 

--- a/src/Paprika.Tests/Merkle/DirtyTests.cs
+++ b/src/Paprika.Tests/Merkle/DirtyTests.cs
@@ -354,7 +354,7 @@ public static class CommitExtensions
     public static void SetLeaf(this ICommit commit, in Key key, string leafPath)
     {
         var leaf = new Node.Leaf(NibblePath.Parse(leafPath));
-        commit.Set(key, leaf.WriteTo(stackalloc byte[leaf.MaxByteLength]));
+        commit.Set(key, leaf.WriteTo(stackalloc byte[Node.Leaf.MaxByteLength]));
     }
 
     public static void Set(this Commit commit, string path) => commit.Set(NibblePath.Parse(path));

--- a/src/Paprika.Tests/Merkle/NibbleSetTests.cs
+++ b/src/Paprika.Tests/Merkle/NibbleSetTests.cs
@@ -1,0 +1,48 @@
+﻿using FluentAssertions;
+using Paprika.Merkle;
+
+namespace Paprika.Tests.Merkle;
+
+public class NibbleSetTests
+{
+    private const int Max = 16;
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(15)]
+    public void Single_nibble_set(byte nibble)
+    {
+        var set = new NibbleSet(nibble);
+        NibbleSet.Readonly @readonly = set;
+
+        for (byte i = 0; i < Max; i++)
+        {
+            var expected = i == nibble;
+
+            set[i].Should().Be(expected);
+            @readonly[i].Should().Be(expected);
+        }
+
+        set.SmallestNibbleSet.Should().Be(nibble);
+        @readonly.SmallestNibbleSet.Should().Be(nibble);
+    }
+
+    [TestCase(0, 1)]
+    [TestCase(2, 15)]
+    public void Double(byte nibble0, byte nibble1)
+    {
+        var set = new NibbleSet(nibble0, nibble1);
+        NibbleSet.Readonly @readonly = set;
+
+        for (byte i = 0; i < Max; i++)
+        {
+            var expected = i == nibble0 || i == nibble1;
+
+            set[i].Should().Be(expected);
+            @readonly[i].Should().Be(expected);
+
+            set.SmallestNibbleSet.Should().Be(nibble0);
+            @readonly.SmallestNibbleSet.Should().Be(nibble0);
+        }
+    }
+}

--- a/src/Paprika.Tests/Merkle/NibbleSetTests.cs
+++ b/src/Paprika.Tests/Merkle/NibbleSetTests.cs
@@ -6,11 +6,10 @@ namespace Paprika.Tests.Merkle;
 public class NibbleSetTests
 {
     private const int Max = 16;
+    private static readonly IEnumerable<byte> Indexes = Enumerable.Range(0, Max).Select(i => (byte)i);
 
-    [TestCase(0)]
-    [TestCase(1)]
-    [TestCase(15)]
-    public void Single_nibble_set(byte nibble)
+    [TestCaseSource(nameof(GetOneNibble))]
+    public void One_nibble(byte nibble)
     {
         var set = new NibbleSet(nibble);
         NibbleSet.Readonly @readonly = set;
@@ -24,13 +23,18 @@ public class NibbleSetTests
         }
 
         set.SmallestNibbleSet.Should().Be(nibble);
+        set.BiggestNibbleSet.Should().Be(nibble);
+
         @readonly.SmallestNibbleSet.Should().Be(nibble);
+        @readonly.BiggestNibbleSet.Should().Be(nibble);
     }
 
-    [TestCase(0, 1)]
-    [TestCase(2, 15)]
-    public void Double(byte nibble0, byte nibble1)
+    [TestCaseSource(nameof(GetTwoNibbles))]
+    public void Two_nibbles(byte nibble0, byte nibble1)
     {
+        var min = Math.Min(nibble0, nibble1);
+        var max = Math.Max(nibble0, nibble1);
+
         var set = new NibbleSet(nibble0, nibble1);
         NibbleSet.Readonly @readonly = set;
 
@@ -40,9 +44,59 @@ public class NibbleSetTests
 
             set[i].Should().Be(expected);
             @readonly[i].Should().Be(expected);
-
-            set.SmallestNibbleSet.Should().Be(nibble0);
-            @readonly.SmallestNibbleSet.Should().Be(nibble0);
         }
+
+        set.SmallestNibbleSet.Should().Be(min);
+        set.BiggestNibbleSet.Should().Be(max);
+        @readonly.SmallestNibbleSet.Should().Be(min);
+        @readonly.BiggestNibbleSet.Should().Be(max);
     }
+
+    [TestCaseSource(nameof(GetTwoNibbles))]
+    public void All_but_two(byte nibble0, byte nibble1)
+    {
+        var @readonly = NibbleSet.Readonly.All
+            .Remove(nibble0)
+            .Remove(nibble1);
+
+        for (byte i = 0; i < Max; i++)
+        {
+            var expected = i != nibble0 && i != nibble1;
+            @readonly[i].Should().Be(expected);
+        }
+
+        var min = Indexes.First(i => @readonly[i]);
+        var max = Indexes.Last(i => @readonly[i]);
+
+        @readonly.SmallestNibbleSet.Should().Be(min);
+        @readonly.BiggestNibbleSet.Should().Be(max);
+    }
+
+    [TestCaseSource(nameof(GetOneNibble))]
+    public void All_but_one(byte nibble)
+    {
+        var @readonly = NibbleSet.Readonly.AllWithout(nibble);
+
+        for (byte i = 0; i < Max; i++)
+        {
+            var expected = i != nibble;
+            @readonly[i].Should().Be(expected);
+        }
+
+        @readonly.SmallestNibbleNotSet.Should().Be(nibble);
+    }
+
+    private static TestCaseData[] GetTwoNibbles() =>
+    [
+        new TestCaseData((byte)0, (byte)1),
+        new TestCaseData((byte)2, (byte)15),
+        new TestCaseData((byte)13, (byte)2)
+    ];
+
+    private static TestCaseData[] GetOneNibble() =>
+    [
+        new TestCaseData((byte)0),
+        new TestCaseData((byte)1),
+        new TestCaseData((byte)15)
+    ];
 }

--- a/src/Paprika.Tests/Merkle/NodeTests.cs
+++ b/src/Paprika.Tests/Merkle/NodeTests.cs
@@ -101,7 +101,7 @@ public class NodeTests
     public void Branch_read_write(ushort nibbleBitSet, Keccak keccak)
     {
         var branch = new Node.Branch(new NibbleSet.Readonly(nibbleBitSet));
-        Span<byte> buffer = stackalloc byte[branch.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Branch.MaxByteLength];
 
         var encoded = branch.WriteTo(buffer);
         var leftover = Node.Branch.ReadFrom(encoded, out var decoded);
@@ -117,7 +117,7 @@ public class NodeTests
     public void Branch_read_write_no_keccak(ushort nibbleBitSet)
     {
         var branch = new Node.Branch(new NibbleSet.Readonly(nibbleBitSet));
-        Span<byte> buffer = stackalloc byte[branch.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Branch.MaxByteLength];
 
         var encoded = branch.WriteTo(buffer);
         var leftover = Node.Branch.ReadFrom(encoded, out var decoded);
@@ -131,10 +131,29 @@ public class NodeTests
     {
         var branch = new Node.Branch(NibbleSet.Readonly.All);
 
-        Span<byte> buffer = stackalloc byte[branch.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Branch.MaxByteLength];
         var encoded = branch.WriteTo(buffer);
 
         encoded.Length.Should().Be(1, "Full branch should encode to one byte");
+
+        var leftover = Node.Branch.ReadFrom(encoded, out var decoded);
+
+        leftover.Length.Should().Be(0);
+
+        decoded.Equals(branch).Should().BeTrue($"Expected {branch.ToString()}, got {decoded.ToString()}");
+    }
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(15)]
+    public void Branch_all_set_but_one(byte without)
+    {
+        var branch = new Node.Branch(NibbleSet.Readonly.AllWithout(without));
+
+        Span<byte> buffer = stackalloc byte[Node.Branch.MaxByteLength];
+        var encoded = branch.WriteTo(buffer);
+
+        encoded.Length.Should().Be(1, "A branch without one child should encode to one byte");
 
         var leftover = Node.Branch.ReadFrom(encoded, out var decoded);
 
@@ -167,7 +186,7 @@ public class NodeTests
     public void Leaf_read_write(byte[] pathBytes, Keccak keccak)
     {
         var leaf = new Node.Leaf(NibblePath.FromKey(pathBytes));
-        Span<byte> buffer = stackalloc byte[leaf.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Leaf.MaxByteLength];
 
         var encoded = leaf.WriteTo(buffer);
         var leftover = Node.Leaf.ReadFrom(encoded, out var decoded);
@@ -183,7 +202,7 @@ public class NodeTests
     {
         var path = NibblePath.FromKey(raw).SliceFrom(odd).SliceTo(length);
         var leaf = new Node.Leaf(path);
-        Span<byte> buffer = stackalloc byte[leaf.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Leaf.MaxByteLength];
 
         var encoded = leaf.WriteTo(buffer);
         encoded.Length.Should().Be(expectedLength);
@@ -218,7 +237,7 @@ public class NodeTests
     public void Extension_read_write(byte[] pathBytes)
     {
         var extension = new Node.Extension(NibblePath.FromKey(pathBytes));
-        Span<byte> buffer = stackalloc byte[extension.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Extension.MaxByteLength];
 
         var encoded = extension.WriteTo(buffer);
         var leftover = Node.Extension.ReadFrom(encoded, out var decoded);
@@ -233,7 +252,7 @@ public class NodeTests
         var nibblePath = NibblePath.FromKey(new byte[] { 0x1, 0x2 });
 
         var leaf = new Node.Leaf(nibblePath);
-        Span<byte> buffer = stackalloc byte[leaf.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Leaf.MaxByteLength];
 
         var encoded = leaf.WriteTo(buffer);
         var leftover = Node.ReadFrom(out var nodeType, out var actual, out _, out _, encoded);
@@ -249,7 +268,7 @@ public class NodeTests
         var nibblePath = NibblePath.FromKey(new byte[] { 0x1, 0x2 });
 
         var extension = new Node.Extension(nibblePath);
-        Span<byte> buffer = stackalloc byte[extension.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Extension.MaxByteLength];
 
         var encoded = extension.WriteTo(buffer);
         var leftover = Node.ReadFrom(out var nodeType, out _, out var actual, out _, encoded);
@@ -265,7 +284,7 @@ public class NodeTests
         const ushort nibbleBitSet = 0b1100_0011_0101_1010;
 
         var branch = new Node.Branch(new NibbleSet.Readonly(nibbleBitSet));
-        Span<byte> buffer = stackalloc byte[branch.MaxByteLength];
+        Span<byte> buffer = stackalloc byte[Node.Branch.MaxByteLength];
 
         var encoded = branch.WriteTo(buffer);
         var leftover = Node.ReadFrom(out var nodeType, out _, out _, out var actual, encoded);

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -26,7 +26,7 @@ public static class CommitExtensions
         }
 
         var leaf = new Node.Leaf(leafPath);
-        commit.Set(key, leaf.WriteTo(stackalloc byte[leaf.MaxByteLength]), type);
+        commit.Set(key, leaf.WriteTo(stackalloc byte[Leaf.MaxByteLength]), type);
     }
 
     [SkipLocalsInit]
@@ -34,7 +34,7 @@ public static class CommitExtensions
         EntryType type = EntryType.Persistent)
     {
         var branch = new Node.Branch(children);
-        commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]), RlpMemo.Empty, type);
+        commit.Set(key, branch.WriteTo(stackalloc byte[Branch.MaxByteLength]), RlpMemo.Empty, type);
     }
 
     [SkipLocalsInit]
@@ -42,14 +42,14 @@ public static class CommitExtensions
         EntryType type = EntryType.Persistent)
     {
         var branch = new Node.Branch(children);
-        commit.Set(key, branch.WriteTo(stackalloc byte[branch.MaxByteLength]), rlp, type);
+        commit.Set(key, branch.WriteTo(stackalloc byte[Branch.MaxByteLength]), rlp, type);
     }
 
     [SkipLocalsInit]
     public static void SetExtension(this ICommit commit, in Key key, in NibblePath path, EntryType type = EntryType.Persistent)
     {
         var extension = new Extension(path);
-        commit.Set(key, extension.WriteTo(stackalloc byte[extension.MaxByteLength]), type);
+        commit.Set(key, extension.WriteTo(stackalloc byte[Extension.MaxByteLength]), type);
     }
 
     public static void DeleteKey(this ICommit commit, in Key key) => commit.Set(key, ReadOnlySpan<byte>.Empty);

--- a/src/Paprika/Merkle/NibbleSet.cs
+++ b/src/Paprika/Merkle/NibbleSet.cs
@@ -57,6 +57,8 @@ public struct NibbleSet
 
     public byte SmallestNibbleSet => (byte)BitOperations.TrailingZeroCount(_value);
 
+    public byte BiggestNibbleSet => (byte)(31 - BitOperations.LeadingZeroCount((uint)_value));
+
     public byte SmallestNibbleNotSet => (byte)BitOperations.TrailingZeroCount(~_value);
 
     public static implicit operator ushort(NibbleSet set) => set._value;
@@ -106,6 +108,8 @@ public struct NibbleSet
 
         public byte SmallestNibbleSet => new NibbleSet(_value).SmallestNibbleSet;
         public byte SmallestNibbleNotSet => new NibbleSet(_value).SmallestNibbleNotSet;
+
+        public byte BiggestNibbleSet => new NibbleSet(_value).BiggestNibbleSet;
 
         public static implicit operator ushort(Readonly set) => set._value;
 

--- a/src/Paprika/Merkle/NibbleSet.cs
+++ b/src/Paprika/Merkle/NibbleSet.cs
@@ -54,7 +54,10 @@ public struct NibbleSet
     }
 
     public int SetCount => BitOperations.PopCount(_value);
+
     public byte SmallestNibbleSet => (byte)BitOperations.TrailingZeroCount(_value);
+
+    public byte SmallestNibbleNotSet => (byte)BitOperations.TrailingZeroCount(~_value);
 
     public static implicit operator ushort(NibbleSet set) => set._value;
     public static implicit operator Readonly(NibbleSet set) => new(set._value);
@@ -95,10 +98,14 @@ public struct NibbleSet
 
         public static Readonly All => new(AllSetValue);
 
+        public static Readonly AllWithout(byte nibble) => new((ushort)(AllSetValue & ~(1 << nibble)));
+
         public bool AllSet => _value == AllSetValue;
 
         public int SetCount => new NibbleSet(_value).SetCount;
+
         public byte SmallestNibbleSet => new NibbleSet(_value).SmallestNibbleSet;
+        public byte SmallestNibbleNotSet => new NibbleSet(_value).SmallestNibbleNotSet;
 
         public static implicit operator ushort(Readonly set) => set._value;
 

--- a/src/Paprika/Merkle/Node.cs
+++ b/src/Paprika/Merkle/Node.cs
@@ -186,10 +186,10 @@ public static partial class Node
     /// </remarks>
     public readonly ref partial struct Leaf
     {
-        public int MaxByteLength => Header.Size + Path.RawSpan.Length - Path.Oddity;
+        public const int MaxByteLength = Header.Size + NibblePath.KeccakNibbleCount;
 
         private const byte OddPathMetadata = 0b0001_0000;
-        public const int MinimalLeafPathLength = 1;
+        private const int MinimalLeafPathLength = 1;
 
         public readonly Header Header;
         public readonly NibblePath Path;
@@ -269,7 +269,7 @@ public static partial class Node
 
     public readonly ref struct Extension
     {
-        public int MaxByteLength => Header.Size + Path.MaxByteLength;
+        public const int MaxByteLength = Header.Size + NibblePath.KeccakNibbleCount;
 
         public readonly Header Header;
         public readonly NibblePath Path;
@@ -323,12 +323,13 @@ public static partial class Node
 
     public readonly ref struct Branch
     {
-        public int MaxByteLength => Header.Size +
-                                    (HeaderHasAllSet(Header) ? 0 : NibbleSet.MaxByteSize);
+        public const int MaxByteLength = Header.Size + NibbleSet.MaxByteSize;
 
+        private const byte HeaderMetadataAllChildrenSetMask = 0b0010_0000;
+        private const byte HeaderMetadataWithoutOneChildSetMask = 0b0001_0000;
+        private const byte OneChildMask = 0b0000_1111;
 
-        // private const byte HeaderMetadataKeccakMask = 0b0000_0001;
-        private const byte HeaderMetadataAllChildrenSetMask = 0b0000_0010;
+        private const byte HeaderMetadataCustomFormat = HeaderMetadataAllChildrenSetMask | HeaderMetadataWithoutOneChildSetMask;
 
         public readonly Header Header;
         public readonly NibbleSet.Readonly Children;
@@ -356,15 +357,21 @@ public static partial class Node
 
         public Branch(NibbleSet.Readonly children)
         {
-            Header = new Header(Type.Branch, metadata: (byte)(children.AllSet ? HeaderMetadataAllChildrenSetMask : 0));
+            byte metadata = children.SetCount switch
+            {
+                NibbleSet.NibbleCount => HeaderMetadataAllChildrenSetMask,
+                NibbleSet.NibbleCount - 1 => (byte)(HeaderMetadataWithoutOneChildSetMask | children.SmallestNibbleNotSet),
+                _ => 0
+            };
+
+            Header = new Header(Type.Branch, metadata: metadata);
 
             Assert(children);
 
             Children = children;
         }
 
-        private static bool HeaderHasAllSet(Header header) =>
-            (header.Metadata & HeaderMetadataAllChildrenSetMask) == HeaderMetadataAllChildrenSetMask;
+        private static bool HeaderHasCustomFormat(Header header) => (header.Metadata & HeaderMetadataCustomFormat) != 0;
 
         public Span<byte> WriteTo(Span<byte> output)
         {
@@ -376,7 +383,7 @@ public static partial class Node
         {
             var leftover = Header.WriteToWithLeftover(output);
 
-            if (!Children.AllSet)
+            if (!HeaderHasCustomFormat(Header))
             {
                 // write children only if not all set. All set is encoded in the header
                 leftover = Children.WriteToWithLeftover(leftover);
@@ -390,9 +397,11 @@ public static partial class Node
             var leftover = Header.ReadFrom(source, out var header);
 
             NibbleSet.Readonly children;
-            if (HeaderHasAllSet(header))
+            if (HeaderHasCustomFormat(header))
             {
-                children = NibbleSet.Readonly.All;
+                children = header.Metadata == HeaderMetadataAllChildrenSetMask
+                    ? NibbleSet.Readonly.All
+                    : NibbleSet.Readonly.AllWithout((byte)(header.Metadata & OneChildMask));
             }
             else
             {
@@ -415,7 +424,7 @@ public static partial class Node
 
         private static int GetBranchDataLength(Header header) =>
             Header.Size +
-            (HeaderHasAllSet(header) ? 0 : NibbleSet.MaxByteSize);
+            (HeaderHasCustomFormat(header) ? 0 : NibbleSet.MaxByteSize);
 
         public bool Equals(in Branch other)
         {

--- a/src/Paprika/Merkle/RlpMemo.cs
+++ b/src/Paprika/Merkle/RlpMemo.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Paprika.Crypto;
 using Paprika.Data;
 using Paprika.RLP;
@@ -116,6 +117,7 @@ public readonly ref struct RlpMemo
         return memo;
     }
 
+    [SkipLocalsInit]
     public static int Compress(in Key key, scoped in ReadOnlySpan<byte> memoizedRlp, NibbleSet.Readonly children, scoped in Span<byte> writeTo)
     {
         // Optimization, omitting some of the branches to memoize.

--- a/src/Paprika/Store/IReporter.cs
+++ b/src/Paprika/Store/IReporter.cs
@@ -58,7 +58,7 @@ public class StatisticsReporter(TrieType trieType) : IReporter
     public long MerkleBranchSize;
     public long MerkleBranchWithSmallEmpty;
     public long MerkleBranchWithOneChildMissing;
-    public long MerkleBranchWithTwoChildrenOnly;
+    public long MerkleBranchWithThreeChildrenOrLess;
     public long MerkleExtensionSize;
     public long MerkleLeafSize;
 
@@ -115,9 +115,9 @@ public class StatisticsReporter(TrieType trieType) : IReporter
                             {
                                 MerkleBranchWithOneChildMissing++;
                             }
-                            else if (branch.Children.SetCount == 2)
+                            else if (branch.Children.SetCount <= 3)
                             {
-                                MerkleBranchWithTwoChildrenOnly++;
+                                MerkleBranchWithThreeChildrenOrLess++;
                             }
 
                             var len = leftover.Length % Keccak.Size;


### PR DESCRIPTION
This PR reduces the size of `Node.Branch` where it has either 15, 3 or 2 children. Size reduction:

- 15 children it's reduced by 2 bytes 
- 2 or 3 children it's reduced by 1 byte

Additionally, `stackalloc` is made of constant size for `Node` serialization.

Effectively, the disk size drops between 0.5% and 1%. The overall import time dropped as well.

### Benchmarks

#### Paprika.Cli stats

![image](https://github.com/NethermindEth/Paprika/assets/519707/ecca9754-012c-4ec2-a5b9-9ef79c179a20)
