### PR TITLE
Add New Test for Abandoned Pages Chain

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -247,7 +247,7 @@ public class AbandonedTests : BasePageTests
     [Test]
     public async Task Abandoned_chain_creation_with_overflow()
     {
-        // Minimum iterations required to overflow the abadoned list (AbandonedList.MaxCount).
+        // Minimum iterations required to overflow the abandoned list (AbandonedList.MaxCount).
         const int minIterations = 60;
 
         // Minimum accounts required to overflow an abandoned page (AbandonedPage.Payload.MaxCount * 2).

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -245,6 +245,7 @@ public class AbandonedTests : BasePageTests
     }
 
     [Test]
+    [Category(Categories.LongRunning)]
     public async Task Abandoned_chain_creation_with_overflow()
     {
         // Minimum iterations required to overflow the abandoned list (AbandonedList.MaxCount).
@@ -259,7 +260,7 @@ public class AbandonedTests : BasePageTests
         var accountValue = new byte[2900];
         new Random(17).NextBytes(accountValue);
 
-        using var db = PagedDb.NativeMemoryDb(150000 * Page.PageSize, HistoryDepth);
+        using var db = PagedDb.NativeMemoryDb(140000 * Page.PageSize, HistoryDepth);
 
         // Start read only batch to ensure that new pages are allocated instead of reusing
         // the abandoned pages.

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -245,14 +245,15 @@ public class AbandonedTests : BasePageTests
     }
 
     [Test]
-    [Category(Categories.LongRunning)]
     public async Task Abandoned_chain_creation_with_overflow()
     {
-        // Minimum iterations required to overflow the abandoned list (AbandonedList.MaxCount).
-        const int minIterations = 60;
+        const int delta = 10;
 
-        // Minimum accounts required to overflow an abandoned page (AbandonedPage.Payload.MaxCount * 2).
-        const int numAccounts = 2000;
+        // Minimum iterations required to overflow the abandoned list.
+        const int minIterations = AbandonedList.MaxCount + delta;
+
+        // Minimum accounts required to overflow an abandoned page.
+        int numAccounts = AbandonedPage.MaxCount * 2 + delta;
 
         var keccaks = Initialize(numAccounts);
 
@@ -260,7 +261,7 @@ public class AbandonedTests : BasePageTests
         var accountValue = new byte[2900];
         new Random(17).NextBytes(accountValue);
 
-        using var db = PagedDb.NativeMemoryDb(140000 * Page.PageSize, HistoryDepth);
+        using var db = PagedDb.NativeMemoryDb(150000 * Page.PageSize, HistoryDepth);
 
         // Start read only batch to ensure that new pages are allocated instead of reusing
         // the abandoned pages.

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -17,7 +17,7 @@ public struct AbandonedList
 
     public const int Size = Page.PageSize - PageHeader.Size - RootPage.Payload.AbandonedStart - EntriesStart;
     private const int EntrySize = sizeof(uint) + DbAddress.Size;
-    private const int MaxCount = (Size - EntriesStart) / EntrySize;
+    public const int MaxCount = (Size - EntriesStart) / EntrySize;
 
     [FieldOffset(0)] private DbAddress Current;
     [FieldOffset(DbAddress.Size)] private uint EntriesCount;

--- a/src/Paprika/Store/AbandonedPage.cs
+++ b/src/Paprika/Store/AbandonedPage.cs
@@ -23,6 +23,7 @@ public readonly struct AbandonedPage(Page page) : IPage
     public DbAddress Next => Data.Next;
 
     public int Count => Data.Count;
+    public static int MaxCount => Payload.MaxCount;
 
     private unsafe ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
 


### PR DESCRIPTION
Follow up PR for https://github.com/NethermindEth/Paprika/pull/403 to improve the test coverage for abandoned pages. The new test (`Abandoned_chain_creation_with_overflow`) creates enough number of abandoned pages to form a chain and ensures that there are no leaks.