### PR TITLE
Use clearable pages

### DIFF
--- a/src/Paprika.Tests/Store/ClearableTests.cs
+++ b/src/Paprika.Tests/Store/ClearableTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Runtime.InteropServices;
+using FluentAssertions;
+using Paprika.Store;
+
+namespace Paprika.Tests.Store;
+
+/// <summary>
+/// Tests for clearable components. Whether they are properly cleared.
+/// </summary>
+[Parallelizable(ParallelScope.None)]
+public unsafe class ClearableTests : IDisposable
+{
+    [Test]
+    public void DataPage() => TestPage<DataPage>();
+
+    [Test]
+    public void AbandonedPage() => TestPage<AbandonedPage>();
+
+    [Test]
+    public void LeafOverflowPage() => TestPage<LeafOverflowPage>();
+
+    [Test]
+    public void StorageFanOut_Level1Page() => TestPage<StorageFanOut.Level1Page>();
+
+    [Test]
+    public void StorageFanOut_Level2Page() => TestPage<StorageFanOut.Level2Page>();
+
+    [Test]
+    public void StorageFanOut_Level3Page() => TestPage<StorageFanOut.Level3Page>();
+
+    [Test]
+    public void DbAddressList_Of4() => TestDbAddressList<DbAddressList.Of4>();
+
+    [Test]
+    public void DbAddressList_Of16() => TestDbAddressList<DbAddressList.Of16>();
+
+    [Test]
+    public void DbAddressList_Of64() => TestDbAddressList<DbAddressList.Of64>();
+
+    [Test]
+    public void DbAddressList_Of256() => TestDbAddressList<DbAddressList.Of256>();
+
+    [Test]
+    public void DbAddressList_Of1024() => TestDbAddressList<DbAddressList.Of1024>();
+
+    private static void TestDbAddressList<TList>()
+        where TList : struct, DbAddressList.IDbAddressList
+    {
+        var list = new TList();
+
+        var length = TList.Length;
+
+        for (var i = 0; i < length; i++)
+        {
+            list[i] = new DbAddress(1);
+        }
+
+        list.Clear();
+
+        for (var i = 0; i < length; i++)
+        {
+            list[i].Should().Be(DbAddress.Null);
+        }
+    }
+
+    private void TestPage<TPage>()
+        where TPage : struct, IPage<TPage>
+    {
+        var p = new Page(_page);
+        p.Span.Fill(0xFF);
+
+        var clearable = TPage.Wrap(new(_page)); ;
+        clearable.Clear();
+
+        clearable.IsClean.Should().BeTrue();
+    }
+
+    private readonly byte* _page = (byte*)NativeMemory.AlignedAlloc(Page.PageSize, (UIntPtr)Page.PageSize);
+
+    public void Dispose() => NativeMemory.AlignedFree(_page);
+}

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -241,6 +241,7 @@ public readonly ref struct SlottedArray /*: IClearable */
     }
 
     public int CapacityLeft => _data.Length - _header.Taken;
+    public bool IsEmpty => _header is { Low: 0, Deleted: 0, High: 0 };
 
     public Enumerator EnumerateAll() => new(this);
     public NibbleEnumerator EnumerateNibble(byte nibble) => new(this, nibble);

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -13,7 +13,7 @@ namespace Paprika.Store;
 /// are written over a single <see cref="uint"/> using a flag <see cref="PackedFlag"/>.
 /// </remarks>
 [method: DebuggerStepThrough]
-public readonly struct AbandonedPage(Page page) : IPage
+public readonly struct AbandonedPage(Page page) : IPage<AbandonedPage>
 {
     private const uint PackedFlag = 0x8000_0000u;
     private const uint PackedDiff = 1;
@@ -21,8 +21,6 @@ public readonly struct AbandonedPage(Page page) : IPage
     private ref PageHeader Header => ref page.Header;
     public uint BatchId => Header.BatchId;
     public DbAddress Next => Data.Next;
-
-    public int Count => Data.Count;
 
     private unsafe ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 
@@ -175,13 +173,9 @@ public readonly struct AbandonedPage(Page page) : IPage
 
         while (to < abandoned.Count)
         {
-            // TODO: consider not clearing the page
-            batch.GetNewPage(out var addr, true);
+            var page = batch.GetNewCleanPage<AbandonedPage>(out var addr);
 
-            var page = new AbandonedPage(batch.GetAt(addr));
-            page.Header.PageType = PageType.Abandoned;
             page.Data.Next = next;
-            page.Data.Count = 0; // initialize
 
             next = addr;
 
@@ -251,4 +245,14 @@ public readonly struct AbandonedPage(Page page) : IPage
 
         new AbandonedPage(batch.GetAt(prev)).Data.Next = tail;
     }
+
+    public void Clear()
+    {
+        Data.Next = default;
+        Data.Count = default;
+    }
+
+    public static AbandonedPage Wrap(Page page) => Unsafe.As<Page, AbandonedPage>(ref page);
+
+    public static PageType DefaultType => PageType.Abandoned;
 }

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -252,6 +252,8 @@ public readonly struct AbandonedPage(Page page) : IPage<AbandonedPage>
         Data.Count = default;
     }
 
+    public bool IsClean => Data.Next.IsNull && Data.Count == 0;
+
     public static AbandonedPage Wrap(Page page) => Unsafe.As<Page, AbandonedPage>(ref page);
 
     public static PageType DefaultType => PageType.Abandoned;

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -371,6 +371,8 @@ public readonly unsafe struct DataPage(Page page) : IPage<DataPage>, IClearable
         Data.Buckets.Clear();
     }
 
+    public bool IsClean => new SlottedArray(Data.DataSpan).IsEmpty && Data.Buckets.IsClean;
+
     private static DbAddress EnsureExistingChildWritable(IBatchContext batch, ref Payload payload, byte nibble)
     {
         var childAddr = payload.Buckets[nibble];

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -191,11 +191,8 @@ public readonly unsafe struct DataPage(Page page) : IPage<DataPage>, IClearable
                 // Create a child
 
                 // Get new page without clearing. Clearing is done manually.
-                var child = batch.GetNewPage(out childAddr, false);
-                new DataPage(child).Clear();
-
-                child.Header.PageType = PageType.DataPage;
-                child.Header.Level = (byte)(page.Header.Level + ConsumedNibbles);
+                var level = (byte)(page.Header.Level + ConsumedNibbles);
+                var child = batch.GetNewCleanPage<DataPage>(out childAddr, level);
 
                 // Set the mode for the new child to Merkle to make it spread content on the NibblePath length basis
                 child.Header.Metadata = Modes.Leaf;
@@ -350,23 +347,15 @@ public readonly unsafe struct DataPage(Page page) : IPage<DataPage>, IClearable
             var addr = payload.Buckets[bucket];
 
             LeafOverflowPage leafOverflowPage;
-            Page overflowPage;
 
             if (addr.IsNull)
             {
-                // Manual clear below
-                overflowPage = batch.GetNewPage(out addr, clear: false);
-
-                overflowPage.Header.PageType = PageType.LeafOverflow;
-                leafOverflowPage = new LeafOverflowPage(overflowPage);
-                leafOverflowPage.Map.Clear();
+                leafOverflowPage = batch.GetNewCleanPage<LeafOverflowPage>(out addr);
             }
             else
             {
-                overflowPage = batch.EnsureWritableCopy(ref addr);
-                leafOverflowPage = new LeafOverflowPage(overflowPage);
-
-                Debug.Assert(overflowPage.Header.PageType == PageType.LeafOverflow);
+                leafOverflowPage = new LeafOverflowPage(batch.EnsureWritableCopy(ref addr));
+                Debug.Assert(leafOverflowPage.AsPage().Header.PageType == PageType.LeafOverflow);
             }
 
             payload.Buckets[bucket] = addr;

--- a/src/Paprika/Store/DbAddressList.cs
+++ b/src/Paprika/Store/DbAddressList.cs
@@ -70,6 +70,8 @@ public static class DbAddressList
         public DbAddress this[int index] { get; set; }
         public static abstract int Length { get; }
 
+        public bool IsClean { get; }
+
         public DbAddress[] ToArray();
     }
 
@@ -124,6 +126,20 @@ public static class DbAddressList
         return array;
     }
 
+    private static bool IsCleanImpl<TList>(in TList list)
+        where TList : struct, IDbAddressList
+    {
+        for (var i = 0; i < TList.Length; i++)
+        {
+            if (list[i].IsNull == false)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
     public struct Of4 : IDbAddressList
     {
@@ -153,6 +169,8 @@ public static class DbAddressList
 
         public void Clear() => MemoryMarshal.CreateSpan(ref _b, Count).Clear();
 
+        public bool IsClean => IsCleanImpl(this);
+
         public DbAddress[] ToArray() => ToArrayImpl(this);
     }
 
@@ -177,6 +195,8 @@ public static class DbAddressList
                 Set(ref _b, index, value);
             }
         }
+
+        public bool IsClean => IsCleanImpl(this);
 
         public void Clear() => MemoryMarshal.CreateSpan(ref _b, Size).Clear();
 
@@ -209,6 +229,8 @@ public static class DbAddressList
 
         public void Clear() => MemoryMarshal.CreateSpan(ref _b, Size).Clear();
 
+        public bool IsClean => IsCleanImpl(this);
+
         public static int Length => Count;
 
         public DbAddress[] ToArray() => ToArrayImpl(this);
@@ -238,6 +260,8 @@ public static class DbAddressList
 
         public void Clear() => MemoryMarshal.CreateSpan(ref _b, Size).Clear();
 
+        public bool IsClean => IsCleanImpl(this);
+
         public static int Length => Count;
 
         public DbAddress[] ToArray() => ToArrayImpl(this);
@@ -266,6 +290,8 @@ public static class DbAddressList
         }
 
         public void Clear() => MemoryMarshal.CreateSpan(ref _b, Size).Clear();
+
+        public bool IsClean => IsCleanImpl(this);
 
         public DbAddress[] ToArray() => ToArrayImpl(this);
 

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -12,10 +12,31 @@ public interface IBatchContext : IReadOnlyBatchContext
     DbAddress GetAddress(Page page);
 
     /// <summary>
-    /// Gets an unused page that is not clean.
+    /// Gets a new (potentially reused) page. If <paramref name="clear"/> is set, the page will be cleared. 
     /// </summary>
-    /// <returns></returns>
+    /// <returns>A new page.</returns>
     Page GetNewPage(out DbAddress addr, bool clear);
+
+    /// <summary>
+    /// Gets a new (potentially reused) page that is clean and ready to be used.
+    /// </summary>
+    /// <param name="addr">The address of the page that is returned.</param>
+    /// <param name="level">The level to be assigned to.</param>
+    /// <typeparam name="TPage"></typeparam>
+    /// <returns>The typed page.</returns>
+    TPage GetNewCleanPage<TPage>(out DbAddress addr, byte level = 0)
+        where TPage : struct, IPage<TPage>, IClearable
+    {
+        var page = GetNewPage(out addr, false);
+
+        page.Header.PageType = TPage.DefaultType;
+        page.Header.Level = level;
+
+        var result = TPage.Wrap(page);
+        result.Clear();
+
+        return result;
+    }
 
     /// <summary>
     /// Gets a writable copy of the page.

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -9,7 +9,7 @@ namespace Paprika.Store;
 /// The page used to store big chunks of data.
 /// </summary>
 [method: DebuggerStepThrough]
-public readonly unsafe struct LeafOverflowPage(Page page) : IPage
+public readonly unsafe struct LeafOverflowPage(Page page) : IPage<LeafOverflowPage>
 {
     private ref PageHeader Header => ref page.Header;
 
@@ -52,4 +52,13 @@ public readonly unsafe struct LeafOverflowPage(Page page) : IPage
 
         return page;
     }
+
+    public void Clear()
+    {
+        Map.Clear();
+    }
+
+    public static LeafOverflowPage Wrap(Page page) => Unsafe.As<Page, LeafOverflowPage>(ref page);
+
+    public static PageType DefaultType => PageType.LeafOverflow;
 }

--- a/src/Paprika/Store/LeafOverflowPage.cs
+++ b/src/Paprika/Store/LeafOverflowPage.cs
@@ -58,6 +58,8 @@ public readonly unsafe struct LeafOverflowPage(Page page) : IPage<LeafOverflowPa
         Map.Clear();
     }
 
+    public bool IsClean => Map.IsEmpty;
+
     public static LeafOverflowPage Wrap(Page page) => Unsafe.As<Page, LeafOverflowPage>(ref page);
 
     public static PageType DefaultType => PageType.LeafOverflow;

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -16,7 +16,7 @@ public interface IPage
 {
 }
 
-public interface IPage<TPage> : IPage
+public interface IPage<TPage> : IPage, IClearable
     where TPage : struct, IPage<TPage>
 {
     public static abstract TPage Wrap(Page page);

--- a/src/Paprika/Store/Page.cs
+++ b/src/Paprika/Store/Page.cs
@@ -22,6 +22,8 @@ public interface IPage<TPage> : IPage, IClearable
     public static abstract TPage Wrap(Page page);
 
     public static abstract PageType DefaultType { get; }
+
+    public bool IsClean { get; }
 }
 
 /// <summary>

--- a/src/Paprika/Store/StateRootPage.cs
+++ b/src/Paprika/Store/StateRootPage.cs
@@ -53,10 +53,9 @@ public readonly unsafe struct StateRootPage(Page page) : IPage
 
         if (addr.IsNull)
         {
-            var child = batch.GetNewPage(out addr, true);
-            child.Header.Level = ConsumedNibbles;
-            child.Header.PageType = PageType.DataPage;
-            new DataPage(child).Set(sliced, data, batch);
+            batch
+                .GetNewCleanPage<DataPage>(out addr, ConsumedNibbles)
+                .Set(sliced, data, batch);
         }
         else
         {


### PR DESCRIPTION
This PR moves from using `.GetNewPage` to a new method that calls a `.Clear` on a clearable page. The idea is to clear as small amount of memory as possible, and for majority of pages it's just a few, maybe a hundred of bytes. In some areas, like `AbandonedPage` this could save some time. Additionally, makes it easy to allocate new clearable pages with just a single call to the batch, without a lot of boilerplate code that sets some properties or calls the Clear.