### PR TITLE
Optimize AbandonedList Space Usage

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -262,7 +262,11 @@ public class AbandonedTests : BasePageTests
         var accountValue = new byte[2900];
         new Random(17).NextBytes(accountValue);
 
-        using var db = PagedDb.NativeMemoryDb(165_000 * Page.PageSize, HistoryDepth);
+        using var db = PagedDb.NativeMemoryDb(350_000 * Page.PageSize, HistoryDepth);
+
+        // Ensure that AbandonedList can pack maximum number of abandoned page addresses.
+        const int estimatedMetadataSize = 32;
+        AbandonedList.MaxCount.Should().BeGreaterThan(AbandonedList.Size / DbAddress.Size - estimatedMetadataSize);
 
         // Start read only batch to ensure that new pages are allocated instead of reusing
         // the abandoned pages.

--- a/src/Paprika/Store/AbandonedList.cs
+++ b/src/Paprika/Store/AbandonedList.cs
@@ -16,13 +16,13 @@ public struct AbandonedList
     private const int EntriesStart = DbAddress.Size + sizeof(uint);
 
     public const int Size = Page.PageSize - PageHeader.Size - RootPage.Payload.AbandonedStart - EntriesStart;
-    private const int EntrySize = sizeof(uint) + DbAddress.Size;
+    private const int EntrySize = DbAddress.Size;
     public const int MaxCount = (Size - EntriesStart) / EntrySize;
 
     [FieldOffset(0)] private DbAddress Current;
     [FieldOffset(DbAddress.Size)] private uint EntriesCount;
 
-    [FieldOffset(MaxCount * sizeof(uint) + EntriesStart)]
+    [FieldOffset(EntriesStart)]
     private DbAddress AddressStart;
 
     private Span<DbAddress> Addresses => MemoryMarshal.CreateSpan(ref AddressStart, MaxCount);


### PR DESCRIPTION
Remove BatchIds from the Abandoned List as it is redundant information which is already stored in each Abandoned page. https://github.com/NethermindEth/Paprika/issues/410