### PR TITLE
StorageFanout pull up

### DIFF
--- a/src/Paprika.Tests/Data/NibbleSelectorTests.cs
+++ b/src/Paprika.Tests/Data/NibbleSelectorTests.cs
@@ -4,7 +4,7 @@ using static Paprika.Data.NibbleSelector;
 
 namespace Paprika.Tests.Data;
 
-[Parallelizable(ParallelScope.None)]
+[Parallelizable(ParallelScope.Self)]
 public class NibbleSelectorTests
 {
     private static readonly Type[] Selectors = typeof(NibbleSelector).GetNestedTypes();

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -50,7 +50,7 @@ public class RootHashFuzzyTests
 
     [TestCase(nameof(Accounts_100_Storage_1), int.MaxValue, 4)]
     [TestCase(nameof(Accounts_1_Storage_100), 11, 8)]
-    [TestCase(nameof(Accounts_1000_Storage_1000), int.MaxValue, 748, Category = Categories.LongRunning)]
+    [TestCase(nameof(Accounts_1000_Storage_1000), int.MaxValue, 752, Category = Categories.LongRunning)]
     public async Task In_memory_run(string test, int commitEvery, int blockchainPoolSizeMB)
     {
         var generator = Build(test);

--- a/src/Paprika.Tests/Store/ClearableTests.cs
+++ b/src/Paprika.Tests/Store/ClearableTests.cs
@@ -7,7 +7,7 @@ namespace Paprika.Tests.Store;
 /// <summary>
 /// Tests for clearable components. Whether they are properly cleared.
 /// </summary>
-[Parallelizable(ParallelScope.None)]
+[Parallelizable(ParallelScope.Self)]
 public unsafe class ClearableTests : IDisposable
 {
     [Test]

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -574,7 +574,11 @@ public static class StorageFanOut
                 if (Root.IsNull)
                     return false;
 
-                return new DataPage(batch.GetAt(Root)).TryGet(batch, key, out result);
+                var root = batch.GetAt(Root);
+
+                return root.Header.PageType == PageType.DataPage
+                    ? new DataPage(root).TryGet(batch, key, out result)
+                    : new BottomPage(root).TryGet(batch, key, out result);
             }
 
             public void Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -571,7 +571,8 @@ public static class StorageFanOut
                     return true;
                 }
 
-                if (Root.IsNull)
+                // If key is empty it should be in the bucket, if root is null, not progress as well
+                if (key.IsEmpty || Root.IsNull)
                     return false;
 
                 var root = batch.GetAt(Root);
@@ -585,7 +586,8 @@ public static class StorageFanOut
             {
                 Page root;
 
-                if (Root.IsNull == false && batch.WasWritten(Root))
+                // Try writing through if the key is non empty, the root exists and the Root was written in this batch
+                if (key.IsEmpty == false && Root.IsNull == false && batch.WasWritten(Root))
                 {
                     // Root exists, and was written in this batch. Write through.
                     Map.Delete(key);
@@ -612,15 +614,33 @@ public static class StorageFanOut
 
                 foreach (var item in Map.EnumerateAll())
                 {
+                    if (item.Key.IsEmpty)
+                    {
+                        // Omit flushing down the empty key
+                        continue;
+                    }
+
                     root = root.Header.PageType == PageType.DataPage
                         ? new DataPage(root).Set(item.Key, item.RawData, batch)
                         : new BottomPage(root).Set(item.Key, item.RawData, batch);
 
                     Debug.Assert(batch.GetAddress(root) == Root, "Should have been COWed before");
+
+                    // Delete each item that is moved
+                    Map.Delete(item);
                 }
 
-                // Clear map, all copied
-                Map.Clear();
+                if (key.IsEmpty)
+                {
+                    if (Map.TrySet(key, data))
+                    {
+                        return;
+                    }
+
+                    throw new Exception("Should be able to set the value");
+                }
+
+                Debug.Assert(key.IsEmpty == false, "Key should not be empty here");
 
                 // Set below
                 if (root.Header.PageType == PageType.DataPage)


### PR DESCRIPTION
This PR makes the `StorageFanOut.Bucket` keep the root of the storage tree and not flush it down. Should save some space and keep the root one level up.