### PR TITLE
Abandoned leakage with test

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -38,6 +38,30 @@ public class AbandonedTests : BasePageTests
         }
     }
 
+    [Test]
+    public void Properly_recognizes_sequences_of_addresses()
+    {
+        var list = new AbandonedList();
+
+        const uint batchId = 10;
+
+        var batch = new TestBatchContext(batchId);
+        batch.GetNewPage(out var a, false);
+        batch.GetNewPage(out var b, false);
+
+        list.Register([a, b], batch);
+
+        var next = batch.Next();
+
+        list.TryGet(out var oneOfReused, next.BatchId, next).Should().BeTrue();
+
+        var addresses = new HashSet<DbAddress> { a, b };
+        addresses.Remove(oneOfReused).Should().BeTrue($"The {oneOfReused} should be in the set");
+        var last = addresses.Single();
+
+        list.GetCurrentForTest().Should().Be(last);
+    }
+
     private const int HistoryDepth = 2;
 
     [TestCase(23, 1, 10_000, false, TestName = "Accounts - 1")]

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -83,7 +83,7 @@ public class AbandonedTests : BasePageTests
 
     private const int HistoryDepth = 2;
 
-    [TestCase(23, 1, 10_000, false, TestName = "Accounts - 1")]
+    [TestCase(20, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(464, 100, 10_000, false, TestName = "Accounts - 100")]
     [TestCase(24533, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -74,7 +74,8 @@ public class AbandonedTests : BasePageTests
         for (int i = 0; i < 1000; i++)
         {
             using var batch = db.BeginNextBatch();
-            //batch.SetRaw(merkle, value);
+            
+            // should modify 2 pages per commit
             batch.SetRaw(account, value);
             batch.Commit(CommitOptions.FlushDataOnly);
         }

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using FluentAssertions;
 using NUnit.Framework;
 using Paprika.Crypto;
+using Paprika.Data;
 using Paprika.Store;
 
 namespace Paprika.Tests.Store;
@@ -39,7 +40,7 @@ public class AbandonedTests : BasePageTests
     }
 
     [Test]
-    public void Properly_recognizes_sequences_of_addresses()
+    public void Properly_handles_page_addresses_that_are_packed_1()
     {
         var list = new AbandonedList();
 
@@ -60,6 +61,23 @@ public class AbandonedTests : BasePageTests
         var last = addresses.Single();
 
         list.GetCurrentForTest().Should().Be(last);
+    }
+
+    [Test]
+    public void Properly_handles_page_addresses_that_are_packed_2()
+    {
+        using var db = PagedDb.NativeMemoryDb(32 * Page.PageSize, 2);
+
+        var value = new byte[1024];
+        var account = Key.Account(Keccak.OfAnEmptySequenceRlp);
+
+        for (int i = 0; i < 1000; i++)
+        {
+            using var batch = db.BeginNextBatch();
+            //batch.SetRaw(merkle, value);
+            batch.SetRaw(account, value);
+            batch.Commit(CommitOptions.FlushDataOnly);
+        }
     }
 
     private const int HistoryDepth = 2;

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -74,7 +74,7 @@ public class AbandonedTests : BasePageTests
         for (int i = 0; i < 1000; i++)
         {
             using var batch = db.BeginNextBatch();
-            
+
             // should modify 2 pages per commit
             batch.SetRaw(account, value);
             batch.Commit(CommitOptions.FlushDataOnly);

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -102,9 +102,9 @@ public struct AbandonedList
             // First, register it for reuse
             batch.RegisterForFutureReuse(current.AsPage());
 
-            if (current.TryPeek(out var newAt))
+            if (current.TryPeek(out var newAt, out var hasMoreThanPeeked))
             {
-                if (current.Count == 1)
+                if (hasMoreThanPeeked == false)
                 {
                     // Special case as the current has only one page. 
                     // There's no use in COWing the page. Just return the page and clean the current
@@ -242,4 +242,6 @@ public struct AbandonedList
                    Current == DbAddress.Null;
         }
     }
+
+    public DbAddress GetCurrentForTest() => Current;
 }

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -88,7 +88,7 @@ public readonly struct AbandonedPage(Page page) : IPage
         addr = new DbAddress(top);
 
         // The entry is not packed and is the only one
-        hasMoreThanPeeked = Data.Count == 1;
+        hasMoreThanPeeked = Data.Count > 1;
 
         return true;
     }

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -24,8 +24,6 @@ public readonly struct AbandonedPage(Page page) : IPage
 
     public int Count => Data.Count;
 
-
-
     private unsafe ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
     [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -24,6 +24,8 @@ public readonly struct AbandonedPage(Page page) : IPage
 
     public int Count => Data.Count;
 
+
+
     private unsafe ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
     [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
@@ -63,11 +65,12 @@ public readonly struct AbandonedPage(Page page) : IPage
         }
     }
 
-    public bool TryPeek(out DbAddress addr)
+    public bool TryPeek(out DbAddress addr, out bool hasMoreThanPeeked)
     {
         if (Data.Count == 0)
         {
             addr = default;
+            hasMoreThanPeeked = default;
             return false;
         }
 
@@ -77,11 +80,18 @@ public readonly struct AbandonedPage(Page page) : IPage
         {
             // Remove the flag and return
             addr = new DbAddress((top & ~PackedFlag) + PackedDiff);
+
+            // The entry is packed so has more than peeked.
+            hasMoreThanPeeked = true;
             return true;
         }
 
         // Not packed, handle
         addr = new DbAddress(top);
+
+        // The entry is not packed and is the only one
+        hasMoreThanPeeked = Data.Count == 1;
+
         return true;
     }
 


### PR DESCRIPTION
The bug observed when the `AbandonedPage` includes only two values that are packed. Previously, it was considered almost empty (count == 1) without noticing the package flag. This PR fixes it.

Kudos to @damian-orzechowski for repro.