### PR TITLE
Flush on empty queue

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -183,6 +183,7 @@ public class Blockchain : IAsyncDisposable
                     var noMoreBlocksToApply = readerCount == 0;
 
                     // Commit, but flush only if there's nothing more to apply.
+                    // If there are more blocks, leave it to the external _db.Flush() called outside of this loop.
                     await batch.Commit(noMoreBlocksToApply
                             ? CommitOptions.FlushDataOnly
                             : CommitOptions.DangerNoFlush);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -180,8 +180,12 @@ public class Blockchain : IAsyncDisposable
 
                     _flusherQueueCount.Set(readerCount);
 
-                    // commit but no flush here, it's too heavy, the flush will come later
-                    await batch.Commit(CommitOptions.FlushDataOnly);
+                    var noMoreBlocksToApply = readerCount == 0;
+
+                    // Commit, but flush only if there's nothing more to apply.
+                    await batch.Commit(noMoreBlocksToApply
+                            ? CommitOptions.FlushDataOnly
+                            : CommitOptions.DangerNoFlush);
 
                     // inform blocks about flushing
                     lock (_blockLock)


### PR DESCRIPTION
This PR reintroduces a lazy flush behavior, when there's more blocks in the queue. If this is the case, the commit options are lowered from `CommitOptions.FlushDataOnly` (ACI, potentially no D) to `CommitOptions.DangerNoFlush` (writes are issued, the FSYNC is not though). This should increase the throughput of the block application where there is a a lot of blocks to apply.