### PR TITLE
Delete by short prefix on state root page

### DIFF
--- a/src/Paprika.Tests/Chain/RawStateTests.cs
+++ b/src/Paprika.Tests/Chain/RawStateTests.cs
@@ -197,7 +197,7 @@ public class RawStateTests
         read2.TryGet(Key.Account(account1), out _).Should().BeFalse();
         read2.TryGet(Key.Account(account2), out _).Should().BeFalse();
     }
-  
+
     [Test]
     public void DeleteByPrefixStorage()
     {


### PR DESCRIPTION
Remove restriction of removing data from root page with a prefix shorter than `ConsumedNibbles` (2). Highly unlikely in real world scenarios, but greatly improves testing (especially fuzzing with smaller trie sizes).
Depends on #414.