### PR TITLE
Reduce usage of explicit disposable

### DIFF
--- a/src/Paprika.Tests/Store/ValueSquashingDictionaryVisitor.cs
+++ b/src/Paprika.Tests/Store/ValueSquashingDictionaryVisitor.cs
@@ -44,12 +44,12 @@ public class ValueSquashingDictionaryVisitor(IPageResolver resolver) : IPageVisi
                 break;
         }
 
-        return Disposable.Instance;
+        return NoopDisposable.Instance;
     }
 
     public IDisposable On<TPage>(TPage page, DbAddress addr)
         where TPage : unmanaged, IPage =>
-        Disposable.Instance;
+        NoopDisposable.Instance;
 
-    public IDisposable Scope(string name) => Disposable.Instance;
+    public IDisposable Scope(string name) => NoopDisposable.Instance;
 }

--- a/src/Paprika/NoopDisposable.cs
+++ b/src/Paprika/NoopDisposable.cs
@@ -1,0 +1,37 @@
+﻿namespace Paprika;
+
+/// <summary>
+/// An <see cref="IDisposable"/> that does nothing.
+/// </summary>
+public sealed class NoopDisposable : IDisposable
+{
+    private NoopDisposable() { }
+
+    public static readonly IDisposable Instance = new NoopDisposable();
+
+    public void Dispose()
+    {
+
+    }
+}
+
+/// <summary>
+/// An <see cref="IDisposable"/> that allows composing disposables.
+/// </summary>
+public sealed class CompositeDisposable<T> : IDisposable
+    where T : IDisposable
+{
+    private readonly List<T> _items = new();
+
+    public void Add(T disposable) => _items.Add(disposable);
+
+    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+
+    public void Dispose()
+    {
+        foreach (var disposable in _items)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/src/Paprika/Store/IPageVisitor.cs
+++ b/src/Paprika/Store/IPageVisitor.cs
@@ -20,17 +20,3 @@ public interface IVisitable
 {
     void Accept(IPageVisitor visitor);
 }
-
-public sealed class Disposable : IDisposable
-{
-    private Disposable()
-    {
-    }
-
-    public static readonly IDisposable Instance = new Disposable();
-
-    public void Dispose()
-    {
-
-    }
-}

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -910,7 +910,7 @@ internal class MissingPagesVisitor : IPageVisitor, IDisposable
         return Mark(addr);
     }
 
-    public IDisposable Scope(string name) => Disposable.Instance;
+    public IDisposable Scope(string name) => NoopDisposable.Instance;
 
     private static TDestinationPage As<TPage, TDestinationPage>(in TPage page)
         where TDestinationPage : IPage
@@ -931,7 +931,7 @@ internal class MissingPagesVisitor : IPageVisitor, IDisposable
     private IDisposable Mark(DbAddress addr)
     {
         _pages[addr] = false;
-        return Disposable.Instance;
+        return NoopDisposable.Instance;
     }
 
     public void Dispose() => _pages.Dispose();

--- a/src/Paprika/Store/StatisticsVisitor.cs
+++ b/src/Paprika/Store/StatisticsVisitor.cs
@@ -128,7 +128,7 @@ public class StatisticsVisitor : IPageVisitor
             }
         }
 
-        return Disposable.Instance;
+        return NoopDisposable.Instance;
     }
 
     public IDisposable On<TPage>(TPage page, DbAddress addr) where TPage : unmanaged, IPage
@@ -140,7 +140,7 @@ public class StatisticsVisitor : IPageVisitor
             AbandonedCount += new AbandonedPage(page.AsPage()).CountPages();
         }
 
-        return Disposable.Instance;
+        return NoopDisposable.Instance;
     }
 
     private void IncTotalVisited()
@@ -162,7 +162,7 @@ public class StatisticsVisitor : IPageVisitor
                 _current = Storage;
                 return new ModeScope(this, previous);
             case nameof(StorageFanOut):
-                return Disposable.Instance;
+                return NoopDisposable.Instance;
             default:
                 throw new NotImplementedException($"Not implemented for {name}");
         }


### PR DESCRIPTION
Some of the tests used explicit `.Dispose` that might show a case that this is how we want to use the `IDisposable`. Always, ALWAYS, prefer `using var` over an explicit that might be forgotten and result in some leakage. Especially when readonly tx are used.