### PR TITLE
Different fanout

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -89,7 +89,7 @@ public class AbandonedTests : BasePageTests
     [TestCase(48228, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
-    [TestCase(88262, 20_000, 50, true,
+    [TestCase(118364, 20_000, 50, true,
         TestName = "Storage - 20_000 accounts with a single storage slot",
         Category = Categories.LongRunning)]
     public async Task Reuse_in_limited_environment(int pageCount, int accounts, int repeats, bool isStorage)

--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -183,7 +183,7 @@ public class PagedDbTests
         const int accounts = 512 * 1024;
         const int size = 10_000;
 
-        using var db = PagedDb.NativeMemoryDb(2 * 1024 * Mb, 2);
+        using var db = PagedDb.NativeMemoryDb(8 * 1024 * Mb, 2);
 
         var value = new byte[1] { 13 };
 

--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -279,7 +279,7 @@ public class PagedDbTests
             // stats.AbandonedCount.Should().BeGreaterThan(0);
             stats.Ids.PageCount.Should().BeGreaterThan(0);
             stats.Storage.PageCount.Should().BeGreaterThan(0);
-            stats.Storage.PageCountPerNibblePathDepth[StorageFanOut.StorageConsumedNibbles].Should().Be(size);
+            stats.Storage.PageCountPerNibblePathDepth[0].Should().Be(size);
         }
     }
 

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -16,7 +16,7 @@ namespace Paprika.Store;
 /// in the parent page, or they are flushed underneath.
 /// </remarks>
 [method: DebuggerStepThrough]
-public readonly unsafe struct DataPage(Page page) : IPage, IClearable
+public readonly unsafe struct DataPage(Page page) : IPage<DataPage>, IClearable
 {
     private const int ConsumedNibbles = 1;
     private const int BucketCount = DbAddressList.Of16.Count;
@@ -41,6 +41,7 @@ public readonly unsafe struct DataPage(Page page) : IPage, IClearable
     }
 
     public static DataPage Wrap(Page page) => Unsafe.As<Page, DataPage>(ref page);
+    public static PageType DefaultType => PageType.DataPage;
 
     public bool IsLeaf => Header.Metadata == Modes.Leaf;
 

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -16,7 +16,7 @@ namespace Paprika.Store;
 /// in the parent page, or they are flushed underneath.
 /// </remarks>
 [method: DebuggerStepThrough]
-public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>, IClearable
+public readonly unsafe struct DataPage(Page page) : IPage, IClearable
 {
     private const int ConsumedNibbles = 1;
     private const int BucketCount = DbAddressList.Of16.Count;

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -520,10 +520,10 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>, ICl
         public Span<byte> DataSpan => MemoryMarshal.CreateSpan(ref DataStart, DataSize);
     }
 
-    public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
+    public bool TryGet(IPageResolver batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
         => TryGet(batch, key, out result, this);
 
-    private static bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result,
+    private static bool TryGet(IPageResolver batch, scoped in NibblePath key, out ReadOnlySpan<byte> result,
         DataPage page)
     {
         var returnValue = false;
@@ -531,8 +531,6 @@ public readonly unsafe struct DataPage(Page page) : IPageWithData<DataPage>, ICl
 
         do
         {
-            batch.AssertRead(page.Header);
-
             if (page.Header.Metadata == Modes.Leaf)
             {
                 if (page.Map.TryGet(sliced, out result))

--- a/src/Paprika/Store/DbAddressList.cs
+++ b/src/Paprika/Store/DbAddressList.cs
@@ -188,6 +188,35 @@ public static class DbAddressList
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
+    public struct Of64 : IDbAddressList
+    {
+        public const int Count = 64;
+        public const int Size = Count / 2 * BytesPer2Addresses;
+
+        private byte _b;
+
+        public DbAddress this[int index]
+        {
+            get
+            {
+                Debug.Assert(index is >= 0 and < Count);
+                return Get(ref _b, index);
+            }
+            set
+            {
+                Debug.Assert(index is >= 0 and < Count);
+                Set(ref _b, index, value);
+            }
+        }
+
+        public void Clear() => MemoryMarshal.CreateSpan(ref _b, Size).Clear();
+
+        public static int Length => Count;
+
+        public DbAddress[] ToArray() => ToArrayImpl(this);
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
     public struct Of256 : IDbAddressList
     {
         public const int Count = 256;

--- a/src/Paprika/Store/IPageVisitor.cs
+++ b/src/Paprika/Store/IPageVisitor.cs
@@ -1,3 +1,4 @@
+using Paprika.Crypto;
 using Paprika.Data;
 
 namespace Paprika.Store;

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -16,28 +16,6 @@ public interface IPage
 {
 }
 
-public interface IPageWithData<TPage> : IPage
-    where TPage : struct, IPageWithData<TPage>
-{
-    /// <summary>
-    /// Wraps the raw page as <typeparamref name="TPage"/>
-    /// </summary>
-    static abstract TPage Wrap(Page page);
-
-    void Clear();
-
-    bool TryGet(IPageResolver batch, scoped in NibblePath key, out ReadOnlySpan<byte> result);
-
-    /// <summary>
-    /// Delete all the values by the given prefix in the page and below.
-    /// </summary>
-    Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch);
-
-    Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch);
-
-    void Accept(ref NibblePath.Builder prefix, IPageVisitor visitor, IPageResolver resolver, DbAddress addr);
-}
-
 /// <summary>
 /// Convenient methods for transforming page types.
 /// </summary>

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -16,6 +16,14 @@ public interface IPage
 {
 }
 
+public interface IPage<TPage> : IPage
+    where TPage : struct, IPage<TPage>
+{
+    public static abstract TPage Wrap(Page page);
+
+    public static abstract PageType DefaultType { get; }
+}
+
 /// <summary>
 /// Convenient methods for transforming page types.
 /// </summary>

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -26,7 +26,7 @@ public interface IPageWithData<TPage> : IPage
 
     void Clear();
 
-    bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result);
+    bool TryGet(IPageResolver batch, scoped in NibblePath key, out ReadOnlySpan<byte> result);
 
     /// <summary>
     /// Delete all the values by the given prefix in the page and below.

--- a/src/Paprika/Store/PageType.cs
+++ b/src/Paprika/Store/PageType.cs
@@ -25,7 +25,7 @@ public enum PageType : byte
     LeafOverflow = 4,
 
     /// <summary>
-    /// <see cref="StorageFanOut.Level1Page"/>
+    /// <see cref="StorageFanOut"/>
     /// </summary>
     FanOutPage = 5,
 }

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -1,4 +1,3 @@
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -147,19 +146,6 @@ public readonly unsafe struct RootPage(Page root) : IPage
         return Data.Storage.TryGetStorage(id, key.StoragePath, out result, batch);
     }
 
-    private static void WriteId(Span<byte> idSpan, uint id)
-    {
-        // Rotation of nibbles could help with an even spread but would make it worse for smaller networks.
-        // If a chain has 16 million contracts or more, this does not matter anyway.
-
-        // // Rotate nibbles so that small value goes first as the NibblePath reads them
-        // // This will distribute buckets more properly for smaller networks as StorageFanOut consumes 5 nibbles.
-        // var rotatedNibbles = ((id & 0x0F0F0F0F) << 4) | ((id & 0xF0F0F0F0) >> 4);
-        // BinaryPrimitives.WriteUInt32LittleEndian(idSpan, rotatedNibbles);
-
-        BinaryPrimitives.WriteUInt32LittleEndian(idSpan, id);
-    }
-
     public void SetRaw(in Key key, IBatchContext batch, ReadOnlySpan<byte> rawData)
     {
         if (key.IsState)
@@ -244,6 +230,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         var updated = new StateRootPage(data).Set(path, rawData, batch);
         root = batch.GetAddress(updated);
     }
+
 }
 
 [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -1,15 +1,9 @@
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Paprika.Crypto;
 using Paprika.Data;
-
-// The definition what kind of page is used on Level2
-#if !USE_BIG_FANOUT
-using Level2 = Paprika.Store.DataPage;
-#else
-using Level2 = Paprika.Store.StorageFanOut.Level2Page;
-#endif
-
 
 namespace Paprika.Store;
 
@@ -22,7 +16,7 @@ public static class StorageFanOut
     public const string ScopeIds = "Ids";
     public const string ScopeStorage = "Storage";
 
-    public enum Type
+    private enum Type
     {
         /// <summary>
         /// Represents the mapping of Keccak->int
@@ -35,11 +29,6 @@ public static class StorageFanOut
         Storage
     }
 
-    private const byte NibbleHalfLower = 0b0011;
-    private const byte NibbleHalfHigher = 0b1100;
-    private const byte NibbleHalfShift = NibblePath.NibbleShift / 2;
-    private const byte TwoNibbleShift = NibblePath.NibbleShift * 2;
-
     /// <summary>
     /// Provides a convenient data structure for <see cref="RootPage"/>,
     /// to hold a list of child addresses of <see cref="DbAddressList.IDbAddressList"/> but with addition of
@@ -49,10 +38,10 @@ public static class StorageFanOut
     {
         private readonly ref DbAddressList.Of1024 _addresses = ref addresses;
 
-        public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, Type type,
+        private bool TryGet(IReadOnlyBatchContext batch, uint at, scoped in NibblePath key, Type type,
             out ReadOnlySpan<byte> result)
         {
-            var index = GetIndex(key, out var sliced);
+            var (next, index) = GetIndex(at);
 
             var addr = _addresses[index];
             if (addr.IsNull)
@@ -62,12 +51,12 @@ public static class StorageFanOut
             }
 
             return Level1Page.Wrap(batch.GetAt(addr))
-                .TryGet(batch, sliced, type, out result);
+                .TryGet(batch, next, key, type, out result);
         }
 
-        public void Set(in NibblePath key, Type type, in ReadOnlySpan<byte> data, IBatchContext batch)
+        private void Set(IBatchContext batch, uint at, in NibblePath key, Type type, in ReadOnlySpan<byte> data)
         {
-            var index = GetIndex(key, out var sliced);
+            var (next, index) = GetIndex(at);
             var addr = _addresses[index];
 
             if (addr.IsNull)
@@ -78,42 +67,17 @@ public static class StorageFanOut
                 newPage.Header.PageType = PageType.FanOutPage;
                 newPage.Header.Level = ConsumedNibbles;
 
-                Level1Page.Wrap(newPage).Set(sliced, type, data, batch);
+                Level1Page.Wrap(newPage).Set(next, key, type, data, batch);
                 return;
             }
 
             // The page exists, update
-            var updated = Level1Page.Wrap(batch.GetAt(addr)).Set(sliced, type, data, batch);
+            var updated = Level1Page.Wrap(batch.GetAt(addr)).Set(next, key, type, data, batch);
             _addresses[index] = batch.GetAddress(updated);
         }
 
-        public void DeleteByPrefix(in NibblePath path, IBatchContext batch)
-        {
-            var index = GetIndex(path, out var sliced);
-            var addr = _addresses[index];
-
-            if (addr.IsNull)
-            {
-                return;
-            }
-
-            // The page exists, update
-            var updated = Level1Page.Wrap(batch.GetAt(addr)).DeleteByPrefix(sliced, batch);
-            _addresses[index] = batch.GetAddress(updated);
-        }
-
-        private static int GetIndex(scoped in NibblePath key, out NibblePath sliced)
-        {
-            Debug.Assert(key.IsOdd == false);
-
-            // Consume 2 first nibbles as raw byte, shift and add lower half
-            var at = (key.UnsafeSpan << NibbleHalfShift) + (key.GetAt(2) & NibbleHalfLower);
-
-            Debug.Assert(0 <= at && at < DbAddressList.Of1024.Count);
-
-            sliced = key.SliceFrom(ConsumedNibbles);
-            return at;
-        }
+        private static (uint next, int index) GetIndex(uint at) =>
+            ((uint next, int index))Math.DivRem(at, DbAddressList.Of1024.Length);
 
         public const int ConsumedNibbles = 2;
 
@@ -126,9 +90,72 @@ public static class StorageFanOut
                 var addr = _addresses[i];
                 if (!addr.IsNull)
                 {
-                    Level1Page.Wrap(resolver.GetAt(addr)).Accept(i, visitor, resolver, addr);
+                    Level1Page.Wrap(resolver.GetAt(addr)).Accept(visitor, resolver, addr);
                 }
             }
+        }
+
+        public bool TryGetId(in Keccak keccak, out uint id, IReadOnlyBatchContext batch)
+        {
+            var at = BuildIdIndex(NibblePath.FromKey(keccak), out var sliced);
+
+            if (TryGet(batch, at, sliced, Type.Id, out var result))
+            {
+                id = BinaryPrimitives.ReadUInt32LittleEndian(result);
+                return true;
+            }
+
+            id = default;
+            return false;
+        }
+
+        public void SetId(Keccak keccak, uint id, IBatchContext batch)
+        {
+            var at = BuildIdIndex(NibblePath.FromKey(keccak), out var sliced);
+
+            Span<byte> span = stackalloc byte[4];
+            BinaryPrimitives.WriteUInt32LittleEndian(span, id);
+
+            Set(batch, at, sliced, Type.Id, span);
+        }
+
+        private static uint BuildIdIndex(in NibblePath path, out NibblePath sliced)
+        {
+            // Combined 1024 at level0 + 64 at level 1 for 
+            Debug.Assert(DbAddressList.Of1024.Length * DbAddressList.Of64.Length == 16 * 16 * 16 * 16,
+                "Should combine properly");
+
+            sliced = path.SliceFrom(4);
+
+            return (uint)
+                ((path.Nibble0 << (NibblePath.NibbleShift * 3)) +
+                 (path.GetAt(1) << (NibblePath.NibbleShift * 2)) +
+                 (path.GetAt(2) << (NibblePath.NibbleShift * 1)) +
+                 path.GetAt(3));
+        }
+
+        public bool TryGetStorage(uint id, scoped in NibblePath path, out ReadOnlySpan<byte> result,
+            IReadOnlyBatchContext batch) =>
+            TryGet(batch, id, path, Type.Storage, out result);
+
+        public void SetStorage(uint id, scoped in NibblePath path, ReadOnlySpan<byte> data, IBatchContext batch)
+        {
+            Set(batch, id, path, Type.Storage, data);
+        }
+
+        public void DeleteStorageByPrefix(uint id, scoped in NibblePath prefix, IBatchContext batch)
+        {
+            var (next, index) = GetIndex(id);
+            var addr = _addresses[index];
+
+            if (addr.IsNull)
+            {
+                return;
+            }
+
+            // The page exists, update
+            _addresses[index] =
+                batch.GetAddress(Level1Page.Wrap(batch.GetAt(addr)).DeleteByPrefix(next, prefix, batch));
         }
     }
 
@@ -147,14 +174,29 @@ public static class StorageFanOut
 
         private ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
-        public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, Type type,
+        public bool TryGet(IReadOnlyBatchContext batch, uint at, scoped in NibblePath key, Type type,
             out ReadOnlySpan<byte> result)
         {
             batch.AssertRead(Header);
 
-            var index = GetIndex(key, type, out var sliced);
+            DbAddress addr;
 
-            var addr = type == Type.Id ? Data.Ids[index] : Data.Storage[index];
+            if (type == Type.Id)
+            {
+                addr = Data.Ids[(int)at];
+                if (addr.IsNull)
+                {
+                    result = default;
+                    return false;
+                }
+
+                return DataPage.Wrap(batch.GetAt(addr)).TryGet(batch, key, out result);
+            }
+
+            Debug.Assert(type == Type.Storage);
+
+            var (next, index) = GetStorageIndex(at);
+            addr = Data.Storage[index];
 
             if (addr.IsNull)
             {
@@ -162,46 +204,68 @@ public static class StorageFanOut
                 return false;
             }
 
-            var p = batch.GetAt(addr);
-
-            return type == Type.Id
-                ? DataPage.Wrap(p).TryGet(batch, sliced, out result)
-                : Level2.Wrap(p).TryGet(batch, sliced, out result);
+            return Level2Page.Wrap(batch.GetAt(addr)).TryGet(batch, next, key, out result);
         }
 
-        public Page Set(in NibblePath key, Type type, in ReadOnlySpan<byte> data, IBatchContext batch)
+        private static (uint next, int index) GetStorageIndex(uint at) =>
+            ((uint next, int index))Math.DivRem(at, DbAddressList.Of1024.Length);
+
+        public Page Set(uint at, in NibblePath key, Type type, in ReadOnlySpan<byte> data, IBatchContext batch)
         {
             if (Header.BatchId != batch.BatchId)
             {
                 // the page is from another batch, meaning, it's readonly. Copy
                 var writable = batch.GetWritableCopy(page);
-                return new Level1Page(writable).Set(key, type, data, batch);
+                return new Level1Page(writable).Set(at, key, type, data, batch);
             }
 
-            var index = GetIndex(key, type, out var sliced);
+            DbAddress addr;
 
             if (type == Type.Id)
             {
-                Set<DbAddressList.Of4, DataPage>(ref Data.Ids, index, sliced, data, batch, Level1ConsumedNibblesForIds);
+                addr = Data.Ids[(int)at];
+                if (addr.IsNull)
+                {
+                    var p = batch.GetNewPage(out addr, false);
+                    p.Header.PageType = PageType.DataPage;
+                    p.Header.Level = 0;
+
+                    new DataPage(p).Clear();
+                }
+
+                Data.Ids[(int)at] = batch.GetAddress(DataPage.Wrap(batch.GetAt(addr)).Set(key, data, batch));
+                return page;
             }
-            else
+
+            Debug.Assert(type == Type.Storage);
+
+            var (next, index) = GetStorageIndex(at);
+            addr = Data.Storage[index];
+
+            if (addr.IsNull)
             {
-                Set<DbAddressList.Of1024, Level2>(ref Data.Storage, index, sliced, data, batch, Level1ConsumedNibblesForStorage);
+                var p = batch.GetNewPage(out addr, false);
+                p.Header.PageType = PageType.FanOutPage;
+
+                var ids = new Level2Page(p);
+                ids.Clear();
             }
+
+            Data.Storage[(int)at] = batch.GetAddress(Level2Page.Wrap(batch.GetAt(addr)).Set(next, key, data, batch));
 
             return page;
         }
 
-        public Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
+        public Page DeleteByPrefix(uint at, in NibblePath prefix, IBatchContext batch)
         {
             if (Header.BatchId != batch.BatchId)
             {
                 // the page is from another batch, meaning, it's readonly.
                 var writable = batch.GetWritableCopy(page);
-                return new Level1Page(writable).DeleteByPrefix(prefix, batch);
+                return new Level1Page(writable).DeleteByPrefix(at, prefix, batch);
             }
 
-            var index = GetIndex(prefix, Type.Storage, out var sliced);
+            var (next, index) = GetStorageIndex(at);
 
             var addr = Data.Storage[index];
 
@@ -211,61 +275,10 @@ public static class StorageFanOut
             }
 
             // update after set
-            addr = batch.GetAddress(Level2.Wrap(batch.GetAt(addr)).DeleteByPrefix(sliced, batch));
-            Data.Storage[index] = addr;
+            Data.Storage[index] =
+                batch.GetAddress(Level2Page.Wrap(batch.GetAt(addr)).DeleteByPrefix(next, prefix, batch));
 
             return page;
-        }
-
-        private void Set<TAddressList, TPage>(ref TAddressList list, int index, in NibblePath sliced,
-            in ReadOnlySpan<byte> data,
-            IBatchContext batch, int consumedNibbles)
-            where TAddressList : struct, DbAddressList.IDbAddressList
-            where TPage : struct, IPageWithData<TPage>
-        {
-            var addr = list[index];
-
-            if (addr.IsNull)
-            {
-                // Clear manually
-                var newPage = batch.GetNewPage(out addr, false);
-
-                list[index] = addr;
-
-                newPage.Header.PageType = PageType.DataPage;
-                newPage.Header.Level = (byte)(Header.Level + consumedNibbles);
-
-                var dataPage = TPage.Wrap(newPage);
-                dataPage.Clear();
-                dataPage.Set(sliced, data, batch);
-                return;
-            }
-
-            // update after set
-            addr = batch.GetAddress(TPage.Wrap(batch.GetAt(addr)).Set(sliced, data, batch));
-            list[index] = addr;
-        }
-
-        private static int GetIndex(scoped in NibblePath key, Type type, out NibblePath sliced)
-        {
-            // Represents high part of the first nibble but lowered
-            var hi = (key.Nibble0 & NibbleHalfHigher) >> NibbleHalfShift;
-
-            Debug.Assert(0 <= hi && hi < 4);
-
-            if (type == Type.Id)
-            {
-                sliced = key.SliceFrom(Level1ConsumedNibblesForIds);
-                return hi;
-            }
-
-            var at = (hi << TwoNibbleShift) + // 0.5 nibble
-                     (key.GetAt(1) << NibblePath.NibbleShift) + // 1 nibble 
-                     key.GetAt(2); // 1 nibble
-            Debug.Assert(0 <= at && at < DbAddressList.Of1024.Count);
-
-            sliced = key.SliceFrom(Level1ConsumedNibblesForStorage);
-            return at;
         }
 
         /// <summary>
@@ -278,60 +291,36 @@ public static class StorageFanOut
         /// </summary>
         public const int Level1ConsumedNibblesForStorage = 3;
 
-        public void Accept(int bucketOf1024, IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
+        public void Accept(IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
         {
-            Debug.Assert(bucketOf1024 < DbAddressList.Of1024.Count,
-                $"The buckets should be within the range of level 0 which uses {nameof(DbAddressList.Of1024)}");
-
             var builder = new NibblePath.Builder(stackalloc byte[NibblePath.Builder.DecentSize]);
 
-            var nibble0 = (byte)((bucketOf1024 >> (NibblePath.NibbleShift + NibbleHalfShift)) & NibblePath.NibbleMask);
-            var nibble1 = (byte)((bucketOf1024 >> NibbleHalfShift) & NibblePath.NibbleMask);
-            var nibble2Low = (byte)(bucketOf1024 & NibbleHalfLower);
+            using var scope = visitor.On(ref builder, this, addr);
 
-            builder.Push(nibble0, nibble1);
+            using (visitor.Scope(ScopeIds))
             {
-                using var scope = visitor.On(ref builder, this, addr);
-
-                using (visitor.Scope(ScopeIds))
+                for (var i = 0; i < DbAddressList.Of64.Count; i++)
                 {
-                    for (var i = 0; i < DbAddressList.Of4.Count; i++)
+                    var bucket = Data.Ids[i];
+
+                    if (!bucket.IsNull)
                     {
-                        var bucket = Data.Ids[i];
-
-                        if (!bucket.IsNull)
-                        {
-                            builder.Push((byte)((i << NibbleHalfShift) | nibble2Low));
-                            {
-                                DataPage.Wrap(resolver.GetAt(bucket)).Accept(ref builder, visitor, resolver, bucket);
-                            }
-                            builder.Pop();
-                        }
-                    }
-                }
-
-                using (visitor.Scope(ScopeStorage))
-                {
-                    for (var i = 0; i < DbAddressList.Of1024.Count; i++)
-                    {
-                        var bucket = Data.Storage[i];
-                        if (!bucket.IsNull)
-                        {
-                            var nibbleStart = i >> (NibblePath.NibbleShift + NibbleHalfShift);
-
-                            builder.Push((byte)((nibbleStart & NibbleHalfHigher) | nibble2Low));
-                            builder.Push((byte)((i >> NibblePath.NibbleShift) & NibblePath.NibbleMask));
-                            builder.Push((byte)((i >> NibbleHalfShift) & NibblePath.NibbleMask));
-
-                            Level2.Wrap(resolver.GetAt(bucket)).Accept(ref builder, visitor, resolver, bucket);
-
-                            builder.Pop(3);
-                        }
+                        DataPage.Wrap(resolver.GetAt(bucket)).Accept(ref builder, visitor, resolver, bucket);
                     }
                 }
             }
 
-            builder.Pop(2);
+            using (visitor.Scope(ScopeStorage))
+            {
+                for (var i = 0; i < DbAddressList.Of1024.Count; i++)
+                {
+                    var bucket = Data.Storage[i];
+                    if (!bucket.IsNull)
+                    {
+                        Level2Page.Wrap(resolver.GetAt(bucket)).Accept(ref builder, visitor, resolver, bucket);
+                    }
+                }
+            }
 
             builder.Dispose();
         }
@@ -344,46 +333,33 @@ public static class StorageFanOut
             /// <summary>
             /// Ids are mapped using a single half-nibble
             /// </summary>
-            [FieldOffset(0)] public DbAddressList.Of4 Ids;
+            [FieldOffset(0)] public DbAddressList.Of64 Ids;
 
             /// <summary>
             /// Storage is mapped further by another 2.5 nibble, making it 5 in total.
             /// </summary>
-            [FieldOffset(DbAddressList.Of4.Size)] public DbAddressList.Of1024 Storage;
+            [FieldOffset(DbAddressList.Of64.Size)] public DbAddressList.Of1024 Storage;
         }
     }
 
-    /// <summary>
-    /// This page is used purely for storage purposes, no ids.
-    /// </summary>
-    /// <param name="page"></param>
     [method: DebuggerStepThrough]
-    public readonly unsafe struct Level2Page(Page page) : IPageWithData<Level2Page>
+    public readonly unsafe struct Level2Page(Page page) : IPage
     {
         public static Level2Page Wrap(Page page) => Unsafe.As<Page, Level2Page>(ref page);
 
-        public void Clear()
-        {
-            new SlottedArray(Data.Data).Clear();
-            Data.Addresses.Clear();
-        }
-
-        private const int ConsumedNibbles = 2;
+        public void Clear() => Data.Addresses.Clear();
 
         private ref PageHeader Header => ref page.Header;
 
         private ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
-        public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
+        private static (uint next, int index) GetStorageIndex(uint at) =>
+            ((uint next, int index))Math.DivRem(at, DbAddressList.Of1024.Length);
+
+        public bool TryGet(IReadOnlyBatchContext batch, uint at, scoped in NibblePath key,
+            out ReadOnlySpan<byte> result)
         {
-            var map = new SlottedArray(Data.Data);
-
-            if (map.TryGet(key, out result))
-            {
-                return true;
-            }
-
-            var index = GetIndex(key);
+            var (next, index) = GetStorageIndex(at);
 
             var addr = Data.Addresses[index];
             if (addr.IsNull)
@@ -392,76 +368,47 @@ public static class StorageFanOut
                 return false;
             }
 
-            return DataPage.Wrap(batch.GetAt(addr)).TryGet(batch, key.SliceFrom(ConsumedNibbles), out result);
+            return Level3Page.Wrap(batch.GetAt(addr)).TryGet(batch, next, key, out result);
         }
 
         private static int GetIndex(scoped in NibblePath key) =>
             (key.Nibble0 << NibblePath.NibbleShift) + key.GetAt(1);
 
-        public Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+        public Page Set(uint at, in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
         {
             if (Header.BatchId != batch.BatchId)
             {
                 // the page is from another batch, meaning, it's readonly. Copy
                 var writable = batch.GetWritableCopy(page);
-                return new Level2Page(writable).Set(key, data, batch);
+                return new Level2Page(writable).Set(at, key, data, batch);
             }
 
-            var map = new SlottedArray(Data.Data);
+            var (next, index) = GetStorageIndex(at);
+            var addr = Data.Addresses[index];
 
-            if (map.TrySet(key, data))
+            if (addr.IsNull)
             {
-                return page;
+                var p = batch.GetNewPage(out addr, false);
+                p.Header.PageType = PageType.FanOutPage;
+
+                new Level3Page(p).Clear();
             }
 
-            // No space in page, flush down
-            foreach (var item in map.EnumerateAll())
-            {
-                var index = GetIndex(item.Key);
-                var sliced = item.Key.SliceFrom(ConsumedNibbles);
+            Data.Addresses[(int)at] = batch.GetAddress(Level3Page.Wrap(batch.GetAt(addr)).Set(next, key, data, batch));
 
-                var addr = Data.Addresses[index];
-
-                Page child;
-
-                if (addr.IsNull)
-                {
-                    child = batch.GetNewPage(out addr, true);
-                    child.Header.PageType = Header.PageType;
-                    child.Header.Level = (byte)(page.Header.Level + ConsumedNibbles);
-                }
-                else
-                {
-                    child = batch.GetAt(addr);
-                }
-
-                // Set and delete
-                Data.Addresses[index] = batch.GetAddress(DataPage.Wrap(child).Set(sliced, item.RawData, batch));
-            }
-
-            // All is pushed down
-            map.Clear();
-
-            // retry
-            return Set(key, data, batch);
+            return page;
         }
 
-        public Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
+        public Page DeleteByPrefix(uint at, in NibblePath prefix, IBatchContext batch)
         {
             if (Header.BatchId != batch.BatchId)
             {
                 // the page is from another batch, meaning, it's readonly. Copy
                 var writable = batch.GetWritableCopy(page);
-                return new Level2Page(writable).DeleteByPrefix(prefix, batch);
+                return new Level2Page(writable).DeleteByPrefix(at, prefix, batch);
             }
 
-            var map = new SlottedArray(Data.Data);
-
-            map.DeleteByPrefix(prefix);
-
-            var index = GetIndex(prefix);
-            var sliced = prefix.SliceFrom(ConsumedNibbles);
-
+            var (next, index) = GetStorageIndex(at);
             var addr = Data.Addresses[index];
 
             if (addr.IsNull)
@@ -469,10 +416,8 @@ public static class StorageFanOut
                 return page;
             }
 
-            var child = batch.GetAt(addr);
-
-            // Delete in child
-            Data.Addresses[index] = batch.GetAddress(DataPage.Wrap(child).DeleteByPrefix(sliced, batch));
+            Data.Addresses[(int)at] =
+                batch.GetAddress(Level3Page.Wrap(batch.GetAt(addr)).DeleteByPrefix(next, prefix, batch));
 
             return page;
         }
@@ -481,19 +426,15 @@ public static class StorageFanOut
         {
             resolver.Prefetch(Data.Addresses);
 
-            using var scope = visitor.On(this, addr);
+            using var scope = visitor.On(ref builder, this, addr);
 
-            for (var i = 0; i < DbAddressList.Of256.Length; i++)
+            for (var i = 0; i < DbAddressList.Of1024.Length; i++)
             {
                 var bucket = Data.Addresses[i];
 
                 if (!bucket.IsNull)
                 {
-                    builder.Push((byte)(i >> NibblePath.NibbleShift), (byte)(i & NibblePath.NibbleMask));
-                    {
-                        DataPage.Wrap(resolver.GetAt(bucket)).Accept(ref builder, visitor, resolver, bucket);
-                    }
-                    builder.Pop(2);
+                    Level3Page.Wrap(resolver.GetAt(bucket)).Accept(ref builder, visitor, resolver, bucket);
                 }
             }
         }
@@ -503,15 +444,170 @@ public static class StorageFanOut
         {
             private const int Size = Page.PageSize - PageHeader.Size;
 
-            private const int FanOutSize = DbAddressList.Of256.Size;
+            [FieldOffset(0)] public DbAddressList.Of1024 Addresses;
+        }
+    }
 
-            private const int DataSize = Size - FanOutSize;
+    [method: DebuggerStepThrough]
+    public readonly unsafe struct Level3Page(Page page) : IPage
+    {
+        public static Level3Page Wrap(Page page) => Unsafe.As<Page, Level3Page>(ref page);
 
-            [FieldOffset(0)] public DbAddressList.Of256 Addresses;
+        private ref PageHeader Header => ref page.Header;
 
-            [FieldOffset(FanOutSize)] private byte DataFirst;
+        private ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
-            public Span<byte> Data => MemoryMarshal.CreateSpan(ref DataFirst, DataSize);
+        public void Clear()
+        {
+            // ref var iteration to do not clear copies!
+            foreach (ref var bucket in Data.Buckets)
+            {
+                bucket.Clear();
+            }
+        }
+
+        public bool TryGet(IReadOnlyBatchContext batch, uint at, in NibblePath key, out ReadOnlySpan<byte> result)
+        {
+            return Data.Buckets[(int)at].TryGet(batch, key, out result);
+        }
+
+        public Page Set(uint at, in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+        {
+            if (Header.BatchId != batch.BatchId)
+            {
+                // the page is from another batch, meaning, it's readonly. Copy
+                var writable = batch.GetWritableCopy(page);
+                return new Level3Page(writable).Set(at, key, data, batch);
+            }
+
+            Data.Buckets[(int)at].Set(key, data, batch);
+
+            return page;
+        }
+
+        public Page DeleteByPrefix(uint at, in NibblePath prefix, IBatchContext batch)
+        {
+            if (Header.BatchId != batch.BatchId)
+            {
+                // the page is from another batch, meaning, it's readonly. Copy
+                var writable = batch.GetWritableCopy(page);
+                return new Level3Page(writable).DeleteByPrefix(at, prefix, batch);
+            }
+
+            Data.Buckets[(int)at].DeleteByPrefix(prefix, batch);
+
+            return page;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = Size)]
+        private struct Payload
+        {
+            private const int Size = Page.PageSize - PageHeader.Size;
+
+            [FieldOffset(Bucket.Size * 0)] private Bucket Bucket0;
+
+            public Span<Bucket> Buckets => MemoryMarshal.CreateSpan(ref Bucket0, Size / Bucket.Size);
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = Size)]
+        private struct Bucket
+        {
+            public const int Size = 1016;
+            private const int DataSize = Size - DbAddress.Size;
+
+            [FieldOffset(0)] public DbAddress Root;
+
+            [FieldOffset(DbAddress.Size)] private byte _first;
+
+            private SlottedArray Map => new(MemoryMarshal.CreateSpan(ref _first, DataSize));
+
+            public void Clear()
+            {
+                Root = default;
+                Map.Clear();
+            }
+
+            public bool TryGet(IReadOnlyBatchContext batch, in NibblePath key, out ReadOnlySpan<byte> result)
+            {
+                if (Map.TryGet(key, out result))
+                {
+                    return true;
+                }
+
+                if (Root.IsNull)
+                    return false;
+
+                return new DataPage(batch.GetAt(Root)).TryGet(batch, key, out result);
+            }
+
+            public void Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+            {
+                if (Map.TrySet(key, data))
+                    return;
+
+                if (Root.IsNull)
+                {
+                    var page = batch.GetNewPage(out Root, false);
+                    page.Header.PageType = PageType.DataPage;
+                    page.Header.Level = 0;
+
+                    // clear
+                    new DataPage(page).Clear();
+                }
+
+                var root = new DataPage(batch.GetAt(Root));
+
+                if (batch.WasWritten(Root))
+                {
+                    // written this batch, write through
+                    Map.Delete(key);
+                    root.Set(key, data, batch);
+                    return;
+                }
+
+                // COW
+                root = new DataPage(batch.EnsureWritableCopy(ref Root));
+
+                foreach (var item in Map.EnumerateAll())
+                {
+                    var result = root.Set(item.Key, item.RawData, batch);
+                    Debug.Assert(result.Raw == root.AsPage().Raw);
+                }
+
+                // Clear map, all copied
+                Map.Clear();
+
+                // Set below
+                root.Set(key, data, batch);
+            }
+
+            public void DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
+            {
+                Map.DeleteByPrefix(prefix);
+
+                if (Root.IsNull)
+                    return;
+
+                Root = batch.GetAddress(new DataPage(batch.GetAt(Root)).DeleteByPrefix(prefix, batch));
+            }
+
+            public void Accept(ref NibblePath.Builder builder, IPageVisitor visitor, IPageResolver resolver)
+            {
+                if (Root.IsNull)
+                    return;
+
+                new DataPage(resolver.GetAt(Root)).Accept(ref builder, visitor, resolver, Root);
+            }
+        }
+
+        public void Accept(ref NibblePath.Builder builder, IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
+        {
+            using var scope = visitor.On(ref builder, this, addr);
+
+            foreach (ref var bucket in Data.Buckets)
+            {
+                bucket.Accept(ref builder, visitor, resolver);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR amends layout of storage one more time. It makes `StorageFanOut` to be split into levels Level0, Level1, Level2, Level3. This allows to align it better with the `Keccak` -> `uint` mapping and use the id that `Keccak` is mapped to directly, without path appending. 

The levels:

- `Level0` - embedded in `RootPage` provides an initial fan out of `1024`. Both `Keccak`->`uint` mapping as well as the actual storage goes through this
- `Level1` separates `Ids` from the `Storage`
   -  `Ids` provides a fanout of `64` that effectively gives 64k buckets for `Keccak`s to be mapped to
   - `Storage`provides additional fanout of `1024` consuming another 10 bits of `uint` contract id.
- `Level2` consumes next 10 bits providing the fan out of `1024`
- `Level3` has only 2 bits left for addressing (32 - 10 + 10 + 10). It uses it to address the contract in one of the 4 buckets in the page

The crux lies in how the bits of `uint` id of the contract are consumed. They are consumed from the highest to the lowest, meaning that two consecutive ids like `1U` and `2U` will have the save `Level1` and `Level2` and will reside in two different buckets of the same page `Level3`. This should ease with navigation through the tree but at the same time make the db smaller for smaller networks (less contracts -> smaller number of buckets used on Level0 that spreads across highest 10 bits of uint id).

### Ethereum mainnet

Importing Ethereum mainnet with `Paprika.Importer` shows a great reduction of application time (simpler logic for addressing, better inserts). This should also reduce the reading time as to get to an contract storage slot one need to go through 3 levels of the fanout pages (level0 is at the root) and then start querying. It should be top 5 levels of pages that should be scanned.

#### Import stats

![image](https://github.com/user-attachments/assets/54076994-1ac6-401c-9041-efa1891f2fbc)

#### CLI stats

![image](https://github.com/user-attachments/assets/446d9a92-bb0d-4b4c-b80c-f19941290a64)




