### PR TITLE
Parallel prefetcher

### DIFF
--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -782,9 +782,14 @@ public class Blockchain : IAsyncDisposable
                 if (CanPrefetchFurther == false)
                     return;
 
-                PrefetchAccount(account);
-
+                // Try account first
                 var accountHash = account.GetHashCodeUlong();
+                if (ShouldPrefetch(accountHash))
+                {
+                    ThreadPool.QueueUserWorkItem(key => { _parent._blockchain._preCommit.Prefetch(key, this); }, account,
+                        false);
+                }
+
                 var storageHash = storage.GetHashCodeUlong();
 
                 if (ShouldPrefetch(accountHash ^ storageHash) == false)

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -33,6 +33,8 @@ public interface IPreCommitPrefetcher
 /// </summary>
 public interface IPrefetcherContext
 {
+    bool CanPrefetchFurther { get; }
+
     /// <summary>
     /// Tries to retrieve the result stored under the given key.
     /// </summary>
@@ -44,5 +46,5 @@ public interface IPrefetcherContext
     /// <summary>
     /// Sets the value under the given key.
     /// </summary>
-    void Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type = EntryType.Persistent);
+    bool Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type = EntryType.Persistent);
 }

--- a/src/Paprika/Chain/PooledSpanDictionary.cs
+++ b/src/Paprika/Chain/PooledSpanDictionary.cs
@@ -242,7 +242,6 @@ public class PooledSpanDictionary : IDisposable
     public void Set(scoped ReadOnlySpan<byte> key, ulong hash, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1,
         byte metadata) => SetImpl(key, Mix(hash), data0, data1, metadata);
 
-
     private void SetImpl(scoped ReadOnlySpan<byte> key, uint mixed, ReadOnlySpan<byte> data0, ReadOnlySpan<byte> data1,
         byte metadata, bool append = false)
     {

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1474,11 +1474,11 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             switch (type)
             {
                 case Node.Type.Leaf:
-                    TryCache(context, key, owner, EntryType.UseOnce);
+                    TryCache(context, key, owner);
                     return;
 
                 case Node.Type.Extension:
-                    if (TryCache(context, key, owner, EntryType.UseOnce) == false)
+                    if (TryCache(context, key, owner) == false)
                     {
                         return;
                     }
@@ -1496,6 +1496,8 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                     // The paths are different, handle by MarkPathAsDirty
                     return;
                 case Node.Type.Branch:
+                    // Use EntryType.Persistent as branches will be overwritten
+                    // so that the prefetcher can handle the burden of copying.
                     if (TryCache(context, key, owner, EntryType.Persistent) == false)
                     {
                         return;
@@ -1523,7 +1525,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         return;
 
         static bool TryCache(IPrefetcherContext context, in Key key, in ReadOnlySpanOwnerWithMetadata<byte> owner,
-            EntryType type)
+            EntryType type = EntryType.UseOnce)
         {
             var local = owner.QueryDepth == 0;
             if (local)


### PR DESCRIPTION
Another, simpler take on the Merkle prefetcher. This PR does it by providing the following:

1. `BitFilter` atomic operations
2. Delegating `Prefetch` calls to `ThreadPool.QueueWorkItem` so that no queue is needed
3. Ensuring that the given prefetch is not called twice.
4. Making it based on `ReaderWriterLockSlim`