### PR TITLE
PageDb reports read and write batch id

### DIFF
--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -58,7 +58,9 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
     private readonly Histogram<int> _commitPageAbandoned;
     private readonly Histogram<int> _commitAbandonedSameBatch;
     private readonly MetricsExtensions.IAtomicIntGauge _dbSize;
-
+    private readonly MetricsExtensions.IAtomicIntGauge _lowestReadTxBatch;
+    private readonly MetricsExtensions.IAtomicIntGauge _lastWriteTxBatch;
+    private const string? BatchIdName = "BatchId";
 
     // pooled objects
     private Context? _ctx;
@@ -108,6 +110,10 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             "The number of pages registered for future reuse (abandoned)");
         _commitAbandonedSameBatch = _meter.CreateHistogram<int>("Written and abandoned in the same batch", "pages",
             "The number of pages written and then registered for future reuse");
+        _lowestReadTxBatch = _meter.CreateAtomicObservableGauge($"Lowest read {BatchIdName}", BatchIdName,
+            "The lowest BatchId that is locked by a read tx");
+        _lastWriteTxBatch = _meter.CreateAtomicObservableGauge($"Last written {BatchIdName}", BatchIdName,
+            "The last ");
 
 #if TRACKING_REUSED_PAGES
         // Reuse tracking
@@ -229,7 +235,13 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         root.CopyTo(copy);
 
         var batch = new ReadOnlyBatch(this, copy, name);
+
+        // Update the lowest read tx batch
+        var batchId = (int)batch.BatchId;
+        _lowestReadTxBatch.Set(_batchesReadOnly.Count == 0 ? batchId : Math.Min(_lowestReadTxBatch.Read(), batchId));
+
         _batchesReadOnly.Add(batch);
+
         return batch;
     }
 
@@ -381,6 +393,16 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
         {
             _batchesReadOnly.Remove(batch);
             _pooledRoots.Return(batch.Root.AsPage());
+
+            // update metrics
+            if (_batchesReadOnly.Count == 0)
+            {
+                _lowestReadTxBatch.Set(0);
+            }
+            else
+            {
+                _lowestReadTxBatch.Set((int)_batchesReadOnly.Min(b => b.BatchId));
+            }
         }
     }
 
@@ -402,6 +424,9 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
             // always inc the batchId
             root.Header.BatchId++;
+
+            // metrics
+            _lastWriteTxBatch.Set((int)root.Header.BatchId);
 
             // select min batch across the one respecting history and the min of all the read-only batches
             var rootBatchId = root.Header.BatchId;


### PR DESCRIPTION
Two additional gauges that should help in finding any anomalies where a read batch is kept for much too long in the memory.

Reports when running importer

![image](https://github.com/user-attachments/assets/236ed83a-043f-4297-8b82-fc58e3979805)
