### PR TITLE
#384 Initial Changes for confirmation

### DIFF
--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -39,7 +39,7 @@ abstract class BatchContextBase(uint batchId) : IBatchContext
 
     public bool WasWritten(DbAddress addr) => GetAt(addr).Header.BatchId == BatchId;
 
-    public abstract void RegisterForFutureReuse(Page page, bool possibleImmediateReuse = false);
+    public abstract void RegisterForFutureReuse(Page page,  bool possibleImmediateReuse = false);
 
     public virtual void NoticeAbandonedPageReused(Page page) { }
 
@@ -71,4 +71,7 @@ abstract class BatchContextBase(uint batchId) : IBatchContext
     }
 
     public BatchStats? Stats { get; } = new();
+
+    public unsafe Page NullPage => new Page((byte*)0);
+
 }

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -74,6 +74,11 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>, ICl
                     buckets[prefix.Nibble0] = batch.GetAddress(child);
                 }
             }
+            else
+            {
+                batch.RegisterForFutureReuse(page);
+                return batch.NullPage;
+            }
         }
         else
         {

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -72,6 +72,8 @@ public interface IBatchContext : IReadOnlyBatchContext
     Page TryGetPageAlloc(ref DbAddress addr, PageType pageType);
 
     BatchStats? Stats { get; }
+
+    public unsafe Page NullPage => new Page((byte*)0);
 }
 
 public class BatchStats : IBatchStats

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -47,6 +47,11 @@ public readonly unsafe struct LeafOverflowPage(Page page) : IPage
             var writable = batch.GetWritableCopy(page);
             return new LeafOverflowPage(writable).DeleteByPrefix(prefix, batch);
         }
+        if (prefix.IsEmpty)
+        {
+            batch.RegisterForFutureReuse(page);
+            return batch.NullPage;
+        }
 
         Map.DeleteByPrefix(prefix);
 

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -520,7 +520,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         private readonly uint _reusePagesOlderThanBatchId;
         private bool _verify = false;
         private bool _disposed;
-
+           
         private readonly Context _ctx;
 
         /// <summary>

--- a/src/Paprika/Store/StateRootPage.cs
+++ b/src/Paprika/Store/StateRootPage.cs
@@ -75,6 +75,12 @@ public readonly unsafe struct StateRootPage(Page page) : IPageWithData<StateRoot
             return new StateRootPage(writable).DeleteByPrefix(prefix, batch);
         }
 
+        if (prefix.IsEmpty)
+        {
+            batch.RegisterForFutureReuse(page);
+            return batch.NullPage;
+        }
+
         Debug.Assert(prefix.Length > ConsumedNibbles, "Removing prefix at the root? Something went wrong.");
 
         var index = GetIndex(prefix);

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -188,6 +188,12 @@ public static class StorageFanOut
                 var writable = batch.GetWritableCopy(page);
                 return new Level1Page(writable).DeleteByPrefix(prefix, batch);
             }
+            if (prefix.IsEmpty)
+            {
+                batch.RegisterForFutureReuse(page);
+                return batch.NullPage;
+            }
+
 
             var index = GetIndex(prefix, Type.Storage, out var sliced);
 


### PR DESCRIPTION
Resolves #384 

List of Changes - 

1. A new property in IBatchContext called as NullPage set to new Page((*ptr)0). 
2. All DeleteByPrefix methods checking if prefix is empty, then registering the page for future reuse and returning batch.NullPage. 

Pending Changes - 
Recursively calling for child pages (if the prefix is empty) - need help here.