### PR TITLE
Span ownerhship improved

### DIFF
--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -48,10 +48,10 @@ public class RootHashFuzzyTests
         AssertRoot(generator.RootHash, commit);
     }
 
-    [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue)]
-    [TestCase(nameof(Accounts_1_Storage_100), 11)]
-    [TestCase(nameof(Accounts_1000_Storage_1000), int.MaxValue, Category = Categories.LongRunning)]
-    public async Task In_memory_run(string test, int commitEvery)
+    [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue, 4)]
+    [TestCase(nameof(Accounts_1_Storage_100), 11, 8)]
+    [TestCase(nameof(Accounts_1000_Storage_1000), int.MaxValue, 748, Category = Categories.LongRunning)]
+    public async Task In_memory_run(string test, int commitEvery, int blockchainPoolSizeMB)
     {
         var generator = Build(test);
 
@@ -61,6 +61,14 @@ public class RootHashFuzzyTests
 
         var rootHash = generator.Run(blockchain, commitEvery);
         AssertRootHash(rootHash, generator);
+
+        AssertBlockchainMaxPoolSize(blockchain, blockchainPoolSizeMB);
+    }
+
+    private static void AssertBlockchainMaxPoolSize(Blockchain blockchain, int expected)
+    {
+        blockchain.PoolAllocatedMB.Should().BeLessOrEqualTo(expected,
+            "Upper boundary set by running this test. Bigger number means too much memory allocated.");
     }
 
     [Test]
@@ -116,9 +124,9 @@ public class RootHashFuzzyTests
         //AnsiConsole.Write(visitor.Tree);
     }
 
-    [TestCase(nameof(Accounts_10_000), 256 * 1024 * 1024L)]
-    [TestCase(nameof(Accounts_1_000_000), 2 * 1024 * 1024 * 1024L, Category = Categories.LongRunning)]
-    public async Task CalculateThenDelete(string test, long size)
+    [TestCase(nameof(Accounts_10_000), 256 * 1024 * 1024L, 8)]
+    [TestCase(nameof(Accounts_1_000_000), 2 * 1024 * 1024 * 1024L, 28, Category = Categories.LongRunning)]
+    public async Task CalculateThenDelete(string test, long size, int blockchainPoolSizeMB)
     {
         var generator = Build(test);
 
@@ -136,6 +144,8 @@ public class RootHashFuzzyTests
         var rootHash = generator.Run(blockchain, 1001, true, true);
 
         rootHash.Should().BeOneOf(Keccak.EmptyTreeHash, Keccak.Zero);
+
+        AssertBlockchainMaxPoolSize(blockchain, blockchainPoolSizeMB);
     }
 
     private static void AssertRootHash(Keccak rootHash, CaseGenerator generator)

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -110,6 +110,8 @@ public class Blockchain : IAsyncDisposable
         _verify = true;
     }
 
+    public int PoolAllocatedMB => _pool.AllocatedMB ?? int.MaxValue;
+
     private static Channel<CommittedBlockState> CreateChannel(int? finalizationQueueLimit)
     {
         if (finalizationQueueLimit == null)

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -69,7 +69,7 @@ public interface IPreCommitBehavior
 /// <remarks>
 /// Use <see cref="Visit"/> to access all the keys.
 /// </remarks>
-public interface ICommit
+public interface ICommit : ISpanOwner
 {
     /// <summary>
     /// Tries to retrieve the result stored under the given key.
@@ -161,9 +161,9 @@ public readonly ref struct ReadOnlySpanOwnerWithMetadata<T>(ReadOnlySpanOwner<T>
     public void Dispose() => _owner.Dispose();
 
     /// <summary>
-    /// Answers whether this span is owned and provided by <paramref name="owner"/>.
+    /// Answers whether this span is owned and provided by <paramref name="spanOwner"/>.
     /// </summary>
-    public bool IsOwnedBy(object owner) => _owner.IsOwnedBy(owner);
+    public bool IsOwnedBy(ISpanOwner spanOwner) => _owner.IsOwnedBy(spanOwner);
 
     /// <summary>
     /// Increases the <see cref="QueryDepth"/> of this span owner, reporting it as more nested.

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -705,67 +705,56 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
     /// This component appends the prefix to all the commit operations.
     /// It's useful for storage operations, that have their key prefixed with the account.
     /// </summary>
-    private class PrefixingCommit : ICommit
+    private class PrefixingCommit(ICommit commit) : ICommit
     {
-        private readonly ICommit _commit;
         private Keccak _keccak;
-
-        public PrefixingCommit(ICommit commit)
-        {
-            _commit = commit;
-        }
 
         public void SetPrefix(in NibblePath path) => SetPrefix(path.UnsafeAsKeccak);
 
         public void SetPrefix(in Keccak keccak) => _keccak = keccak;
 
         public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key) =>
-            _commit.Get(Build(key));
+            commit.Get(Build(key));
 
         public void Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type) =>
-            _commit.Set(Build(key), in payload, type);
+            commit.Set(Build(key), in payload, type);
 
         public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1, EntryType type)
-            => _commit.Set(Build(key), payload0, payload1, type);
+            => commit.Set(Build(key), payload0, payload1, type);
 
         /// <summary>
         /// Builds the <see cref="_keccak"/> aware key, treating the path as the path for the storage.
         /// </summary>
         private Key Build(scoped in Key key) => Key.Raw(NibblePath.FromKey(_keccak), key.Type, key.Path);
 
-        public IChildCommit GetChild() => new ChildCommit(this, _commit.GetChild());
+        public IChildCommit GetChild() => new ChildCommit(this, commit.GetChild());
 
         public void Visit(CommitAction action, TrieType type) => throw new Exception("Should not be called");
+
+        public bool Owns(object? actualSpanOwner) => ReferenceEquals(actualSpanOwner, commit);
 
         public IReadOnlyDictionary<Keccak, int> Stats =>
             throw new NotImplementedException("No stats for the child commit");
 
-        private class ChildCommit : IChildCommit
+        private class ChildCommit(PrefixingCommit parent, IChildCommit commit) : IChildCommit
         {
-            private readonly PrefixingCommit _parent;
-            private readonly IChildCommit _commit;
-
-            public ChildCommit(PrefixingCommit parent, IChildCommit commit)
-            {
-                _parent = parent;
-                _commit = commit;
-            }
-
             public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key) =>
-                _commit.Get(_parent.Build(key));
+                commit.Get(parent.Build(key));
 
             public void Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type) =>
-                _commit.Set(_parent.Build(key), payload, type);
+                commit.Set(parent.Build(key), payload, type);
 
             public void Set(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1,
                 EntryType type) =>
-                _commit.Set(_parent.Build(key), payload0, payload1, type);
+                commit.Set(parent.Build(key), payload0, payload1, type);
 
-            public void Dispose() => _commit.Dispose();
+            public void Dispose() => commit.Dispose();
 
-            public void Commit() => _commit.Commit();
+            public void Commit() => commit.Commit();
 
-            public IChildCommit GetChild() => new ChildCommit(_parent, _commit.GetChild());
+            public IChildCommit GetChild() => new ChildCommit(parent, commit.GetChild());
+
+            public bool Owns(object? actualSpanOwner) => ReferenceEquals(actualSpanOwner, commit);
 
             public IReadOnlyDictionary<Keccak, int> Stats =>
                 throw new NotImplementedException("No stats for the child commit");

--- a/src/Paprika/Utils/ReadOnlySpanOwner.cs
+++ b/src/Paprika/Utils/ReadOnlySpanOwner.cs
@@ -14,5 +14,14 @@ public readonly ref struct ReadOnlySpanOwner<T>(ReadOnlySpan<T> span, IDisposabl
     /// </summary>
     public void Dispose() => owner?.Dispose();
 
-    public bool IsOwnedBy(object potentialOwner) => ReferenceEquals(potentialOwner, owner);
+    public bool IsOwnedBy(ISpanOwner potentialSpanOwner) => potentialSpanOwner.Owns(owner);
+}
+
+public interface ISpanOwner
+{
+    /// <summary>
+    /// Checks whether this owner is capable of owning spans
+    /// owned by <paramref name="actualSpanOwner"/>.
+    /// </summary>
+    public bool Owns(object? actualSpanOwner) => ReferenceEquals(actualSpanOwner, this);
 }


### PR DESCRIPTION
This PR slightly amends the logic of the owner's resolution for `ReadOnlySpanOwner` that can be overwritten by a specific type of owner that implements `ISpanOwner`. Then, it uses the new seam to properly implement the ownership check for `PrefixingCommit` that delegates all the storage operations to the underlying commit, but previously was not capable of properly asserting the ownership. This resulted in much to large amount of copies of data. The assertion for the memory usage is done using a gross measure, the pool of the blockchain.

Effectively, if you use Merkle for storage a lot, this PR saves a lot of data copying and reduces memory usage. For tests with storage it reduced the pool usage for the commit by 60%. Of course committed but not flushed data will still occupy a lot, but it should help a lot in general.



