### PR TITLE
SlottedArray faster search

### DIFF
--- a/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
@@ -37,7 +37,6 @@ public class SlottedArrayBenchmarks
 
             Span<byte> key = stackalloc byte[4];
 
-
             while (true)
             {
                 WriteInt32LittleEndian(key, _to);

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -62,7 +62,8 @@ public readonly ref struct SlottedArray
 
     private bool TrySetImpl(ushort hash, byte preamble, in NibblePath trimmed, ReadOnlySpan<byte> data)
     {
-        if (TryGetImpl(trimmed, hash, preamble, out var existingData, out var index))
+        var index = TryGetImpl(trimmed, hash, preamble, out var existingData);
+        if (index != NotFoundIndex)
         {
             // same size, copy in place
             if (data.Length == existingData.Length)
@@ -249,7 +250,8 @@ public readonly ref struct SlottedArray
             if (data.IsEmpty && treatEmptyAsTombstone)
             {
                 // special case for tombstones in overflows
-                if (map.TryGetImpl(trimmed, slot.Hash, slot.KeyPreamble, out _, out var index))
+                var index = map.TryGetImpl(trimmed, slot.Hash, slot.KeyPreamble, out _);
+                if (index != NotFoundIndex)
                 {
                     map.DeleteImpl(index);
                 }
@@ -310,7 +312,8 @@ public readonly ref struct SlottedArray
     public bool Delete(in NibblePath key)
     {
         var hash = Slot.PrepareKey(key, out var preamble, out var trimmed);
-        if (TryGetImpl(trimmed, hash, preamble, out _, out var index))
+        var index = TryGetImpl(trimmed, hash, preamble, out _);
+        if (index != NotFoundIndex)
         {
             DeleteImpl(index);
             return true;
@@ -417,7 +420,8 @@ public readonly ref struct SlottedArray
     public bool TryGet(scoped in NibblePath key, out ReadOnlySpan<byte> data)
     {
         var hash = Slot.PrepareKey(key, out byte preamble, out var trimmed);
-        if (TryGetImpl(trimmed, hash, preamble, out var span, out _))
+        var index = TryGetImpl(trimmed, hash, preamble, out var span);
+        if (index != NotFoundIndex)
         {
             data = span.IsEmpty ? ReadOnlySpan<byte>.Empty : MemoryMarshal.CreateReadOnlySpan(ref span[0], span.Length);
             return true;
@@ -435,9 +439,11 @@ public readonly ref struct SlottedArray
         _header = default;
     }
 
+    private const int NotFoundIndex = -1;
+
     [OptimizationOpportunity(OptimizationType.CPU,
         "key encoding is delayed but it might be called twice, here + TrySet")]
-    private bool TryGetImpl(in NibblePath key, ushort hash, byte preamble, out Span<byte> data, out int slotIndex)
+    private int TryGetImpl(in NibblePath key, ushort hash, byte preamble, out Span<byte> data)
     {
         var to = _header.Low;
 
@@ -453,8 +459,7 @@ public readonly ref struct SlottedArray
         if (index == notFound)
         {
             data = default;
-            slotIndex = default;
-            return false;
+            return NotFoundIndex;
         }
 
         while (index != notFound)
@@ -476,16 +481,14 @@ public readonly ref struct SlottedArray
                         if (NibblePath.TryReadFrom(actual, key, out var leftover))
                         {
                             data = leftover;
-                            slotIndex = i;
-                            return true;
+                            return i;
                         }
                     }
                     else
                     {
                         // The key is contained in the hash, all is equal and good to go!
                         data = actual;
-                        slotIndex = i;
-                        return true;
+                        return i;
                     }
                 }
             }
@@ -506,8 +509,7 @@ public readonly ref struct SlottedArray
         }
 
         data = default;
-        slotIndex = default;
-        return false;
+        return NotFoundIndex;
     }
 
     /// <summary>

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -460,6 +460,8 @@ public readonly ref struct SlottedArray
 
         // set represents significant bits, they are set in the order of the vector, meaning, that 0th value sets 0th bit
         ulong set;
+
+        // If the max-to is small, consume the set first
         if (max - to < batch)
         {
             i = max - to;
@@ -494,7 +496,7 @@ public readonly ref struct SlottedArray
                     i += Vector512<int>.Count;
                     continue;
                 }
-                
+
                 consumed = Vector512<int>.Count;
             }
             else if (Vector256.IsHardwareAccelerated)
@@ -504,6 +506,7 @@ public readonly ref struct SlottedArray
                 var masked = Vector256.BitwiseAnd(v, mask);
                 var searchVector = Vector256.Create(search);
                 var result = Vector256.Equals(masked, searchVector);
+
                 if (result != Vector256<int>.Zero)
                 {
                     set = result.ExtractMostSignificantBits();
@@ -513,7 +516,7 @@ public readonly ref struct SlottedArray
                     i += Vector256<int>.Count;
                     continue;
                 }
-                
+
                 consumed = Vector256<int>.Count;
             }
             else if (Vector128.IsHardwareAccelerated)
@@ -532,7 +535,7 @@ public readonly ref struct SlottedArray
                     i += Vector128<int>.Count;
                     continue;
                 }
-              
+
                 consumed = Vector128<int>.Count;
             }
             else if (Vector64.IsHardwareAccelerated)
@@ -542,7 +545,7 @@ public readonly ref struct SlottedArray
                 var masked = Vector64.BitwiseAnd(v, mask);
                 var searchVector = Vector64.Create(search);
                 var result = Vector64.Equals(masked, searchVector);
-                
+
                 if (result != Vector64<int>.Zero)
                 {
                     set = result.ExtractMostSignificantBits();

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -472,7 +472,9 @@ public readonly ref struct SlottedArray
                 var i = offset / 2;
 
                 ref var slot = ref this[i];
-                if (slot.IsDeleted == false && slot.KeyPreamble == preamble)
+
+                // IsDeleted is encoded as a special preamble no need to check it
+                if (/*slot.IsDeleted == false && */ slot.KeyPreamble == preamble)
                 {
                     var actual = GetSlotPayload(ref slot);
 


### PR DESCRIPTION
This PR augments `SlottedArray` to make it faster so that the data application is faster as well.

1. 4c0a052 - `TryGetImpl` changed from `bool` returning to index returning results in shorter code, from `809` to ` 777`
2. 70e765d - removed not needed `IsDeleted` check `; Total bytes of code 738`