### PR TITLE
Linked overflow

### DIFF
--- a/src/Paprika.Tests/Data/SlottedArrayTests.cs
+++ b/src/Paprika.Tests/Data/SlottedArrayTests.cs
@@ -559,7 +559,7 @@ public class SlottedArrayTests
         original.SetAssert(key4, Data(4));
         original.SetAssert(key5, Data(5));
 
-        original.MoveNonEmptyKeysTo(new(copy0));
+        original.MoveNonEmptyKeysTo(new MapSource(copy0));
 
         // original should have only empty
         original.Count.Should().Be(1);
@@ -602,7 +602,7 @@ public class SlottedArrayTests
         original.SetAssert(key4, tombstone);
         original.SetAssert(key5, Data(5));
 
-        original.MoveNonEmptyKeysTo(new(copy0), true);
+        original.MoveNonEmptyKeysTo(new MapSource(copy0), true);
 
         // original should have only empty
         original.Count.Should().Be(0);
@@ -643,7 +643,7 @@ public class SlottedArrayTests
         original.SetAssert(key4, Data(4));
         original.SetAssert(key5, Data(5));
 
-        original.MoveNonEmptyKeysTo(new(copy0, copy1));
+        original.MoveNonEmptyKeysTo(new MapSource(copy0, copy1));
 
         // original should have only empty
         original.Count.Should().Be(1);
@@ -696,7 +696,7 @@ public class SlottedArrayTests
         original.SetAssert(key4, Data(4));
         original.SetAssert(key5, Data(5));
 
-        original.MoveNonEmptyKeysTo(new(copy0, copy1, copy2, copy3));
+        original.MoveNonEmptyKeysTo(new MapSource(copy0, copy1, copy2, copy3));
 
         // original should have only empty
         original.Count.Should().Be(1);
@@ -777,7 +777,7 @@ public class SlottedArrayTests
         original.SetAssert(key7, Data(7));
         original.SetAssert(key8, Data(8));
 
-        original.MoveNonEmptyKeysTo(new(copy0, copy1, copy2, copy3, copy4, copy5, copy6, copy7));
+        original.MoveNonEmptyKeysTo(new MapSource(copy0, copy1, copy2, copy3, copy4, copy5, copy6, copy7));
 
         // original should have only empty
         HasOnly(original, 0);

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -83,10 +83,10 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(20, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(428, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(19285, 4000, 200, false,
+    [TestCase(18025, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(48240, 10_000, 50, false,
+    [TestCase(45556, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(88262, 20_000, 50, true,

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -83,10 +83,10 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(20, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(428, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(18025, 4000, 200, false,
+    [TestCase(16578, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(45556, 10_000, 50, false,
+    [TestCase(42147, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(88262, 20_000, 50, true,

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -462,6 +462,61 @@ public readonly ref struct SlottedArray /*: IClearable */
         }
     }
 
+    public void MoveNonEmptyKeysTo(in SlottedArray destination, bool treatEmptyAsTombstone = false)
+    {
+        var to = Count;
+        var moved = 0;
+
+        for (int i = 0; i < to; i++)
+        {
+            ref var slot = ref GetSlotRef(i);
+            if (slot.IsDeleted)
+                continue;
+
+            if (slot.HasAtLeastOneNibble == false)
+                continue;
+
+            var payload = GetSlotPayload(i);
+
+            Span<byte> data;
+
+            NibblePath trimmed;
+            if (slot.HasKeyBytes)
+            {
+                data = KeyEncoding.ReadFrom(payload, out trimmed);
+            }
+            else
+            {
+                trimmed = default;
+                data = payload;
+            }
+
+            var hash = GetHashRef(i);
+            if (data.IsEmpty && treatEmptyAsTombstone)
+            {
+                // special case for tombstones in overflows
+                var index = destination.TryGetImpl(trimmed, hash, slot.KeyPreamble, out _);
+                if (index != NotFound)
+                {
+                    destination.DeleteImpl(index);
+                }
+
+                slot.MarkAsDeleted();
+            }
+            else if (destination.TrySetImpl(hash, slot.KeyPreamble, trimmed, data))
+            {
+                slot.MarkAsDeleted();
+                moved++;
+            }
+        }
+
+        if (moved > 0)
+        {
+            CollectTombstones();
+            Defragment();
+        }
+    }
+
     public void RemoveKeysFrom(in SlottedArray source)
     {
         var to = source.Count;

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -123,6 +123,11 @@ public readonly unsafe struct LeafOverflowPage(Page page) : IPage
         {
             // No level below, create one
             child = new LeafOverflowPage(batch.GetNewPage(out Data.Next, false));
+            ref var header = ref child.AsPage().Header;
+
+            header.PageType = PageType.LeafOverflow;
+            header.Level = Header.Level; // same level
+
             child.Clear();
         }
         else

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -47,9 +47,10 @@ public readonly unsafe struct LeafOverflowPage(Page page) : IPage
     {
         using var scope = visitor.On(ref builder, this, addr);
 
-        if (Data.Next.IsNull == false)
+        var next = Data.Next;
+        if (next.IsNull == false)
         {
-            new LeafOverflowPage(resolver.GetAt(Data.Next)).Accept(ref builder, visitor, resolver, addr);
+            new LeafOverflowPage(resolver.GetAt(next)).Accept(ref builder, visitor, resolver, next);
         }
     }
 

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -15,29 +15,41 @@ public readonly unsafe struct LeafOverflowPage(Page page) : IPage
 
     private ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
-    [InlineArray(Size)]
-    [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
+    [StructLayout(LayoutKind.Explicit, Pack = sizeof(byte), Size = Size)]
     private struct Payload
     {
         private const int Size = Page.PageSize - PageHeader.Size;
+        private const int DataSize = Size - DbAddress.Size;
+
+        [FieldOffset(0)]
+        public DbAddress Next;
 
         /// <summary>
         /// The first item of map of frames to allow ref to it.
         /// </summary>
+        [FieldOffset(DbAddress.Size)]
         private byte DataStart;
 
         /// <summary>
         /// Writable area.
         /// </summary>
-        public Span<byte> DataSpan => MemoryMarshal.CreateSpan(ref DataStart, Size);
+        public Span<byte> DataSpan => MemoryMarshal.CreateSpan(ref DataStart, DataSize);
     }
 
     public SlottedArray Map => new(Data.DataSpan);
+
+    public void Clear()
+    {
+        Map.Clear();
+        Data.Next = default;
+    }
 
     public void Accept(ref NibblePath.Builder builder, IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
     {
         using var scope = visitor.On(ref builder, this, addr);
     }
+
+    public bool TryGet(in NibblePath key, out ReadOnlySpan<byte> result) => Map.TryGet(key, out result);
 
     public Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
     {
@@ -51,5 +63,36 @@ public readonly unsafe struct LeafOverflowPage(Page page) : IPage
         Map.DeleteByPrefix(prefix);
 
         return page;
+    }
+
+    public void Delete(in NibblePath key, IBatchContext batch)
+    {
+        Debug.Assert(batch.BatchId == Header.BatchId, "Should have been COWed before");
+        Map.Delete(key);
+    }
+
+    public void StealFrom(in SlottedArray map)
+    {
+        map.MoveNonEmptyKeysTo(new MapSource(Map), treatEmptyAsTombstone: true);
+    }
+
+    public void RemoveKeysFrom(in SlottedArray map)
+    {
+        Map.RemoveKeysFrom(map);
+    }
+
+    public void GatherStats(Span<ushort> stats)
+    {
+        Map.GatherCountStats1Nibble(stats);
+    }
+
+    public void CopyTo(DataPage data, IBatchContext batch)
+    {
+        foreach (var item in Map.EnumerateAll())
+        {
+            var result = data.Set(item.Key, item.RawData, batch);
+
+            Debug.Assert(result.Raw == data.AsPage().Raw, "Set should not change the data page");
+        }
     }
 }


### PR DESCRIPTION
This PR changes how overflow pages work. Instead of having a complex logic of splitting keys by the first nibble (a part of it, masked to match the number of buckets), a simple linked list is used. This introduces some overhead for finding a value as all the elements in the list must be traversed, but can greatly decrease the amount of pages used for storing data.

Currently, a single `LeafOverflowPage` will point only to another one, making a chain of length of 2. This already shows nice size reduction. If generalized, this can be a succinct implementation with one or maybe two levels more.

