### PR TITLE
DataPage smart write through

### DIFF
--- a/src/Paprika.Tests/Store/BasePageTests.cs
+++ b/src/Paprika.Tests/Store/BasePageTests.cs
@@ -56,9 +56,6 @@ public abstract class BasePageTests
             return page;
         }
 
-        // for now
-        public override bool WasWritten(DbAddress addr) => true;
-
         public override void RegisterForFutureReuse(Page page)
         {
             _toReuse.Add(GetAddress(page))

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -37,7 +37,7 @@ abstract class BatchContextBase(uint batchId) : IBatchContext
         return @new;
     }
 
-    public abstract bool WasWritten(DbAddress addr);
+    public bool WasWritten(Page page) => page.Header.BatchId == BatchId;
 
     /// <summary>
     /// Registers the given page for future GC.

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -66,12 +66,17 @@ public interface IBatchContext : IReadOnlyBatchContext
     /// Informs the batch, that the given page was abandoned before and is manually reused.
     /// </summary>
     /// <param name="page">The page that will be reused.</param>
-    public void NoticeAbandonedPageReused(Page page);
+    void NoticeAbandonedPageReused(Page page);
 
     /// <summary>
     /// Checks whether the page was written during this batch.
     /// </summary>
-    bool WasWritten(DbAddress addr);
+    bool WasWritten(DbAddress addr) => WasWritten(GetAt(addr));
+
+    /// <summary>
+    /// Checks whether the page was written during this batch.
+    /// </summary>
+    bool WasWritten(Page page);
 
     /// <summary>
     /// Abandon this page from this batch on.

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -781,8 +781,6 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             return claimed;
         }
 
-        public override bool WasWritten(DbAddress addr) => _written.Contains(addr);
-
         public override void RegisterForFutureReuse(Page page)
         {
             var addr = _db.GetAddress(page);


### PR DESCRIPTION
This PR introduces a change in the way of handling overflown `DataPage`s. 

In current situation, when a page is full and there's no place to put the new key in it, it will be flushed down. The flushing down is a powerful mechanism but requires to iterate over the `SlottedArray`, move items down and delete them in the original page. If the `DataPage` is near the top, this situation may happen quite frequently. 

This PR introduces an additional check using `batch.WasWritten` that allows to check if a child page was written during this batch. If a key does not fit to a page (`SlottedArray.TrySet` failed), is non-empty (can have a nibble truncated), a child page exist and `WasWritten` during this batch, it's a perfect opportunity to pass through this page and move down. 

The expectation is that by limiting the amount of time spent in flushing down, we could greatly decrease the time of applying a block. This would help with a lot of cases where there's a bulk of updates for a given account but we don't want to flush a few layers of `DataPage`s constantly. The disadvantage is that this limits LRU behavior a bit (values pushed down in the tree).

To be implemented and tested.