### PR TITLE
Different prefetcher

### DIFF
--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -55,7 +55,7 @@ public class PrefetchingTests
             db.AllowAllReads();
 
             // prefetch first
-            var p = block.OpenPrefetcher();
+            var p = block.OpenPrefetcher<IdentityPrefetchMapping, Keccak, Keccak>();
             p!.CanPrefetchFurther.Should().BeTrue();
             p.PrefetchAccount(keccak);
 
@@ -78,6 +78,7 @@ public class PrefetchingTests
         start.SetAccount(k, new Account(13, bigNonce));
     }
 
+    [Parallelizable(ParallelScope.None)]
     [Explicit]
     [TestCase(true, false, Category = Categories.LongRunning, TestName = "No storage, prefetch")]
     [TestCase(false, false, Category = Categories.LongRunning, TestName = "No storage, no prefetch")]
@@ -119,7 +120,7 @@ public class PrefetchingTests
                 ? Task.FromResult(true)
                 : Task.Factory.StartNew(() =>
                 {
-                    var prefetcher = block.OpenPrefetcher();
+                    var prefetcher = block.OpenPrefetcher<IdentityPrefetchMapping, Keccak, Keccak>();
                     if (prefetcher == null)
                         return true;
 
@@ -177,6 +178,9 @@ public class PrefetchingTests
             block.SetAccount(keccak, new Account(i, i));
             if (storage)
             {
+                block.SetStorage(keccak, Keccak.EmptyTreeHash, value);
+                block.SetStorage(keccak, Keccak.OfAnEmptyString, value);
+                block.SetStorage(keccak, Keccak.OfAnEmptySequenceRlp, value);
                 block.SetStorage(keccak, keccak, value);
             }
         }

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -141,7 +141,7 @@ public class PrefetchingTests
                     return true;
                 });
 
-            await Task.WhenAll(Task.Delay(20), task);
+            await Task.WhenAll(Task.Delay(25), task);
 
             if ((await task) == false)
                 prefetchFailures++;

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -160,12 +160,16 @@ public class PrefetchingTests
             }
         }
 
+        Keccak keccak = default;
         while (finality.TryDequeue(out var k))
         {
             blockchain.Finalize(k);
+            keccak = k;
         }
 
-        Console.WriteLine($"Prefetch failures: {prefetchFailures}. Commit time {commits.Elapsed:g}");
+        Console.WriteLine($"Prefetch failures: {prefetchFailures}. " +
+                          $"Commit time {commits.Elapsed:g}. " +
+                          $"Final Keccak: {keccak}");
     }
 
     private static void SetAccounts(ReadOnlyMemory<Keccak> slice, IWorldState block, uint i, bool storage)

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -140,7 +140,7 @@ public class PrefetchingTests
                     return true;
                 });
 
-            await Task.WhenAll(Task.Delay(50), task);
+            await Task.WhenAll(Task.Delay(20), task);
 
             if ((await task) == false)
                 prefetchFailures++;

--- a/src/Paprika.Tests/Data/BitMapFilterTests.cs
+++ b/src/Paprika.Tests/Data/BitMapFilterTests.cs
@@ -29,6 +29,25 @@ public abstract class BitMapFilterTests<TAccessor> : IDisposable
     }
 
     [Test]
+    public void Atomic_non_colliding_sets()
+    {
+        var filter = Build(_pool);
+
+        var count = filter.BucketCount;
+
+        Parallel.For(0, count, i =>
+        {
+            var hash = (uint)i;
+            filter.MayContainVolatile(hash).Should().BeFalse();
+            filter.AddAtomic(hash).Should().BeTrue();
+            filter.MayContainVolatile(hash).Should().BeTrue();
+            filter.AddAtomic(hash).Should().BeFalse();
+        });
+
+        filter.Return(_pool);
+    }
+
+    [Test]
     public void Or_with()
     {
         var filter1 = Build(_pool);

--- a/src/Paprika.Tests/Data/BitMapFilterTests.cs
+++ b/src/Paprika.Tests/Data/BitMapFilterTests.cs
@@ -20,9 +20,9 @@ public abstract class BitMapFilterTests<TAccessor> : IDisposable
 
         for (ulong i = 0; i < count; i++)
         {
-            filter[i].Should().BeFalse();
-            filter[i] = true;
-            filter[i].Should().BeTrue();
+            filter.MayContain(i).Should().BeFalse();
+            filter.Add(i);
+            filter.MayContain(i).Should().BeTrue();
         }
 
         filter.Return(_pool);

--- a/src/Paprika.Tests/Merkle/MerkleVariousTests.cs
+++ b/src/Paprika.Tests/Merkle/MerkleVariousTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Data;
+using FluentAssertions;
+using Paprika.Chain;
+using Paprika.Crypto;
+using Paprika.Data;
+using Paprika.Merkle;
+
+namespace Paprika.Tests.Merkle;
+
+public class MerkleVariousTests
+{
+    [Test]
+    public void Inspect([Values(true, false)] bool rlpMemo, [Values(true, false)] bool longKey)
+    {
+        var children2 = new NibbleSet.Readonly(0b1010_0000);
+        var children3 = new NibbleSet.Readonly(0b1010_1000);
+        var children4 = new NibbleSet.Readonly(0b1111_0000);
+        var childrenAll = NibbleSet.Readonly.All;
+
+        var merkle = new ComputeMerkleBehavior();
+
+        var workingSet = new byte[1024];
+        var commit = new Commit();
+
+        var key = longKey ? Key.Merkle(NibblePath.Parse("12343456789")) : Key.Merkle(NibblePath.Parse("1"));
+        var rlp = rlpMemo ? RlpMemo.Empty : ReadOnlySpan<byte>.Empty;
+
+        Inspect(key, children2, rlp);
+        Inspect(key, children3, rlp);
+        Inspect(key, children4, rlp);
+        Inspect(key, childrenAll, rlp);
+
+        void Inspect(in Key key, NibbleSet.Readonly children, ReadOnlySpan<byte> rlp)
+        {
+            commit.SetBranch(key, children, rlp);
+            var inspected = merkle.InspectBeforeApply(commit.Key, commit.Value, workingSet);
+        }
+    }
+
+    class Commit : ICommit
+    {
+        private byte[] _key;
+        private byte[] _value;
+
+        public Key Key
+        {
+            get
+            {
+                var left = Key.ReadFrom(_key, out var key);
+                left.Length.Should().Be(0);
+
+                return key;
+            }
+        }
+
+        public ReadOnlySpan<byte> Value => _value;
+
+        public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type = EntryType.Persistent)
+        {
+            Set(key, payload, ReadOnlySpan<byte>.Empty, type);
+        }
+
+        public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1, EntryType type = EntryType.Persistent)
+        {
+            _key = key.WriteTo(stackalloc byte[key.MaxByteLength]).ToArray();
+            _value = new byte[payload0.Length + payload1.Length];
+
+            payload0.CopyTo(_value);
+            payload1.CopyTo(_value.AsSpan(payload0.Length));
+        }
+
+        public IChildCommit GetChild()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IReadOnlyDictionary<Keccak, int> Stats => throw new RowNotInTableException();
+    }
+}

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -805,8 +805,15 @@ public class Blockchain : IAsyncDisposable
                 if (_merkleCached.MayContainVolatile(hash))
                 {
                     _lock.EnterReadLock();
+
                     try
                     {
+                        if (_prefetchPossible == false)
+                        {
+                            // prefetch no longer active, default!
+                            return default;
+                        }
+
                         if (_cache.TryGet(keyWritten, hash, out var data))
                         {
                             // No ownership needed, it's all local here
@@ -854,6 +861,8 @@ public class Blockchain : IAsyncDisposable
 
             public void Dispose()
             {
+                _prefetched.Return(_parent.Pool);
+                _merkleCached.Return(_parent.Pool);
             }
         }
 

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -7,7 +7,7 @@ namespace Paprika.Chain;
 /// The prefetcher that can be used to prefetch data for <see cref="IPreCommitBehavior"/>
 /// to help it with a faster commitment when <see cref="IWorldState.Commit"/> happens.
 /// </summary>
-public interface IPreCommitPrefetcher
+public interface IPreCommitPrefetcher<TAccount, TStorage>
 {
     /// <summary>
     /// Whether this prefetcher is still capable of prefetching data.
@@ -18,14 +18,33 @@ public interface IPreCommitPrefetcher
     /// Prefetches data needed for the account.
     /// </summary>
     /// <param name="account">The account to be prefetched.</param>
-    void PrefetchAccount(in Keccak account);
+    void PrefetchAccount(in TAccount account);
 
     /// <summary>
     /// Prefetches data needed for the account.
     /// </summary>
     /// <param name="account">The account to be prefetched.</param>
     /// <param name="storage">The storage slot</param>
-    void PrefetchStorage(in Keccak account, in Keccak storage);
+    void PrefetchStorage(in TAccount account, in TStorage storage);
+}
+
+public interface IPrefetchMapping<TAccount, TStorage>
+{
+    public static abstract int GetHashCode(in TAccount account);
+    public static abstract int GetStorageHashCode(in TStorage storage);
+
+    public static abstract Keccak ToKeccak(in TAccount account);
+    public static abstract Keccak ToStorageKeccak(in TStorage storage);
+}
+
+public struct IdentityPrefetchMapping : IPrefetchMapping<Keccak, Keccak>
+{
+    public static int GetHashCode(in Keccak storage) => storage.GetHashCode();
+    public static int GetStorageHashCode(in Keccak account) => account.GetHashCode();
+
+    public static Keccak ToKeccak(in Keccak account) => account;
+
+    public static Keccak ToStorageKeccak(in Keccak storage) => storage;
 }
 
 /// <summary>

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -44,5 +44,6 @@ public interface IPrefetcherContext
     /// <summary>
     /// Sets the value under the given key.
     /// </summary>
-    void Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type = EntryType.Persistent);
+    /// <remarks>Whether set was successful. If false, the consecutive sets will fail as well.</remarks>
+    bool TrySet(in Key key, in ReadOnlySpan<byte> payload, EntryType type = EntryType.Persistent);
 }

--- a/src/Paprika/Chain/IWorldState.cs
+++ b/src/Paprika/Chain/IWorldState.cs
@@ -43,7 +43,8 @@ public interface IWorldState : IDisposable
 
     public IStateStats Stats { get; }
 
-    public IPreCommitPrefetcher? OpenPrefetcher();
+    public IPreCommitPrefetcher<TAccount, TStorage>? OpenPrefetcher<TMapping, TAccount, TStorage>()
+        where TMapping : IPrefetchMapping<TAccount, TStorage>;
 }
 
 public interface IReadOnlyWorldState : IReadOnlyCommit, IDisposable

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1477,7 +1477,10 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                     if (nonLocal)
                     {
                         // data came from the depth
-                        context.Set(key, owner.Span, EntryType.UseOnce);
+                        if (context.TrySet(key, owner.Span, EntryType.UseOnce) == false)
+                        {
+                            return;
+                        }
                     }
                     return;
                 case Node.Type.Extension:
@@ -1485,7 +1488,10 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                         if (nonLocal)
                         {
                             // data came from the depth
-                            context.Set(key, owner.Span, EntryType.UseOnce);
+                            if (context.TrySet(key, owner.Span, EntryType.UseOnce) == false)
+                            {
+                                return;
+                            }
                         }
 
                         var diffAt = ext.Path.FindFirstDifferentNibble(leftoverPath);
@@ -1505,7 +1511,10 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                     if (nonLocal)
                     {
                         // Will be modified and we can set to persistent already
-                        context.Set(key, owner.Span, EntryType.Persistent);
+                        if (context.TrySet(key, owner.Span, EntryType.Persistent) == false)
+                        {
+                            return;
+                        }
                     }
 
                     var nibble = path[i];


### PR DESCRIPTION
This PR alters how the Merkle `prefetcher` works. It's different from the previous one in the following way.

1. Prefetcher is usable as is, requiring no additional work in Nethermind state.
1. All prefetches are scheduled separately with ` ThreadPool.QueueUserWorkItem`
1. The scheduling call doesn't do the mapping of `Address` ->`Keccak` nor `StorageCell`->`(Keccak, Keccak)`. It checks whether to run a frefetch using BitFilter with hash of raw inputs and then scheduled the work item
1. To allow the check whether something was run or not, a `IPrefetcherMapping` is introduced that allows to pass an arbitrary parameter (Address, StorageCell) and define the mapping that will be run in the thread pool work item.

### Benchmarks

Using `PrefetcherTests.Spin` scenarios. _Accounts + storage_ means that each account has 4 slots occupied, so at least one branch will be there.

| Scenario | Prefetcher used | Total commit time |
| --- | --- | --- |
| Only accounts  | n  | 13s |
| Only accounts  | y  | 11s |
| Accounts + storage | n | 30s | 
| Accounts + storage | y | 24s | 

