### PR TITLE
Batching for blocks enabled

### DIFF
--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -69,7 +69,7 @@ public class RootHashFuzzyTests
     {
         var generator = Build(test);
 
-        using var db = PagedDb.NativeMemoryDb(16 * 1024 * 1024, 2);
+        using var db = PagedDb.NativeMemoryDb(32 * 1024 * 1024, 2);
         var parallelism = parallel ? ComputeMerkleBehavior.ParallelismUnlimited : ComputeMerkleBehavior.ParallelismNone;
         var merkle = new ComputeMerkleBehavior(parallelism);
 


### PR DESCRIPTION
A PR that allows to batch blocks before applying them to the database if the number of blocks in the queue is sufficiently big that it breaches the history depth. If the number is bigger, blocks can be squashed before applying them to the database so that there's less book keeping in regards to the copying data in the database.