### PR TITLE
Handle empty (zero length) prefix in Slotted Array

### DIFF
--- a/src/Paprika.Tests/Chain/RawStateTests.cs
+++ b/src/Paprika.Tests/Chain/RawStateTests.cs
@@ -150,4 +150,32 @@ public class RawStateTests
         using var read = db.BeginReadOnlyBatch();
         read.TryGet(Key.Account(account), out _).Should().BeFalse();
     }
+
+    [Test]
+    public void DeleteByPrefixStorage()
+    {
+        var account = Values.Key1;
+
+        using var db = PagedDb.NativeMemoryDb(256 * 1024, 2);
+        var merkle = new ComputeMerkleBehavior();
+
+        var blockchain = new Blockchain(db, merkle);
+
+        using var raw = blockchain.StartRaw();
+
+        raw.SetAccount(account, new Account(1, 1));
+        raw.SetStorage(account, Values.Key2, new byte[] { 1, 2, 3, 4, 5 });
+        raw.Commit();
+
+        using var read = db.BeginReadOnlyBatch();
+        read.TryGet(Key.StorageCell(NibblePath.FromKey(account), Values.Key2), out _).Should().BeTrue();
+
+        raw.RegisterDeleteByPrefix(Key.StorageCell(NibblePath.FromKey(account), NibblePath.Empty));
+        raw.Commit();
+
+        raw.Finalize(1);
+
+        using var read2 = db.BeginReadOnlyBatch();
+        read2.TryGet(Key.StorageCell(NibblePath.FromKey(account), Values.Key2), out _).Should().BeFalse();
+    }
 }

--- a/src/Paprika/Data/Key.cs
+++ b/src/Paprika/Data/Key.cs
@@ -55,6 +55,9 @@ public readonly ref partial struct Key
     public static Key StorageCell(NibblePath path, ReadOnlySpan<byte> keccak) =>
         new(path, DataType.StorageCell, NibblePath.FromKey(keccak));
 
+    public static Key StorageCell(NibblePath path, NibblePath storagePath) =>
+        new(path, DataType.StorageCell, storagePath);
+
     [DebuggerStepThrough]
     public Key SliceFrom(int nibbles) => new(Path.SliceFrom(nibbles), Type, StoragePath);
 

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -122,7 +122,7 @@ public readonly ref struct SlottedArray /*: IClearable */
     {
         if (prefix.Length == 0)
         {
-            Delete(prefix);
+            Clear();
         }
         else if (prefix.Length == 1)
         {


### PR DESCRIPTION
Use Clear instead of Delete to correctly empty all the data in Slotted Array when processing deletion by prefix.