### PR TITLE
Root page separates abandoned

### DIFF
--- a/src/Paprika.Cli/Program.cs
+++ b/src/Paprika.Cli/Program.cs
@@ -22,7 +22,7 @@ public class StatisticsSettings : CommandSettings
     public string Path { get; set; }
 
     [CommandArgument(1, "<size>")]
-    public byte Size { get; set; }
+    public int Size { get; set; }
 
     [CommandArgument(1, "<historyDepth>")]
     public byte HistoryDepth { get; set; }

--- a/src/Paprika.Tests/Chain/BlockchainTests.cs
+++ b/src/Paprika.Tests/Chain/BlockchainTests.cs
@@ -181,7 +181,7 @@ public class BlockchainTests
     [Category(Categories.LongRunning)]
     public async Task Account_destruction_spin()
     {
-        using var db = PagedDb.NativeMemoryDb(8 * Mb, 2);
+        using var db = PagedDb.NativeMemoryDb(10 * Mb, 2);
         await using var blockchain = new Blockchain(db, new ComputeMerkleBehavior());
 
         var parent = Keccak.EmptyTreeHash;

--- a/src/Paprika.Tests/Chain/RawTests.cs
+++ b/src/Paprika.Tests/Chain/RawTests.cs
@@ -106,7 +106,7 @@ public class RawTests
     {
         var account = Values.Key1;
 
-        using var db = PagedDb.NativeMemoryDb(256 * 1024, 2);
+        using var db = PagedDb.NativeMemoryDb(512 * 1024, 2);
         var merkle = new ComputeMerkleBehavior();
 
         await using var blockchain = new Blockchain(db, merkle);

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -83,15 +83,15 @@ public class AbandonedTests : BasePageTests
 
     private const int HistoryDepth = 2;
 
-    [TestCase(20, 1, 10_000, false, TestName = "Accounts - 1")]
-    [TestCase(464, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(24533, 4000, 200, false,
+    [TestCase(22, 1, 10_000, false, TestName = "Accounts - 1")]
+    [TestCase(466, 100, 10_000, false, TestName = "Accounts - 100")]
+    [TestCase(24535, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(68419, 10_000, 50, false,
+    [TestCase(68421, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
-    [TestCase(98577, 20_000, 50, true,
+    [TestCase(98579, 20_000, 50, true,
         TestName = "Storage - 20_000 accounts with a single storage slot",
         Category = Categories.LongRunning)]
     public async Task Reuse_in_limited_environment(int pageCount, int accounts, int repeats, bool isStorage)
@@ -189,7 +189,7 @@ public class AbandonedTests : BasePageTests
 
         byte[] value = [13];
 
-        using var db = PagedDb.NativeMemoryDb((multiplier * repeats + historyDepth) * Page.PageSize);
+        using var db = PagedDb.NativeMemoryDb((multiplier * repeats + historyDepth * PagedDb.DbPagesPerRoot) * Page.PageSize);
 
         var reads = new List<IReadOnlyBatch>();
 

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Paprika.Store;
@@ -16,7 +17,7 @@ public struct AbandonedList
     /// </summary>
     private const int EntriesStart = DbAddress.Size + sizeof(uint);
 
-    public const int Size = Page.PageSize - PageHeader.Size - RootPage.Payload.AbandonedStart - EntriesStart;
+    public const int Size = Page.PageSize;
     private const int EntrySize = sizeof(uint) + DbAddress.Size;
     private const int MaxCount = (Size - EntriesStart) / EntrySize;
 
@@ -254,4 +255,7 @@ public struct AbandonedList
     }
 
     public DbAddress GetCurrentForTest() => Current;
+
+    public static ref AbandonedList Wrap(Page page) =>
+        ref Unsafe.As<byte, AbandonedList>(ref MemoryMarshal.GetReference(page.Span));
 }

--- a/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
+++ b/src/Paprika/Store/PageManagers/NativeMemoryPageManager.cs
@@ -8,10 +8,10 @@ public sealed unsafe class NativeMemoryPageManager : PointerPageManager
 
     public NativeMemoryPageManager(long size, byte historyDepth) : base(size)
     {
-        _ptr = NativeMemory.AlignedAlloc((UIntPtr)size, (UIntPtr)Page.PageSize);
+        _ptr = NativeMemory.AlignedAlloc((UIntPtr)size, Page.PageSize);
 
         // clear first pages to make it clean
-        for (var i = 0; i < historyDepth; i++)
+        for (var i = 0; i < historyDepth * PagedDb.DbPagesPerRoot; i++)
         {
             GetAt(new DbAddress((uint)i)).Clear();
         }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -67,7 +67,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
     // pooled objects
     private Context? _ctx;
-    private readonly BufferPool _pooledRoots;
+    private readonly BufferPool _pooledPages;
 
 #if TRACKING_REUSED_PAGES
     // reuse tracking
@@ -118,7 +118,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             "The number of pages registered to be reused");
 #endif
         // Pool
-        _pooledRoots = new BufferPool(16, true, _meter);
+        _pooledPages = new BufferPool(16, true, _meter);
     }
 
     public static PagedDb NativeMemoryDb(long size, byte historyDepth = 2) =>
@@ -193,7 +193,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
     public void Dispose()
     {
-        _pooledRoots.Dispose();
+        _pooledPages.Dispose();
         _manager.Dispose();
         _meter.Dispose();
     }
@@ -225,11 +225,15 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
     private ReadOnlyBatch BeginReadOnlyBatch(string name, in RootPage root)
     {
-        var copy = new RootPage(_pooledRoots.Rent(false));
+        // Root
+        var rootCopy = new RootPage(_pooledPages.Rent(false));
+        root.CopyTo(rootCopy);
 
-        root.CopyTo(copy);
+        // Abandoned
+        var abandonedCopy = _pooledPages.Rent(false);
+        GetAt(GetAddress(root.AsPage()).Next).CopyTo(abandonedCopy);
 
-        var batch = new ReadOnlyBatch(this, copy, name);
+        var batch = new ReadOnlyBatch(this, rootCopy, abandonedCopy, name);
         _batchesReadOnly.Add(batch);
         return batch;
     }
@@ -344,9 +348,12 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
         foreach (var root in _roots)
         {
-            using (visitor.On(root, DbAddress.Page(i++)))
+            var addr = DbAddress.Page(i);
+            i += DbPagesPerRoot;
+
+            using (visitor.On(root, addr))
             {
-                root.Accept(visitor, this);
+                root.Accept(visitor, this, GetAt(addr.Next));
             }
         }
     }
@@ -354,10 +361,11 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
     public void VisitRoot(IPageVisitor visitor)
     {
         var root = Root;
+        var addr = GetAddress(Root.AsPage());
 
-        using (visitor.On(root, GetAddress(Root.AsPage())))
+        using (visitor.On(root, addr))
         {
-            root.Accept(visitor, this);
+            root.Accept(visitor, this, GetAt(addr.Next));
         }
     }
 
@@ -381,8 +389,10 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         lock (_batchLock)
         {
             _batchesReadOnly.Remove(batch);
-            _pooledRoots.Return(batch.Root.AsPage());
         }
+
+        _pooledPages.Return(batch.Root.AsPage());
+        _pooledPages.Return(batch.Abandoned.AsPage());
     }
 
     private IBatch BuildFromRoot(RootPage rootPage)
@@ -395,6 +405,10 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
         // always inc the batchId
         root.Header.BatchId++;
+
+        // copy abandoned
+        var abandoned = ctx.PageForAbandoned;
+        GetAt(GetAddress(rootPage.AsPage()).Next).CopyTo(abandoned);
 
         // copying done above, to minimize the lock
         lock (_batchLock)
@@ -413,7 +427,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
                 minBatch = Math.Min(batch.BatchId, minBatch);
             }
 
-            return _batchCurrent = new Batch(this, root, minBatch, ctx);
+            return _batchCurrent = new Batch(this, root, abandoned, minBatch, ctx);
         }
 
         [DoesNotReturn]
@@ -435,16 +449,17 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
     /// </summary>
     private DbAddress SetNewRoot(RootPage root)
     {
-        var pageAddress = (_lastRoot + 1) % _historyDepth;
-
-        root.CopyTo(_roots[pageAddress]);
-        return DbAddress.Page((uint)pageAddress);
+        var next = NextRootIndex;
+        root.CopyTo(_roots[next]);
+        return DbAddress.Page(next * DbPagesPerRoot);
     }
+
+    private uint NextRootIndex => (uint)(_lastRoot + 1) % _historyDepth;
 
     private void CommitNewRoot() => _lastRoot += 1;
 
 
-    private sealed class ReadOnlyBatch(PagedDb db, RootPage root, string name)
+    private sealed class ReadOnlyBatch(PagedDb db, RootPage root, Page abandoned, string name)
         : IReportingReadOnlyBatch, IReadOnlyBatchContext
     {
         [ThreadStatic] private static ConcurrentDictionary<Keccak, uint>? s_cache;
@@ -454,6 +469,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             RootPage.IdCacheLimit);
 
         public RootPage Root => root;
+        public Page Abandoned => abandoned;
 
         private long _reads;
         private volatile bool _disposed;
@@ -496,8 +512,8 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         {
             ref readonly var data = ref root.Data;
 
-            totalAbandoned = 0;
-            totalAbandoned = data.AbandonedList.GatherTotalAbandoned(this);
+
+            totalAbandoned = AbandonedList.Wrap(abandoned).GatherTotalAbandoned(this);
 
             if (data.StateRoot.IsNull == false)
             {
@@ -530,8 +546,9 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
     {
         private readonly PagedDb _db;
         private readonly RootPage _root;
+        private readonly Page _abandonedPage;
         private readonly uint _reusePagesOlderThanBatchId;
-        private bool _verify = false;
+        private bool _verify;
         private bool _disposed;
 
         private readonly Context _ctx;
@@ -548,11 +565,13 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
         private readonly BatchMetrics _metrics;
 
-        public Batch(PagedDb db, RootPage root, uint reusePagesOlderThanBatchId, Context ctx) : base(
+
+        public Batch(PagedDb db, RootPage root, Page abandoned, uint reusePagesOlderThanBatchId, Context ctx) : base(
             root.Header.BatchId)
         {
             _db = db;
             _root = root;
+            _abandonedPage = abandoned;
             _reusePagesOlderThanBatchId = reusePagesOlderThanBatchId;
             _ctx = ctx;
             _abandoned = ctx.Abandoned;
@@ -629,12 +648,12 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             CheckDisposed();
 
             // memoize the abandoned so that it's preserved for future uses
-            MemoizeAbandoned();
+            MemoizeAbandoned(_db.NextRootIndex);
 
             if (_verify)
             {
                 using var missing = new MissingPagesVisitor(_root, _db._historyDepth);
-                _root.Accept(missing, this);
+                _root.Accept(missing, this, _abandonedPage);
                 missing.EnsureNoMissing(this);
             }
 
@@ -726,20 +745,27 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             return page;
         }
 
-        private void MemoizeAbandoned()
+        private void MemoizeAbandoned(uint nextRootIndex)
         {
-            if (_abandoned.Count == 0)
+            ref var list = ref AbandonedList.Wrap(_abandonedPage);
+
+            if (_abandoned.Count > 0)
             {
-                // nothing to memoize
-                return;
+                list.Register(_abandoned, this);
             }
 
-            _root.Data.AbandonedList.Register(_abandoned, this);
+            var addr = DbAddress.Page(nextRootIndex * DbPagesPerRoot + 1);
+
+            Debug.Assert(addr < _db.NextFreePage, "Abandoned should not breach the range of pages at the beginning of the database");
+            Debug.Assert(addr.Raw % DbPagesPerRoot == 1, "Abandoned page should lie next to the root");
+
+            _abandonedPage.CopyTo(GetAt(addr));
+            _written.Add(addr);
         }
 
         private bool TryGetNoLongerUsedPage(out DbAddress found)
         {
-            var claimed = _root.Data.AbandonedList.TryGet(out found, _reusePagesOlderThanBatchId, this);
+            var claimed = AbandonedList.Wrap(_abandonedPage).TryGet(out found, _reusePagesOlderThanBatchId, this);
 
 #if TRACKING_REUSED_PAGES
             if (claimed)
@@ -815,6 +841,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         public unsafe Context()
         {
             PageForRoot = new((byte*)NativeMemory.AlignedAlloc(Page.PageSize, (UIntPtr)UIntPtr.Size));
+            PageForAbandoned = new((byte*)NativeMemory.AlignedAlloc(Page.PageSize, (UIntPtr)UIntPtr.Size));
             Abandoned = new List<DbAddress>();
             Written = new HashSet<DbAddress>();
             IdCache = new Dictionary<Keccak, uint>();
@@ -823,6 +850,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         public Dictionary<Keccak, uint> IdCache { get; }
 
         public Page PageForRoot { get; }
+        public Page PageForAbandoned { get; }
 
         public List<DbAddress> Abandoned { get; }
         public HashSet<DbAddress> Written { get; }

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -512,7 +512,6 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         {
             ref readonly var data = ref root.Data;
 
-
             totalAbandoned = AbandonedList.Wrap(abandoned).GatherTotalAbandoned(this);
 
             if (data.StateRoot.IsNull == false)
@@ -521,6 +520,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             }
 
             data.Storage.Report(storage, this, 0, 0);
+            data.StorageMerkle.Report(storage, this, 0, 0);
             data.Ids.Report(ids, this, 0, 0);
         }
 


### PR DESCRIPTION
This PR changes the structure of the root pages in Paprika database. 

Previously, each root occupied just one page (4kb). The number of root pages was defined by the `historyDepth` so that the first pages in the database were: `[root0, root1, ..., rootN, regular0, regular1, ...]` where `N = historyDepth`.

This PR changes this structure expanding each root page and allowing to make it of size 2*PageSize (8kb) or even bigger in the future. The changes needed for atomicity are still preserved in the first page, while the second is used as an extension. This makes the first pages in db look like the following: `[root0a, root0b, root1a, root1b, ..., rootNa, rootNb]`.

This extension allows to change the root structure to the following:

1. 0th page:
   1. metadata - metadata of the root
   2. state - the address of the state root page
   3. ids - a fanout list
   4. storage - a fanout list
   5. storage merkle - a fanout list
2. 1th page:
   1. abandoned page list - full 4 kb

where a `fanout list` is a list of 256 addresses (1kb in total) that consumes 2 nibbles from the path.