### PR TITLE
Flush behavior reverted

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -147,8 +147,6 @@ public class Blockchain : IAsyncDisposable
 
                 (uint _blocksByNumber, Keccak blockHash) last = default;
 
-                bool requiresForceFlush = false;
-
                 while (timer.Elapsed < _minFlushDelay && reader.TryRead(out var block))
                 {
                     last = (block.BlockNumber, block.Hash);
@@ -182,20 +180,8 @@ public class Blockchain : IAsyncDisposable
 
                     _flusherQueueCount.Set(readerCount);
 
-                    var level = readerCount switch
-                    {
-                        0 => CommitOptions.FlushDataOnly, // see: CommitOptions.FlushDataOnly
-                        1 => CommitOptions.FlushDataOnly, // see: CommitOptions.FlushDataOnly
-                        _ when readerCount <= _db.HistoryDepth => CommitOptions
-                            .DangerNoFlush, // see: CommitOptions.DangerNoFlush
-                        _ => CommitOptions.DangerNoWrite
-                    };
-
-                    // If at least one write is no write, require flush
-                    requiresForceFlush |= level == CommitOptions.DangerNoWrite;
-
                     // commit but no flush here, it's too heavy, the flush will come later
-                    await batch.Commit(level);
+                    await batch.Commit(CommitOptions.FlushDataOnly);
 
                     // inform blocks about flushing
                     lock (_blockLock)
@@ -230,14 +216,7 @@ public class Blockchain : IAsyncDisposable
 
                 var flushWatch = Stopwatch.StartNew();
 
-                if (requiresForceFlush)
-                {
-                    _db.ForceFlush();
-                }
-                else
-                {
-                    _db.Flush();
-                }
+                _db.Flush();
 
                 _flusherFlushInMs.Record((int)flushWatch.ElapsedMilliseconds);
 


### PR DESCRIPTION
This PR reverts the batching in `Blockhain.FlusherTask` that introduced a complex logic of batching some blocks if there's a lot of them in the flushing queue. After write-through introduced in #375 the block application is no longer a bottle neck and happens reasonably fast. This will also help the import/sync a lot as previously issuing `.ForceFlush` from time to time was killing the gains of using the `MMAP_ONLY` mode for these cases and was resulting in long MSYNC/FSYNC stalls.

Effectively, as the application of data is much faster now, this kind-of-optimization looks terribly dumb.