### PR TITLE
IFlushStrategy introduced to enable a catch up behavior

### DIFF
--- a/src/Paprika.Runner.Pareto/Program.cs
+++ b/src/Paprika.Runner.Pareto/Program.cs
@@ -100,8 +100,8 @@ public static class Program
             var cacheBudgetStateAndStorage = new CacheBudget.Options(2_000, 16);
             var cacheBudgetPreCommit = new CacheBudget.Options(2_000, 16);
 
-            await using (var blockchain = new Blockchain(db, preCommit, TimeSpan.FromSeconds(5),
-                             cacheBudgetStateAndStorage, cacheBudgetPreCommit, 1000, reporter.Observe))
+            await using (var blockchain = new Blockchain(db, preCommit, cacheBudgetStateAndStorage,
+                             cacheBudgetPreCommit, 1000, FlushStrategy.AfterNCommits(), reporter.Observe))
             {
                 blockchain.Flushed += (_, e) => gate.Signal(e.blockNumber);
 

--- a/src/Paprika.Runner/Program.cs
+++ b/src/Paprika.Runner/Program.cs
@@ -25,7 +25,6 @@ public record Case(
     int AccountsPerBlock,
     long DbFileSize,
     bool PersistentDb,
-    TimeSpan FlushEvery,
     bool Fsync,
     bool UseBigStorageAccount)
 {
@@ -36,22 +35,22 @@ public record Case(
 public static class Program
 {
     private static readonly Case InMemoryReallySmall =
-        new(100, 1000, 1 * Gb, false, TimeSpan.FromSeconds(5), false, true);
+        new(100, 1000, 1 * Gb, false, false, true);
 
     private static readonly Case InMemorySmall =
-        new(10_000, 1000, 10 * Gb, false, TimeSpan.FromSeconds(5), false, true);
+        new(10_000, 1000, 10 * Gb, false, false, true);
 
     private static readonly Case InMemoryMedium =
-        new(50_000, 1000, 32 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+        new(50_000, 1000, 32 * Gb, false, false, false);
 
     private static readonly Case
-        InMemoryBig = new(100_000, 1000, 56 * Gb, false, TimeSpan.FromSeconds(5), false, false);
+        InMemoryBig = new(100_000, 1000, 56 * Gb, false, false, false);
 
     private static readonly Case DiskSmallNoFlush =
-        new(50_000, 1000, 11 * Gb, true, TimeSpan.FromSeconds(5), false, false);
+        new(50_000, 1000, 11 * Gb, true, false, false);
 
     private static readonly Case DiskSmallFlushFile =
-        new(50_000, 1000, 32 * Gb, true, TimeSpan.FromSeconds(60), true, false);
+        new(50_000, 1000, 32 * Gb, true, true, false);
 
     private const int MaxReorgDepth = 64;
     private const int FinalizeEvery = 64;
@@ -164,7 +163,7 @@ public static class Program
             //IPreCommitBehavior preCommit = null;
 
             await using (var blockchain =
-                         new Blockchain(db, preCommit, config.FlushEvery, default, default, 1000, reporter.Observe))
+                         new Blockchain(db, preCommit, default, default, 1000, FlushStrategy.AfterNCommits(), reporter.Observe))
             {
                 blockchain.Flushed += (_, e) => gate.Signal(e.blockNumber);
 

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -523,7 +523,7 @@ public class BlockchainTests
 
         var cacheBudgetPreCommit = new CacheBudget.Options(1, 1);
 
-        await using var blockchain = new Blockchain(db, new ComputeMerkleBehavior(), null, CacheBudget.Options.None,
+        await using var blockchain = new Blockchain(db, new ComputeMerkleBehavior(), CacheBudget.Options.None,
             cacheBudgetPreCommit, 1, null);
 
         // Initial commit
@@ -551,7 +551,7 @@ public class BlockchainTests
     {
         using var db = PagedDb.NativeMemoryDb(1 * Mb);
 
-        await using var blockchain = new Blockchain(db, new PreCommit(), null, CacheBudget.Options.None,
+        await using var blockchain = new Blockchain(db, new PreCommit(), CacheBudget.Options.None,
             CacheBudget.Options.None, 1);
 
         // Arrange

--- a/src/Paprika.Tests/Chain/FlushStrategyTests.cs
+++ b/src/Paprika.Tests/Chain/FlushStrategyTests.cs
@@ -1,0 +1,67 @@
+﻿using FluentAssertions;
+using Paprika.Chain;
+
+namespace Paprika.Tests.Chain;
+
+public class FlushStrategyTests
+{
+    [Test]
+    public void AfterN()
+    {
+        const int single = 1;
+        const int many = 2;
+        const int n = 10;
+        const int manyCount = 20;
+
+        var strategy = FlushStrategy.AfterNCommits(n);
+
+        for (var i = 0; i < manyCount; i++)
+        {
+            ShouldNotWrite(many);
+        }
+
+        for (var i = 0; i < n; i++)
+        {
+            ShouldNotWrite(single);
+        }
+
+        ShouldFlushData(single);
+        ShouldFlushData(single);
+
+        // a single value "many" resets the counter
+        ShouldNotWrite(many);
+
+        for (var i = 0; i < n; i++)
+        {
+            ShouldNotWrite(single);
+        }
+
+        // should write data again
+        ShouldFlushData(single);
+
+        return;
+
+        void ShouldNotWrite(int count) => strategy.GetCommitOptions(count).Should().Be(CommitOptions.DangerNoWrite);
+        void ShouldFlushData(int count) => strategy.GetCommitOptions(count).Should().Be(CommitOptions.FlushDataOnly);
+    }
+
+    [Test]
+    public void Never([Values(1, 10, 1000)] int inQueue)
+    {
+        RunConst(inQueue, FlushStrategy.Never, CommitOptions.DangerNoWrite);
+    }
+
+    [Test]
+    public void Always([Values(1, 10, 1000)] int inQueue)
+    {
+        RunConst(inQueue, FlushStrategy.Always, CommitOptions.FlushDataOnly);
+    }
+
+    private static void RunConst(int inQueue, IFlushStrategy strategy, CommitOptions expected)
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            strategy.GetCommitOptions(inQueue).Should().Be(expected);
+        }
+    }
+}

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -96,7 +96,7 @@ public class RootHashFuzzyTests
 
         using var db = PagedDb.NativeMemoryDb(1024 * 1024 * 1024, 2);
         using var merkle = new ComputeMerkleBehavior(ComputeMerkleBehavior.ParallelismNone);
-        await using var blockchain = new Blockchain(db, merkle, null, new CacheBudget.Options(2000, 4), new CacheBudget.Options(2000, 4));
+        await using var blockchain = new Blockchain(db, merkle, new CacheBudget.Options(2000, 4), new CacheBudget.Options(2000, 4));
 
         // set
         generator.Run(blockchain, 513, false, true);

--- a/src/Paprika.Tests/Performance.cs
+++ b/src/Paprika.Tests/Performance.cs
@@ -28,7 +28,7 @@ public class Performance
         var cache = new CacheBudget.Options(5000, 16);
         var merkle = new ComputeMerkleBehavior();
 
-        await using var blockchain = new Blockchain(db, merkle, TimeSpan.FromSeconds(10), cache, cache);
+        await using var blockchain = new Blockchain(db, merkle, cache, cache);
 
         // Create 64 blocks, then try to read non-existing accounts
 

--- a/src/Paprika/Chain/IFlushStrategy.cs
+++ b/src/Paprika/Chain/IFlushStrategy.cs
@@ -1,0 +1,41 @@
+﻿namespace Paprika.Chain;
+
+public interface IFlushStrategy
+{
+    CommitOptions GetCommitOptions(int numberOfItemsInFlusherQueue);
+}
+
+public static class FlushStrategy
+{
+    /// <summary>
+    /// Always flushes the data, ensuring ACI but not necessary D from ACID.
+    /// </summary>
+    public static readonly IFlushStrategy Always = new ConstWritingFlushStrategy(CommitOptions.FlushDataOnly);
+
+    public static readonly IFlushStrategy Never = new ConstWritingFlushStrategy(CommitOptions.DangerNoWrite);
+
+    public static IFlushStrategy AfterNCommits(int numberOfTimesASingleBlocksIsFlushed = 64) =>
+        new CountingSingularCommitsFlushStrategy(numberOfTimesASingleBlocksIsFlushed);
+
+    private class CountingSingularCommitsFlushStrategy(int numberOfTimesASingleBlocksIsFlushed) : IFlushStrategy
+    {
+        private const int Single = 1;
+
+        private long _singleCount;
+
+        public CommitOptions GetCommitOptions(int numberOfItemsInFlusherQueue)
+        {
+            _singleCount = numberOfItemsInFlusherQueue == Single ? _singleCount + 1 : 0;
+
+            return _singleCount > numberOfTimesASingleBlocksIsFlushed
+                ? CommitOptions.FlushDataOnly
+                : CommitOptions.DangerNoWrite;
+        }
+    }
+
+    private class ConstWritingFlushStrategy(CommitOptions options) : IFlushStrategy
+    {
+        public CommitOptions GetCommitOptions(int numberOfItemsInFlusherQueue) => options;
+    }
+}
+

--- a/src/Paprika/IDb.cs
+++ b/src/Paprika/IDb.cs
@@ -17,11 +17,6 @@ public interface IDb
     IReadOnlyBatch BeginReadOnlyBatch(string name = "");
 
     /// <summary>
-    /// Force flush
-    /// </summary>
-    void Flush();
-
-    /// <summary>
     /// Begins the readonly batch with the given Keccak or the latest.
     /// </summary>
     IReadOnlyBatch BeginReadOnlyBatchOrLatest(in Keccak stateHash, string name = "");
@@ -42,5 +37,13 @@ public interface IDb
     /// </summary>
     int HistoryDepth { get; }
 
+    /// <summary>
+    /// Flushes the file buffers (FSYNS/FlushFileBuffers).
+    /// </summary>
+    void Flush();
+
+    /// <summary>
+    /// Forcefully flush after operating without file writes. Will issue MSYNC/FlushViewOfFile followed by FSYNS/FlushFileBuffers.
+    /// </summary>
     void ForceFlush();
 }


### PR DESCRIPTION
This PR separates the decision of whether to flush or not to a separate component `IFlushStrategy`. It also removes the min timespan to flush as now it should spin fast, depending on the strategy, and only then, when the channel is empty, flush it (depending on the level)