### PR TITLE
#265 Update MemoryMappedPageManager memory mapped initiation

### DIFF
--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -61,11 +61,9 @@ public sealed class MemoryMappedPageManager : PointerPageManager
             _file = new FileStream(Path, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096,
                 PaprikaFileOptions);
         }
+        _mapped = MemoryMappedFile.CreateFromFile(_file, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true);
 
-        _mapped = MemoryMappedFile.CreateFromFile(_file, null, (long)size, MemoryMappedFileAccess.ReadWrite,
-            HandleInheritability.None, true);
-
-        _whole = _mapped.CreateViewAccessor();
+        _whole = _mapped.CreateViewAccessor(0, historyDepth * Page.PageSize);
         _whole.SafeMemoryMappedViewHandle.AcquirePointer(ref _ptr);
         _options = options;
 


### PR DESCRIPTION
#265 

Two changes: 

1. Creating the MemoryMappedFile without setting the total file size upfront 

_mapped = MemoryMappedFile.CreateFromFile(_file, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true);

2. Instead of mapping the whole file, mapping only a portion of it dynamically as needed

_whole = _mapped.CreateViewAccessor(0, historyDepth * Page.PageSize);