### PR TITLE
New page fix

### DIFF
--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -720,6 +720,9 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
             _written.Add(addr);
 
+            // Clear whole header first
+            page.Header = default;
+
             AssignBatchId(page);
             return page;
         }


### PR DESCRIPTION
This PR fixes the bug where the header is not cleaned for the new page (or reused). It potentially can left some data from the previous state. After this fix, the header is always overwritten first so no leftovers from the previous life of a page will survive.