### PR TITLE
BitFilter made faster

### DIFF
--- a/src/Paprika.Benchmarks/Allocator.cs
+++ b/src/Paprika.Benchmarks/Allocator.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+using Paprika.Store;
+
+namespace Paprika.Benchmarks;
+
+public static class Allocator
+{
+    public static unsafe void* AllocAlignedPage(bool clean = true)
+    {
+        const UIntPtr size = Page.PageSize;
+        var memory = NativeMemory.AlignedAlloc(size, size);
+        if (clean)
+        {
+            NativeMemory.Clear(memory, size);
+        }
+
+        return memory;
+    }
+}

--- a/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
+++ b/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
@@ -18,6 +18,12 @@ public class BitMapFilterBenchmarks
     private readonly Page[] _pages16A = AlignedAlloc(128);
     private readonly Page[] _pages16B = AlignedAlloc(128);
 
+    private readonly BitMapFilter<BitMapFilter.OfN>[] _filters = Enumerable.Range(0, MaxFilterCount)
+        .Select(i => new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(AlignedAlloc(128))))
+        .ToArray();
+
+    private const int MaxFilterCount = 64;
+
     [Benchmark(OperationsPerInvoke = 4)]
     public void Or_BitMapFilter_Of1()
     {
@@ -57,16 +63,12 @@ public class BitMapFilterBenchmarks
     [Benchmark]
     [Arguments(16)]
     [Arguments(32)]
-    [Arguments(64)]
+    [Arguments(MaxFilterCount)]
     public void Or_BitMapFilter_OfN_128_Multiple(int count)
     {
         var a = new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16A));
-
-        var filters = Enumerable.Range(0, count)
-            .Select(i => new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16B)))
-            .ToArray();
-
-        a.OrWith(filters);
+        _filters.AsSpan(0, count).ToArray();
+        a.OrWith(_filters);
     }
 
     [Benchmark(OperationsPerInvoke = 4)]

--- a/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
+++ b/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
@@ -67,14 +67,14 @@ public class BitMapFilterBenchmarks
     }
 
     [Benchmark]
-    //[Arguments(16)]
-    //[Arguments(32)]
+    [Arguments(16)]
+    [Arguments(32)]
     [Arguments(MaxFilterCount)]
     public void Or_BitMapFilter_OfN_128_Multiple(int count)
     {
         var a = new BitMapFilter<BitMapFilter.OfN<BitMapFilter.OfNSize128>>(new BitMapFilter.OfN<BitMapFilter.OfNSize128>(_pages16A));
-        //var filters = _filters.AsSpan(0, count).ToArray();
-        a.OrWith(_filters);
+        var filters = _filters.AsSpan(0, count).ToArray();
+        a.OrWith(filters);
     }
 
     [Benchmark(OperationsPerInvoke = 4)]

--- a/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
+++ b/src/Paprika.Benchmarks/BitMapFilterBenchmarks.cs
@@ -54,6 +54,21 @@ public class BitMapFilterBenchmarks
         a.OrWith(b);
     }
 
+    [Benchmark]
+    [Arguments(16)]
+    [Arguments(32)]
+    [Arguments(64)]
+    public void Or_BitMapFilter_OfN_128_Multiple(int count)
+    {
+        var a = new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16A));
+
+        var filters = Enumerable.Range(0, count)
+            .Select(i => new BitMapFilter<BitMapFilter.OfN>(new BitMapFilter.OfN(_pages16B)))
+            .ToArray();
+
+        a.OrWith(filters);
+    }
+
     [Benchmark(OperationsPerInvoke = 4)]
     public int MayContainAny_BitMapFilter_OfN_128()
     {

--- a/src/Paprika.Benchmarks/PageExtensionsBenchmarks.cs
+++ b/src/Paprika.Benchmarks/PageExtensionsBenchmarks.cs
@@ -4,6 +4,7 @@ using Paprika.Store;
 
 namespace Paprika.Benchmarks;
 
+[DisassemblyDiagnoser]
 public class PageExtensionsBenchmarks
 {
     private readonly Page _a;

--- a/src/Paprika.Benchmarks/PageExtensionsBenchmarks.cs
+++ b/src/Paprika.Benchmarks/PageExtensionsBenchmarks.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using Paprika.Data;
+using Paprika.Store;
+
+namespace Paprika.Benchmarks;
+
+public class PageExtensionsBenchmarks
+{
+    private readonly Page _a;
+    private readonly Page _b;
+
+    public unsafe PageExtensionsBenchmarks()
+    {
+        _a = new Page((byte*)Allocator.AllocAlignedPage());
+        _b = new Page((byte*)Allocator.AllocAlignedPage());
+    }
+
+    [Benchmark]
+    public void OrWith()
+    {
+        _a.OrWith(_b);
+    }
+}

--- a/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
+++ b/src/Paprika.Benchmarks/Paprika.Benchmarks.csproj
@@ -9,8 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.12" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.14.0" />
+      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
+++ b/src/Paprika.Benchmarks/SlottedArrayBenchmarks.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Paprika.Crypto;
 using Paprika.Data;
@@ -29,7 +28,7 @@ public unsafe class SlottedArrayBenchmarks
     public SlottedArrayBenchmarks()
     {
         // Create keys
-        _keys = AllocAlignedPage();
+        _keys = Allocator.AllocAlignedPage();
 
         var span = new Span<byte>(_keys, Page.PageSize);
         for (byte i = 0; i < KeyCount; i++)
@@ -41,7 +40,7 @@ public unsafe class SlottedArrayBenchmarks
         }
 
         // Map
-        _map = AllocAlignedPage();
+        _map = Allocator.AllocAlignedPage();
         Span<byte> value = stackalloc byte[1];
 
         var map = new SlottedArray(new Span<byte>(_map, Page.PageSize));
@@ -55,7 +54,7 @@ public unsafe class SlottedArrayBenchmarks
         }
 
         // Hash colliding
-        _hashCollidingKeys = AllocAlignedPage();
+        _hashCollidingKeys = Allocator.AllocAlignedPage();
 
         // Create keys so that two consecutive ones share the hash.
         // This should make it somewhat realistic where there are some collisions but not a lot of them.
@@ -72,7 +71,7 @@ public unsafe class SlottedArrayBenchmarks
             hashCollidingKeys[i * BytesPerKeyHashColliding + 2] = (byte)(i / 2);
         }
 
-        _hashCollidingMap = AllocAlignedPage();
+        _hashCollidingMap = Allocator.AllocAlignedPage();
 
         var hashColliding = new SlottedArray(new Span<byte>(_hashCollidingMap, Page.PageSize));
         for (byte i = 0; i < HashCollidingKeyCount; i++)
@@ -82,16 +81,6 @@ public unsafe class SlottedArrayBenchmarks
             {
                 throw new Exception("Not enough memory");
             }
-        }
-
-        return;
-
-        static void* AllocAlignedPage()
-        {
-            const UIntPtr size = Page.PageSize;
-            var memory = NativeMemory.AlignedAlloc(size, size);
-            NativeMemory.Clear(memory, size);
-            return memory;
         }
     }
 

--- a/src/Paprika.Tests/Data/BitMapFilterTests.cs
+++ b/src/Paprika.Tests/Data/BitMapFilterTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Runtime.CompilerServices;
+using FluentAssertions;
 using Paprika.Chain;
 using Paprika.Data;
 
@@ -69,6 +70,12 @@ public abstract class BitMapFilterTests<TAccessor> : IDisposable
         filter.Return(_pool);
     }
 
+    [Test]
+    public void Size()
+    {
+        Console.WriteLine(Unsafe.SizeOf<BitMapFilter<TAccessor>>());
+    }
+
 
     public void Dispose() => _pool.Dispose();
 }
@@ -86,10 +93,13 @@ public class BitMapFilterTestsOf2 : BitMapFilterTests<BitMapFilter.Of2>
 }
 
 [TestFixture]
-public class BitMapFilterTestsOf4 : BitMapFilterTests<BitMapFilter.OfN>
+public class BitMapFilterTestsOf4 : BitMapFilterTests<BitMapFilter.OfN<OfSize4>>
 {
-    protected override BitMapFilter<BitMapFilter.OfN> Build(BufferPool pool) => BitMapFilter.CreateOfN(pool, 4);
+    protected override BitMapFilter<BitMapFilter.OfN<OfSize4>> Build(BufferPool pool) =>
+        BitMapFilter.CreateOfN<OfSize4>(pool);
 }
 
-
-
+public struct OfSize4 : BitMapFilter.IOfNSize
+{
+    public static int Count => 4;
+}

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -13,7 +13,7 @@ using Paprika.Data;
 using Paprika.Merkle;
 using Paprika.Store;
 using Paprika.Utils;
-using BitFilter = Paprika.Data.BitMapFilter<Paprika.Data.BitMapFilter.OfN>;
+using BitFilter = Paprika.Data.BitMapFilter<Paprika.Data.BitMapFilter.OfN<Paprika.Data.BitMapFilter.OfNSize128>>;
 
 namespace Paprika.Chain;
 
@@ -483,7 +483,7 @@ public class Blockchain : IAsyncDisposable
         }
     }
 
-    private BitFilter CreateBitFilter() => BitMapFilter.CreateOfN(_pool, BitMapFilterSizePerBlock);
+    private BitFilter CreateBitFilter() => BitMapFilter.CreateOfN<BitMapFilter.OfNSize128>(_pool);
 
     /// <summary>
     /// Represents a block that is a result of ExecutionPayload.

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -2031,11 +2031,7 @@ public class Blockchain : IAsyncDisposable
             return null;
 
         var filter = CreateBitFilter();
-        foreach (var ancestor in ancestors)
-        {
-            filter.OrWith(ancestor.Filter);
-        }
-
+        filter.OrWith(ancestors.Select(a => a.Filter).ToArray());
         return filter;
     }
 

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -19,15 +19,16 @@ public static class BitMapFilter
 
     public static BitMapFilter<Of2> CreateOf2(BufferPool pool) => new(new Of2(pool.Rent(true), pool.Rent(true)));
 
-    public static BitMapFilter<OfN> CreateOfN(BufferPool pool, int n)
+    public static BitMapFilter<OfN<TSize>> CreateOfN<TSize>(BufferPool pool)
+        where TSize : IOfNSize
     {
-        var pages = new Page[n];
-        for (var i = 0; i < n; i++)
+        var pages = new Page[TSize.Count];
+        for (var i = 0; i < TSize.Count; i++)
         {
             pages[i] = pool.Rent(true);
         }
 
-        return new BitMapFilter<OfN>(new OfN(pages));
+        return new BitMapFilter<OfN<TSize>>(new OfN<TSize>(pages));
     }
 
     public interface IAccessor<TAccessor>
@@ -48,20 +49,13 @@ public static class BitMapFilter
         void OrWith(in TAccessor other);
 
         [Pure]
-        void OrWith<TAncestorProvider>(TAncestorProvider[] others)
-            where TAncestorProvider : struct, IAccessorProvider<TAccessor>
+        void OrWith(TAccessor[] others)
         {
             foreach (var other in others)
             {
-                OrWith(other.Accessor);
+                OrWith(other);
             }
         }
-    }
-
-    public interface IAccessorProvider<TAccessor>
-        where TAccessor : struct, IAccessor<TAccessor>
-    {
-        public TAccessor Accessor { get; }
     }
 
     public readonly struct Of1(Page page) : IAccessor<Of1>
@@ -122,24 +116,34 @@ public static class BitMapFilter
         }
     }
 
-    public readonly struct OfN : IAccessor<OfN>
+    public interface IOfNSize
+    {
+        public static abstract int Count { get; }
+    }
+
+    public struct OfNSize128 : IOfNSize
+    {
+        public static int Count => 128;
+    }
+
+    public readonly struct OfN<TSize> : IAccessor<OfN<TSize>>
+        where TSize : IOfNSize
     {
         private readonly Page[] _pages;
-        private readonly byte _pageMask;
-        private readonly byte _pageMaskShift;
+
+        private static int PageMask => TSize.Count - 1;
+        private static int PageMaskShift => BitOperations.Log2((uint)TSize.Count);
 
         public OfN(Page[] pages)
         {
             _pages = pages;
-            Debug.Assert(BitOperations.IsPow2(pages.Length));
-            _pageMask = (byte)(pages.Length - 1);
-            _pageMaskShift = (byte)BitOperations.Log2((uint)pages.Length);
+            Debug.Assert(pages.Length == TSize.Count);
         }
 
         public unsafe ref int GetSlot(uint hash)
         {
-            var page = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_pages), (int)(hash & _pageMask));
-            var index = (hash >> _pageMaskShift) & SlotsPerPageMask;
+            var page = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_pages), (int)(hash & PageMask));
+            var index = (hash >> PageMaskShift) & SlotsPerPageMask;
 
             return ref Unsafe.Add(ref Unsafe.AsRef<int>(page.Raw.ToPointer()), index);
         }
@@ -160,11 +164,11 @@ public static class BitMapFilter
             }
         }
 
-        public void OrWith(in OfN other)
+        public void OrWith(in OfN<TSize> other)
         {
             var count = PageCount;
 
-            Debug.Assert(other.PageCount == count);
+            Debug.Assert(PageCount == count);
 
             ref var a = ref MemoryMarshal.GetArrayDataReference(_pages);
             ref var b = ref MemoryMarshal.GetArrayDataReference(other._pages);
@@ -176,8 +180,7 @@ public static class BitMapFilter
         }
 
         [Pure]
-        public void OrWith<TAncestorProvider>(TAncestorProvider[] others)
-            where TAncestorProvider : struct, IAccessorProvider<OfN>
+        public void OrWith(OfN<TSize>[] others)
         {
             var pages = _pages;
 
@@ -193,27 +196,27 @@ public static class BitMapFilter
                         // prefetch next
                         unsafe
                         {
-                            Sse.Prefetch2(others[j + 1].Accessor._pages[i].Payload);
+                            Sse.Prefetch2(others[j + 1]._pages[i].Payload);
                         }
                     }
 
-                    page.OrWith(others[j].Accessor._pages[i]);
+                    page.OrWith(others[j]._pages[i]);
                 }
 
-                page.OrWith(others[length - 1].Accessor._pages[i]);
+                page.OrWith(others[length - 1]._pages[i]);
             });
         }
 
         public int BucketCount => Page.PageSize * BitsPerByte * PageCount;
 
-        private int PageCount => _pageMask + 1;
+        private static int PageCount => TSize.Count;
     }
 }
 
 /// <summary>
 /// Represents a simple bitmap based filter for <see cref="ulong"/> hashes.
 /// </summary>
-public readonly struct BitMapFilter<TAccessor> : BitMapFilter.IAccessorProvider<TAccessor>
+public readonly struct BitMapFilter<TAccessor>
     where TAccessor : struct, BitMapFilter.IAccessor<TAccessor>
 {
     private readonly TAccessor _accessor;
@@ -305,11 +308,18 @@ public readonly struct BitMapFilter<TAccessor> : BitMapFilter.IAccessorProvider<
     /// <remarks>
     /// A bulk version of <see cref="OrWith(in Paprika.Data.BitMapFilter{TAccessor})"/>.
     /// </remarks>
-    public void OrWith(BitMapFilter<TAccessor>[] others) => _accessor.OrWith(others);
+    public void OrWith(BitMapFilter<TAccessor>[] others)
+    {
+        var copy = new TAccessor[others.Length];
+        for (int i = 0; i < others.Length; i++)
+        {
+            copy[i] = others[i]._accessor;
+        }
+
+        _accessor.OrWith(copy);
+    }
 
     public int BucketCount => _accessor.BucketCount;
 
     public void Return(BufferPool pool) => _accessor.Return(pool);
-
-    public TAccessor Accessor => _accessor;
 }

--- a/src/Paprika/Data/BitMapFilter.cs
+++ b/src/Paprika/Data/BitMapFilter.cs
@@ -174,6 +174,22 @@ public static class BitMapFilter
             }
         }
 
+        [Pure]
+        public void OrWith<TAncestorProvider>(TAncestorProvider[] others)
+            where TAncestorProvider : struct, IAccessorProvider<OfN>
+        {
+            var pages = _pages;
+
+            Parallel.For(0, PageCount, i =>
+            {
+                var page = pages[i];
+                foreach (var t in others)
+                {
+                    page.OrWith(t.Accessor._pages[i]);
+                }
+            });
+        }
+
         public int BucketCount => Page.PageSize * BitsPerByte * PageCount;
 
         private int PageCount => _pageMask + 1;

--- a/src/Paprika/Data/PageExtensions.cs
+++ b/src/Paprika/Data/PageExtensions.cs
@@ -9,10 +9,12 @@ namespace Paprika.Data;
 /// </summary>
 public static class PageExtensions
 {
+    [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static unsafe void OrWith(this Page @this, Page other)
     {
         const int bitsPerByte = 8;
+        const int unroll = 2;
 
         ref var a = ref Unsafe.AsRef<byte>(@this.Raw.ToPointer());
         ref var b = ref Unsafe.AsRef<byte>(other.Raw.ToPointer());
@@ -21,39 +23,57 @@ public static class PageExtensions
         {
             const int size = 512 / bitsPerByte;
 
-            for (UIntPtr i = 0; i < Page.PageSize; i += size)
+            for (UIntPtr i = 0; i < Page.PageSize; i += size * unroll)
             {
-                var va = Vector512.LoadUnsafe(ref a, i);
-                var vb = Vector512.LoadUnsafe(ref b, i);
-                var vc = Vector512.BitwiseOr(va, vb);
+                var va1 = Vector512.LoadUnsafe(ref a, i);
+                var vb1 = Vector512.LoadUnsafe(ref b, i);
+                var vc1 = Vector512.BitwiseOr(va1, vb1);
 
-                vc.StoreUnsafe(ref a, i);
+                vc1.StoreUnsafe(ref a, i);
+
+                var va2 = Vector512.LoadUnsafe(ref a, i + size);
+                var vb2 = Vector512.LoadUnsafe(ref b, i + size);
+                var vc2 = Vector512.BitwiseOr(va2, vb2);
+
+                vc2.StoreUnsafe(ref a, i + size);
             }
         }
         else if (Vector256.IsHardwareAccelerated)
         {
             const int size = 256 / bitsPerByte;
 
-            for (UIntPtr i = 0; i < Page.PageSize; i += size)
+            for (UIntPtr i = 0; i < Page.PageSize; i += size * unroll)
             {
-                var va = Vector256.LoadUnsafe(ref a, i);
-                var vb = Vector256.LoadUnsafe(ref b, i);
-                var vc = Vector256.BitwiseOr(va, vb);
+                var va1 = Vector256.LoadUnsafe(ref a, i);
+                var vb1 = Vector256.LoadUnsafe(ref b, i);
+                var vc1 = Vector256.BitwiseOr(va1, vb1);
 
-                vc.StoreUnsafe(ref a, i);
+                vc1.StoreUnsafe(ref a, i);
+
+                var va2 = Vector256.LoadUnsafe(ref a, i + size);
+                var vb2 = Vector256.LoadUnsafe(ref b, i + size);
+                var vc2 = Vector256.BitwiseOr(va2, vb2);
+
+                vc2.StoreUnsafe(ref a, i + size);
             }
         }
         else if (Vector128.IsHardwareAccelerated)
         {
             const int size = 128 / bitsPerByte;
 
-            for (UIntPtr i = 0; i < Page.PageSize; i += size)
+            for (UIntPtr i = 0; i < Page.PageSize; i += size * unroll)
             {
-                var va = Vector128.LoadUnsafe(ref a, i);
-                var vb = Vector128.LoadUnsafe(ref b, i);
-                var vc = Vector128.BitwiseOr(va, vb);
+                var va1 = Vector128.LoadUnsafe(ref a, i);
+                var vb1 = Vector128.LoadUnsafe(ref b, i);
+                var vc1 = Vector128.BitwiseOr(va1, vb1);
 
-                vc.StoreUnsafe(ref a, i);
+                vc1.StoreUnsafe(ref a, i);
+
+                var va2 = Vector128.LoadUnsafe(ref a, i + size);
+                var vb2 = Vector128.LoadUnsafe(ref b, i + size);
+                var vc2 = Vector128.BitwiseOr(va2, vb2);
+
+                vc2.StoreUnsafe(ref a, i + size);
             }
         }
         else


### PR DESCRIPTION
This PR amends BitFilter to make it faster. Tracing shows that up to 8% of the block execution falls into the `BitFilter` creation. By making it faster, we can improve the time before other endeavors like #417 are taken. This PR:

1. improves `Page.OrWith` by unrolling the loop and making two vectorized operations per spin that gives ~20% improvement
2. makes or-ing of multiple filters parallel, by applying the operation per range of pages at the specific index. Think running it by column rather then by row. This should help in both cases, where the number of committed sets is low and high.
3. uses SSE prefetch to get the next page before it's ORed
4. modifies the `OfN` bit filter so that it uses a generic `<TSize>` parameter that allows to skip the length, mask and shift fields

Overall, `BitFilter` creation is ~60% faster now (depends on the number of ancestors).

The allocation on the filter comes mostly from `Parallel.For` that allocates 3.6kb on its own. It looks that we need to pay the cost.

### Benchmarks

#### Page.OrWith

| Method | Mean     | Error    | StdDev   | Code Size |
|------- |---------:|---------:|---------:|----------:|
| OrWith (before) | 41.86 ns | 0.576 ns | 0.510 ns |      48 B |
| OrWith (after) | 36.77 ns | 0.372 ns | 0.330 ns |      63 B |

#### BitFiler.OrWith

| Method                           | count | Mean     | Error    | StdDev   | Gen0   | Code Size | Allocated |
|--------------------------------- |------ |---------:|---------:|---------:|-------:|----------:|----------:|
| Or_BitMapFilter_OfN_128_Multiple (before) | 16    |   223.0 us |  4.13 us |  3.86 us |     0 | 376 B |     328 B |
| Or_BitMapFilter_OfN_128_Multiple | 16    | 101.9 us | 5.61 us | 16.28 us | 0.3662 |   2,370 B |   5.56 KB |
| Or_BitMapFilter_OfN_128_Multiple (before) | 32    |   498.0 us |  9.87 us | 17.29 us |     0 |  376 B |     584 B |
| Or_BitMapFilter_OfN_128_Multiple | 32    | 108.6 us | 2.14 us |  3.08 us | 0.2441 |   2,408 B |   4.77 KB |
| Or_BitMapFilter_OfN_128_Multiple (before) | 64    | 1,423.7 us | 19.28 us | 16.10 us |  0 |    376 B |    1097 B |
| Or_BitMapFilter_OfN_128_Multiple | 64    | 344.2 us | 5.55 us |  4.92 us | 0.4883 |   2,401 B |   6.42 KB |

### Assembly

The assembly for `Page.OrWith`

#### Before

```assembly
; Paprika.Benchmarks.PageExtensionsBenchmarks.OrWith()
       vzeroupper
       mov       rax,[rcx+8]
       mov       rcx,[rcx+10]
       xor       edx,edx
       nop       dword ptr [rax]
M00_L00:
       vmovups   ymm0,[rax+rdx]
       vpor      ymm0,ymm0,[rcx+rdx]
       vmovups   [rax+rdx],ymm0
       add       rdx,20
       cmp       rdx,1000
       jb        short M00_L00
       vzeroupper
       ret
; Total bytes of code 48
```

#### After

```assembly
; Paprika.Benchmarks.PageExtensionsBenchmarks.OrWith()
       vzeroupper
       mov       rax,[rcx+8]
       mov       rcx,[rcx+10]
       xor       edx,edx
M00_L00:
       vmovups   ymm0,[rax+rdx]
       vpor      ymm0,ymm0,[rcx+rdx]
       vmovups   [rax+rdx],ymm0
       vmovups   ymm0,[rax+rdx+20]
       vpor      ymm0,ymm0,[rcx+rdx+20]
       vmovups   [rax+rdx+20],ymm0
       add       rdx,40
       cmp       rdx,1000
       jb        short M00_L00
       vzeroupper
       ret
; Total bytes of code 63
```