### PR TITLE
Delete by prefix delete

### DIFF
--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -644,6 +644,15 @@ public readonly ref struct NibblePath
 
     private static readonly char[] Hex = "0123456789ABCDEF".ToArray();
 
+    // TODO: optimize
+    public bool StartsWith(in NibblePath prefix)
+    {
+        if (prefix.Length > Length)
+            return false;
+
+        return SliceTo(prefix.Length).Equals(prefix);
+    }
+
     public bool Equals(in NibblePath other)
     {
         if (((other.Length ^ Length) | (other._odd ^ _odd)) > 0)

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -83,6 +83,34 @@ public readonly ref struct SlottedArray
         return TrySetImpl(hash, preamble, trimmed, data);
     }
 
+    public void DeleteByPrefix(in NibblePath prefix)
+    {
+        if (prefix.Length == 0)
+        {
+            Delete(prefix);
+        }
+        else if (prefix.Length == 1)
+        {
+            // TODO: optimize by filtering by hash. The key is at least 2 nibbles long so can be easily filtered with a bitwise mask over the hash.
+            // Don't materialize data! 
+            foreach (var item in EnumerateNibble(prefix.FirstNibble))
+            {
+                Delete(item);
+            }
+        }
+        else
+        {
+            // TODO: optimize by filtering by hash. The key is at least 2 nibbles long so can be easily filtered with a bitwise mask over the hash.
+            foreach (var item in EnumerateAll())
+            {
+                if (item.Key.StartsWith(prefix))
+                {
+                    Delete(item);
+                }
+            }
+        }
+    }
+
     private bool TrySetImpl(ushort hash, byte preamble, in NibblePath trimmed, ReadOnlySpan<byte> data)
     {
         var index = TryGetImpl(trimmed, hash, preamble, out var existingData);
@@ -954,7 +982,6 @@ public readonly ref struct SlottedArray
             }
 
             data = input;
-
 
             switch (lengthBits)
             {

--- a/src/Paprika/IBatch.cs
+++ b/src/Paprika/IBatch.cs
@@ -21,6 +21,11 @@ public interface IBatch : IReadOnlyBatch
     void Destroy(in NibblePath account);
 
     /// <summary>
+    /// Deletes all the keys that share the given prefix.
+    /// </summary>
+    void DeleteByPrefix(in Key prefix);
+
+    /// <summary>
     /// Commits the block returning its root hash.
     /// </summary>
     /// <param name="options">How to commit.</param>
@@ -33,7 +38,7 @@ public interface IBatch : IReadOnlyBatch
     IBatchStats? Stats { get; }
 
     /// <summary>
-    /// Performs a time consuming verification when <see cref="Commit"/> is called that all the pages are reachable.
+    /// Performs a time-consuming verification when <see cref="Commit"/> is called that all the pages are reachable.
     /// </summary>
     void VerifyDbPagesOnCommit();
 }

--- a/src/Paprika/Store/FanOutListOf256.cs
+++ b/src/Paprika/Store/FanOutListOf256.cs
@@ -54,6 +54,24 @@ public readonly ref struct FanOutListOf256<TPage, TPageType>(ref DbAddressList.O
         _addresses[index] = batch.GetAddress(updated);
     }
 
+    public void DeleteByPrefix(in NibblePath path, IBatchContext batch)
+    {
+        var index = GetIndex(path);
+        var sliced = path.SliceFrom(ConsumedNibbles);
+
+        var addr = _addresses[index];
+
+        if (addr.IsNull)
+        {
+            // There's nothing to delete here
+            return;
+        }
+
+        // The page exists, update
+        var updated = TPage.Wrap(batch.GetAt(addr)).DeleteByPrefix(sliced, batch);
+        _addresses[index] = batch.GetAddress(updated);
+    }
+
     public void Report(IReporter reporter, IPageResolver resolver, int level, int trimmedNibbles)
     {
         var consumedNibbles = trimmedNibbles + ConsumedNibbles;

--- a/src/Paprika/Store/Merkle.cs
+++ b/src/Paprika/Store/Merkle.cs
@@ -70,6 +70,35 @@ public static class Merkle
             return page;
         }
 
+        public Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
+        {
+            if (Header.BatchId != batch.BatchId)
+            {
+                // the page is from another batch, meaning, it's readonly. Copy
+                var writable = batch.GetWritableCopy(page);
+                return new StateRootPage(writable).DeleteByPrefix(prefix, batch);
+            }
+
+            if (prefix.Length < ConsumedNibbles)
+            {
+                var map = new SlottedArray(Data.DataSpan);
+                map.DeleteByPrefix(prefix);
+                return page;
+            }
+
+            var index = GetIndex(prefix);
+            var sliced = prefix.SliceFrom(ConsumedNibbles);
+            ref var addr = ref Data.Buckets[index];
+
+            if (addr.IsNull)
+            {
+                return page;
+            }
+
+            addr = batch.GetAddress(new DataPage(batch.GetAt(addr)).DeleteByPrefix(sliced, batch));
+            return page;
+        }
+
         /// <summary>
         /// Represents the data of this data page. This type of payload stores data in 16 nibble-addressable buckets.
         /// These buckets is used to store up to <see cref="DataSize"/> entries before flushing them down as other pages

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -26,6 +26,11 @@ public interface IPageWithData<TPage> : IPage
 
     bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result);
 
+    /// <summary>
+    /// Delete all the values by the given prefix in the page and below.
+    /// </summary>
+    Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch);
+
     Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch);
 
     void Report(IReporter reporter, IPageResolver resolver, int pageLevel, int trimmedNibbles);

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -594,6 +594,11 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             _root.Destroy(this, account);
         }
 
+        public void DeleteByPrefix(in Key prefix)
+        {
+            _root.DeleteByPrefix(in prefix, this);
+        }
+
         private void CheckDisposed()
         {
             if (_disposed)


### PR DESCRIPTION
This PR introduces a new top-level method `IBatch.DeleteByPrefix (in Key key)` that allows a deletion of an arbitrary subtree pointed to by the key.