### PR TITLE
Different Merkle prefetching

### DIFF
--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -85,14 +85,11 @@ public class PrefetchingTests
     [TestCase(false, true, Category = Categories.LongRunning, TestName = "Storage, no prefetch")]
     public async Task Spin(bool prefetch, bool storage)
     {
-        var commits = new Stopwatch();
-
         const int parallelism = ComputeMerkleBehavior.ParallelismNone;
         const int finalityLength = 16;
-        const int accounts = 200_000;
+        const int accounts = 50_000;
         const int accountsPerBlock = 100;
-        const int visitSameAccountCount = 2;
-        const int blocks = accounts / accountsPerBlock * visitSameAccountCount;
+        const int blocks = accounts / accountsPerBlock;
 
         var random = new Random(13);
         var keccaks = new Keccak[accounts];
@@ -102,69 +99,90 @@ public class PrefetchingTests
         using var db = PagedDb.NativeMemoryDb(1024 * 1024 * 1024, 2);
         var merkle = new ComputeMerkleBehavior(parallelism);
         await using var blockchain = new Blockchain(db, merkle);
-        var at = 0;
+
+        const uint startBlockNumber = 1;
         var parent = Keccak.EmptyTreeHash;
-        var finality = new Queue<Keccak>();
-        var prefetchFailures = 0;
 
-        for (uint i = 1; i < blocks; i++)
+        // Setup test by creating all the account first.
+        // This should ensure that he Merkle construct is created and future updates should be prefetched properly without additional db reads 
+        using var first = blockchain.StartNew(parent);
+        SetAccounts(new ReadOnlyMemory<Keccak>(keccaks), first, startBlockNumber, storage);
+        parent = first.Commit(startBlockNumber);
+        blockchain.Finalize(parent);
+        await blockchain.WaitTillFlush(startBlockNumber);
+
+        // Run commits now with a prefetching
+        await RunBlocksWithPrefetching(blockchain, keccaks, parent, prefetch, storage);
+        return;
+
+        static async Task RunBlocksWithPrefetching(Blockchain blockchain, Keccak[] keccaks, Keccak parent,
+            bool prefetch, bool storage)
         {
-            using var block = blockchain.StartNew(parent);
+            var finality = new Queue<Keccak>();
+            var prefetchFailures = 0;
+            var at = 0;
 
-            var slice = keccaks.AsMemory(at % accounts, accountsPerBlock);
-            at += accountsPerBlock;
+            var commits = new Stopwatch();
 
-            // Execution delay
-            var task = !prefetch
-                ? Task.FromResult(true)
-                : Task.Factory.StartNew(() =>
-                {
-                    var prefetcher = block.OpenPrefetcher();
-                    if (prefetcher == null)
-                        return true;
-
-                    foreach (var keccak in slice.Span)
-                    {
-                        if (prefetcher.CanPrefetchFurther == false)
-                        {
-                            return false;
-                        }
-
-                        prefetcher.PrefetchAccount(keccak);
-                        if (storage)
-                        {
-                            prefetcher.PrefetchStorage(keccak, keccak);
-                        }
-                    }
-
-                    return true;
-                });
-
-            await Task.WhenAll(Task.Delay(50), task);
-
-            if ((await task) == false)
-                prefetchFailures++;
-
-            SetAccounts(slice, block, i, storage);
-
-            commits.Start();
-            parent = block.Commit(i);
-            commits.Stop();
-
-            finality.Enqueue(parent);
-
-            if (finality.Count > finalityLength)
+            for (var i = startBlockNumber + 1; i < blocks + startBlockNumber + 1; i++)
             {
-                blockchain.Finalize(finality.Dequeue());
+                using var block = blockchain.StartNew(parent);
+
+                var slice = keccaks.AsMemory(at % accounts, accountsPerBlock);
+                at += accountsPerBlock;
+
+                // Execution delay
+                var task = !prefetch
+                    ? Task.FromResult(true)
+                    : Task.Factory.StartNew(() =>
+                    {
+                        var prefetcher = block.OpenPrefetcher();
+                        if (prefetcher == null)
+                            return true;
+
+                        foreach (var keccak in slice.Span)
+                        {
+                            if (prefetcher.CanPrefetchFurther == false)
+                            {
+                                return false;
+                            }
+
+                            prefetcher.PrefetchAccount(keccak);
+                            if (storage)
+                            {
+                                prefetcher.PrefetchStorage(keccak, keccak);
+                            }
+                        }
+
+                        return true;
+                    });
+
+                await Task.WhenAll(Task.Delay(50), task);
+
+                if ((await task) == false)
+                    prefetchFailures++;
+
+                SetAccounts(slice, block, i, storage);
+
+                commits.Start();
+                parent = block.Commit(i);
+                commits.Stop();
+
+                finality.Enqueue(parent);
+
+                if (finality.Count > finalityLength)
+                {
+                    blockchain.Finalize(finality.Dequeue());
+                }
             }
-        }
 
-        while (finality.TryDequeue(out var k))
-        {
-            blockchain.Finalize(k);
-        }
+            while (finality.TryDequeue(out var k))
+            {
+                blockchain.Finalize(k);
+            }
 
-        Console.WriteLine($"Prefetch failures: {prefetchFailures}. Commit time {commits.Elapsed:g}");
+            Console.WriteLine($"Prefetch failures: {prefetchFailures}. Commit time {commits.Elapsed:g}");
+        }
     }
 
     private static void SetAccounts(ReadOnlyMemory<Keccak> slice, IWorldState block, uint i, bool storage)

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -746,7 +746,7 @@ public class Blockchain : IAsyncDisposable
             private readonly PooledSpanDictionary _cache;
             private readonly BlockState _parent;
             private readonly BufferPool _pool;
-            
+
             private const int Working = 1;
             private const int NotWorking = 0;
             private volatile int _working = NotWorking;

--- a/src/Paprika/Chain/IPreCommitBehavior.cs
+++ b/src/Paprika/Chain/IPreCommitBehavior.cs
@@ -153,6 +153,11 @@ public readonly ref struct ReadOnlySpanOwnerWithMetadata<T>(ReadOnlySpanOwner<T>
 
     public ReadOnlySpan<T> Span => _owner.Span;
 
+    /// <summary>
+    /// Returns the underlying owner. It's up to the caller to navigate the lifetime properly.
+    /// </summary>
+    public ReadOnlySpanOwner<T> Owner => _owner;
+
     public bool IsEmpty => _owner.IsEmpty;
 
     /// <summary>
@@ -164,15 +169,6 @@ public readonly ref struct ReadOnlySpanOwnerWithMetadata<T>(ReadOnlySpanOwner<T>
     /// Answers whether this span is owned and provided by <paramref name="spanOwner"/>.
     /// </summary>
     public bool IsOwnedBy(ISpanOwner spanOwner) => _owner.IsOwnedBy(spanOwner);
-
-    /// <summary>
-    /// Increases the <see cref="QueryDepth"/> of this span owner, reporting it as more nested.
-    /// </summary>
-    public ReadOnlySpanOwnerWithMetadata<T> Nest()
-    {
-        return new ReadOnlySpanOwnerWithMetadata<T>(_owner,
-            QueryDepth == DatabaseQueryDepth ? QueryDepth : (ushort)(QueryDepth + 1));
-    }
 }
 
 public static class ReadOnlySpanOwnerExtensions

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -1,5 +1,7 @@
-﻿using Paprika.Crypto;
+﻿using System.Buffers;
+using Paprika.Crypto;
 using Paprika.Data;
+using Paprika.Utils;
 
 namespace Paprika.Chain;
 
@@ -29,7 +31,7 @@ public interface IPreCommitPrefetcher
 }
 
 /// <summary>
-/// Allows <see cref="IPreCommitBehavior.Prefetch"/> to access ancestors data.
+/// Allows <see cref="IPreCommitBehavior"/> prefetches to access ancestors data.
 /// </summary>
 public interface IPrefetcherContext
 {
@@ -37,14 +39,10 @@ public interface IPrefetcherContext
 
     /// <summary>
     /// Tries to retrieve the result stored under the given key.
+    /// If it fails to get it from the current state, it will fetch it from the ancestors and store it accordingly to the
+    /// <paramref name="entryMapping"/>.
     /// </summary>
-    /// <remarks>
-    /// Returns a result as an owner that must be disposed properly (using var owner = Get)
-    /// </remarks>
-    public ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key);
-
-    /// <summary>
-    /// Sets the value under the given key.
-    /// </summary>
-    bool Set(in Key key, in ReadOnlySpan<byte> payload, EntryType type = EntryType.Persistent);
+    public ReadOnlySpanOwner<byte> Get(scoped in Key key, SpanFunc<EntryType> entryMapping);
 }
+
+public delegate TResult SpanFunc<TResult>(in ReadOnlySpan<byte> data);

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -1,5 +1,4 @@
-﻿using System.Buffers;
-using Paprika.Crypto;
+﻿using Paprika.Crypto;
 using Paprika.Data;
 using Paprika.Utils;
 

--- a/src/Paprika/Merkle/Node.cs
+++ b/src/Paprika/Merkle/Node.cs
@@ -161,10 +161,7 @@ public static partial class Node
             return source.Slice(Size);
         }
 
-        public static Type GetTypeFrom(ReadOnlySpan<byte> source)
-        {
-            return new Header(source[0]).NodeType;
-        }
+        public static Type GetTypeFrom(ReadOnlySpan<byte> source) => new Header(source[0]).NodeType;
 
         public static Header Peek(ReadOnlySpan<byte> source) => new(source[0]);
 

--- a/src/Paprika/Utils/ReadOnlySpanOwner.cs
+++ b/src/Paprika/Utils/ReadOnlySpanOwner.cs
@@ -9,6 +9,8 @@ public readonly ref struct ReadOnlySpanOwner<T>(ReadOnlySpan<T> span, IDisposabl
 
     public bool IsEmpty => Span.IsEmpty;
 
+    public bool HasOwner => owner != null;
+
     /// <summary>
     /// Disposes the owner provided as <see cref="IDisposable"/> once.
     /// </summary>

--- a/src/Paprika/Utils/ReadOnlySpanOwner.cs
+++ b/src/Paprika/Utils/ReadOnlySpanOwner.cs
@@ -9,8 +9,6 @@ public readonly ref struct ReadOnlySpanOwner<T>(ReadOnlySpan<T> span, IDisposabl
 
     public bool IsEmpty => Span.IsEmpty;
 
-    public bool HasOwner => owner != null;
-
     /// <summary>
     /// Disposes the owner provided as <see cref="IDisposable"/> once.
     /// </summary>


### PR DESCRIPTION
This PR amends the prefetching one more time. The previous implementation was not thread safe and resulted in some undefined behavior from time to time (reading/writing when it should not to). The current implementation moves back to being single threaded and scheduling its work using `ThreadPool.UnsafeQueueUserWorkItem` and by implementing `IThreadPoolWorkItem`. 

### BitFilter issue

To limit the overhead of merging a prefetcher filter with the filter from `BlockState`, the block's filter is used directly so no copying at the end happens. This requires `AddAtomic` but it should not be a burden (runs show that it's not). 

### Benchmarks

| Case with storage  | Prefetch  | Time (seconds)  | 
|---|---|---|
| ❌ |❌ | 02.45 | 
| ❌ | ✅  | 01.23 |
| ✅  | ❌ | 03.30 |
| ✅  | ✅  | 02.26 |