### PR TITLE
AbadonedList page omition  fix

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -199,6 +199,8 @@ public class AbandonedTests : BasePageTests
 
             using var block = db.BeginNextBatch();
             block.SetAccount(account, value);
+            block.VerifyDbPagesOnCommit();
+
             await block.Commit(CommitOptions.FlushDataAndRoot);
         }
 

--- a/src/Paprika.Tests/Store/DbAddressSetTests.cs
+++ b/src/Paprika.Tests/Store/DbAddressSetTests.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using Paprika.Store;
+
+namespace Paprika.Tests.Store;
+
+public class DbAddressSetTests
+{
+    [Test]
+    public void Dummy()
+    {
+        const uint max = 1000;
+
+        var set = new DbAddressSet(DbAddress.Page(max));
+
+        for (uint i = 0; i < max; i++)
+        {
+            var addr = DbAddress.Page(i);
+            set[addr].Should().BeTrue();
+            set[addr] = false;
+        }
+
+        for (uint i = 0; i < max; i++)
+        {
+            var addr = DbAddress.Page(i);
+            set[addr].Should().BeFalse();
+        }
+    }
+}

--- a/src/Paprika.Tests/Store/DbAddressSetTests.cs
+++ b/src/Paprika.Tests/Store/DbAddressSetTests.cs
@@ -25,4 +25,17 @@ public class DbAddressSetTests
             set[addr].Should().BeFalse();
         }
     }
+
+    [Test]
+    public void Set_enumeration()
+    {
+        const uint max = 5;
+        var set = new DbAddressSet(DbAddress.Page(max));
+
+        set[DbAddress.Page(0)] = false;
+        set[DbAddress.Page(2)] = false;
+        set[DbAddress.Page(4)] = false;
+
+        set.EnumerateSet().ToArray().Should().BeEquivalentTo([DbAddress.Page(1), DbAddress.Page(3)]);
+    }
 }

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -114,6 +114,8 @@ public class DbTests
 
                 // write current
                 block.SetAccount(Key0, GetValue(i));
+
+                block.VerifyDbPagesOnCommit();
                 await block.Commit(CommitOptions.FlushDataOnly);
 
                 read.ShouldHaveAccount(Key0, GetValue(start));

--- a/src/Paprika/IBatch.cs
+++ b/src/Paprika/IBatch.cs
@@ -31,6 +31,11 @@ public interface IBatch : IReadOnlyBatch
     /// Gets the low levels stats of the given batch.
     /// </summary>
     IBatchStats? Stats { get; }
+
+    /// <summary>
+    /// Performs a time consuming verification when <see cref="Commit"/> is called that all the pages are reachable.
+    /// </summary>
+    void VerifyDbPagesOnCommit();
 }
 
 public interface IBatchStats

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -178,8 +178,12 @@ public struct AbandonedList
                 }
             }
 
+            // 1. Attach the previously existing abandoned as tail to the current one
             new AbandonedPage(batch.GetAt(head)).AttachTail(Addresses[maxAt], batch);
+            // 2. Update the batch id
             BatchIds[maxAt] = batch.BatchId;
+            // 3. Set properly the address to the head that has been chained up
+            Addresses[maxAt] = head;
         }
         else
         {

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -197,16 +197,22 @@ public struct AbandonedList
 
     public void Accept(IPageVisitor visitor, IPageResolver resolver)
     {
+        TryAcceptAbandoned(visitor, resolver, Current);
+
         foreach (var addr in Addresses)
         {
-            if (addr.IsNull == false)
-            {
-                var abandoned = new AbandonedPage(resolver.GetAt(addr));
-                visitor.On(abandoned, addr);
-
-                abandoned.Accept(visitor, resolver);
-            }
+            TryAcceptAbandoned(visitor, resolver, addr);
         }
+    }
+
+    private static void TryAcceptAbandoned(IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
+    {
+        if (addr.IsNull)
+            return;
+
+        var abandoned = new AbandonedPage(resolver.GetAt(addr));
+        visitor.On(abandoned, addr);
+        abandoned.Accept(visitor, resolver);
     }
 
     [Pure]

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -63,6 +63,26 @@ public readonly struct AbandonedPage(Page page) : IPage
         }
     }
 
+    public IEnumerable<DbAddress> Enumerate()
+    {
+        for (var i = 0; i < Data.Count; i++)
+        {
+            var top = Data.Abandoned[i];
+            if ((top & PackedFlag) == PackedFlag)
+            {
+                // is packed, return this and next
+                var addr = top & ~PackedFlag;
+                yield return new DbAddress(addr);
+                yield return new DbAddress(addr + PackedDiff);
+            }
+            else
+            {
+                // not packed, just return
+                yield return new DbAddress(top);
+            }
+        }
+    }
+
     public bool TryPeek(out DbAddress addr, out bool hasMoreThanPeeked)
     {
         if (Data.Count == 0)

--- a/src/Paprika/Store/DbAddressSet.cs
+++ b/src/Paprika/Store/DbAddressSet.cs
@@ -33,6 +33,22 @@ public class DbAddressSet : IDisposable
         }
     }
 
+    public IEnumerable<DbAddress> EnumerateSet()
+    {
+        for (var i = 0; i < _bitSets.Length; i++)
+        {
+            var set = _bitSets[i];
+            foreach (var index in set.EnumerateSet())
+            {
+                var addr = DbAddress.Page((uint)(i * AddressesPerPage + index));
+                if (addr >= _max)
+                    yield break;
+
+                yield return addr;
+            }
+        }
+    }
+
     public bool this[DbAddress addr]
     {
         get
@@ -66,6 +82,24 @@ public class DbAddressSet : IDisposable
                 else
                 {
                     slot = (byte)(slot & ~bitMask);
+                }
+            }
+        }
+
+        public bool AnySet => page.Span.IndexOfAnyExcept((byte)0) != -1;
+
+        public IEnumerable<int> EnumerateSet()
+        {
+            if (page.Span.IndexOfAnyExcept((byte)0) == -1)
+            {
+                yield break;
+            }
+
+            for (int i = 0; i < AddressesPerPage; i++)
+            {
+                if (this[i])
+                {
+                    yield return i;
                 }
             }
         }

--- a/src/Paprika/Store/DbAddressSet.cs
+++ b/src/Paprika/Store/DbAddressSet.cs
@@ -1,0 +1,100 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Paprika.Chain;
+
+namespace Paprika.Store;
+
+/// <summary>
+/// A dense representation of db addresses
+/// </summary>
+public class DbAddressSet : IDisposable
+{
+    private readonly DbAddress _max;
+    private static readonly BufferPool _pool = new(128, false);
+    private readonly BitSet[] _bitSets;
+
+    private const int BitsPerByte = 8;
+    private const int AddressesPerPage = Page.PageSize * BitsPerByte;
+    private const int MemoryPerPage = AddressesPerPage * Page.PageSize;
+
+    public DbAddressSet(DbAddress max)
+    {
+        _max = max;
+        var pageCount = max / AddressesPerPage + 1;
+
+        _bitSets = new BitSet[pageCount];
+        for (var i = 0; i < pageCount; i++)
+        {
+            var page = _pool.Rent(false);
+            var set = new BitSet(page);
+            _bitSets[i] = set;
+            set.SetAll();
+        }
+    }
+
+    public bool this[DbAddress addr]
+    {
+        get
+        {
+            var (pageNo, i) = Math.DivRem(addr.Raw, AddressesPerPage);
+            return _bitSets[pageNo][(int)i];
+        }
+        set
+        {
+            var (pageNo, i) = Math.DivRem(addr.Raw, AddressesPerPage);
+            _bitSets[pageNo][(int)i] = value;
+        }
+    }
+
+    private readonly struct BitSet(Page page)
+    {
+        public bool this[int i]
+        {
+            get
+            {
+                ref var slot = ref GetSlot(i, out var bitMask);
+                return (slot & bitMask) == bitMask;
+            }
+            set
+            {
+                ref var slot = ref GetSlot(i, out var bitMask);
+                if (value)
+                {
+                    slot = (byte)(slot | bitMask);
+                }
+                else
+                {
+                    slot = (byte)(slot & ~bitMask);
+                }
+            }
+        }
+
+        private unsafe ref byte GetSlot(int i, out int bitMask)
+        {
+            Debug.Assert(i < AddressesPerPage);
+
+            var (atByte, atBit) = Math.DivRem(i, BitsPerByte);
+
+            Debug.Assert(atBit < BitsPerByte);
+            bitMask = 1 << atBit;
+
+            return ref Unsafe.Add(ref Unsafe.AsRef<byte>(page.Raw.ToPointer()), atByte);
+        }
+
+        public void SetAll()
+        {
+            MemoryMarshal.Cast<byte, ulong>(page.Span).Fill(0xFF_FF_FF_FF_FF_FF_FF_FF);
+        }
+
+        public void Return(BufferPool pool) => pool.Return(page);
+    }
+
+    public void Dispose()
+    {
+        foreach (var set in _bitSets)
+        {
+            set.Return(_pool);
+        }
+    }
+}

--- a/src/Paprika/Store/IPageVisitor.cs
+++ b/src/Paprika/Store/IPageVisitor.cs
@@ -17,3 +17,17 @@ public interface IPageVisitor
 
     IDisposable On(Merkle.StateRootPage data, DbAddress addr);
 }
+
+public sealed class Disposable : IDisposable
+{
+    private Disposable()
+    {
+    }
+
+    public static readonly IDisposable Instance = new Disposable();
+
+    public void Dispose()
+    {
+
+    }
+}

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -881,6 +881,13 @@ internal class MissingPagesVisitor : IPageVisitor, IDisposable
 
     public void EnsureNoMissing(IPageResolver resolver)
     {
+        foreach (var addr in _pages.EnumerateSet())
+        {
+            var page = resolver.GetAt(addr);
+            throw new Exception(
+                $"The page at {addr} is not reachable from the tree nor from the set of abandoned pages. " +
+                $"Highly likely it's a leak. The page is {page.Header.PageType} and was written last in batch {page.Header.BatchId}");
+        }
     }
 }
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -879,14 +879,15 @@ internal class MissingPagesVisitor : IPageVisitor, IDisposable
 
     public void Dispose() => _pages.Dispose();
 
-    public void EnsureNoMissing(IPageResolver resolver)
+    public void EnsureNoMissing(IReadOnlyBatchContext batch)
     {
         foreach (var addr in _pages.EnumerateSet())
         {
-            var page = resolver.GetAt(addr);
+            var page = batch.GetAt(addr);
             throw new Exception(
                 $"The page at {addr} is not reachable from the tree nor from the set of abandoned pages. " +
-                $"Highly likely it's a leak. The page is {page.Header.PageType} and was written last in batch {page.Header.BatchId}");
+                $"Highly likely it's a leak. The page is {page.Header.PageType} and was written last in batch {page.Header.BatchId} " +
+                $"while the current batch is {batch.BatchId}");
         }
     }
 }

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -103,7 +103,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
 
         Data.Storage.Accept(visitor, resolver);
 
-        // Data.AbandonedList.Accept(visitor, resolver);
+        Data.AbandonedList.Accept(visitor, resolver);
     }
 
     /// <summary>

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -101,8 +101,8 @@ public readonly unsafe struct RootPage(Page root) : IPage
             new Merkle.StateRootPage(resolver.GetAt(stateRoot)).Accept(visitor, resolver, stateRoot);
         }
 
+        Data.Ids.Accept(visitor, resolver);
         Data.Storage.Accept(visitor, resolver);
-
         Data.AbandonedList.Accept(visitor, resolver);
     }
 


### PR DESCRIPTION
This PR introduces a verification that walks through the tree trying to find missing pages. It does it by walking the tree and visiting the abandoned. If any of the pages is not reachable, it means that either the validation is wrong (possible) or there's a leak. The verification is enabled by calling  `block.VerifyDbPagesOnCommit()` on a block. When a block is committed, the verification will ensure page reachability.

This new method of verifying reachability has been used to ensure the `AbandonedList` fix.

