### PR TITLE
Paprika.Cli verify

### DIFF
--- a/src/Paprika.Cli/Program.cs
+++ b/src/Paprika.Cli/Program.cs
@@ -7,6 +7,7 @@ app.Configure(cfg =>
 {
     cfg.AddCommand<StatisticsSettings.Command>("stats");
     cfg.AddCommand<StorageVisitSettings.Command>("storage");
+    cfg.AddCommand<VerifyWholeTreeSettings.Command>("verify");
 
     cfg.SetExceptionHandler(ex =>
     {

--- a/src/Paprika.Cli/VerifyWholeTreeSettings.cs
+++ b/src/Paprika.Cli/VerifyWholeTreeSettings.cs
@@ -1,0 +1,29 @@
+﻿using Paprika.Chain;
+using Paprika.Merkle;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Paprika.Cli;
+
+public class VerifyWholeTreeSettings : BasePaprikaSettings
+{
+    public class Command : Command<VerifyWholeTreeSettings>
+    {
+        public override int Execute(CommandContext context, VerifyWholeTreeSettings settings)
+        {
+            using var db = settings.BuildDb();
+
+            using var read = db.BeginReadOnlyBatch();
+            using var latest = Blockchain.StartReadOnlyLatestFromDb(db);
+
+            AnsiConsole.WriteLine("Checking whole tree...");
+
+            var keccak = new ComputeMerkleBehavior().CalculateStateRootHash(latest);
+
+            AnsiConsole.WriteLine($"Keccak {keccak.ToString()}");
+
+
+            return 0;
+        }
+    }
+}

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -342,9 +342,9 @@ public class Blockchain : IAsyncDisposable
         return new ReadOnlyState(keccak, new ReadOnlyBatchCountingRefs(batch), ancestors, filter, _pool);
     }
 
-    public IReadOnlyWorldState StartReadOnlyLatestFromDb()
+    public static IReadOnlyWorldState StartReadOnlyLatestFromDb(IDb db)
     {
-        var batch = _db.BeginReadOnlyBatch($"Blockchain dependency LATEST");
+        var batch = db.BeginReadOnlyBatch($"Blockchain dependency LATEST");
         return new ReadOnlyState(batch.Metadata.StateHash, new ReadOnlyBatchCountingRefs(batch), []);
     }
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -84,7 +84,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     /// Calculates state root hash, passing through all the account and storage tries and building a new value
     /// that is not based on any earlier calculation. It's time consuming.
     /// </summary>
-    public Keccak CalculateStateRootHash(IReadOnlyWorldState commit)
+    public Keccak CalculateStateRootHash(IReadOnlyCommit commit)
     {
         const ComputeHint hint = ComputeHint.ForceStorageRootHashRecalculation | ComputeHint.SkipCachedInformation;
         var wrapper = new CommitWrapper(commit, true);
@@ -98,7 +98,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         return value.Keccak;
     }
 
-    public Keccak CalculateStorageHash(IReadOnlyWorldState commit, in Keccak account, NibblePath storagePath = default)
+    public Keccak CalculateStorageHash(IReadOnlyCommit commit, in Keccak account, NibblePath storagePath = default)
     {
         const ComputeHint hint = ComputeHint.DontUseParallel | ComputeHint.SkipCachedInformation;
         var prefixed = new PrefixingCommit(new CommitWrapper(commit));
@@ -114,10 +114,10 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
     class CommitWrapper : IChildCommit
     {
-        private readonly IReadOnlyWorldState _readOnly;
+        private readonly IReadOnlyCommit _readOnly;
         private readonly bool _allowChildCommits;
 
-        public CommitWrapper(IReadOnlyWorldState readOnly, bool allowChildCommits = false)
+        public CommitWrapper(IReadOnlyCommit readOnly, bool allowChildCommits = false)
         {
             _readOnly = readOnly;
             _allowChildCommits = allowChildCommits;


### PR DESCRIPTION
This PR introduces `verify` command to `Paprika.Cli` that allows to verify the root hash of any Paprika db

```bash
Paprika.Cli.exe verify E:\nethermind_db\mainnet\state 512 32

Checking whole tree...
Keccak 0x97712742cb514f8d229db3fadf53bc131556d0239590276333dffd4b65fbd956
```

