### PR TITLE
Create directory if not exists

### DIFF
--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -43,6 +43,11 @@ public sealed class MemoryMappedPageManager : PointerPageManager
 
         if (!File.Exists(Path))
         {
+            var directory = System.IO.Path.GetDirectoryName(Path);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
             _file = File.OpenHandle(Path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, PaprikaFileOptions);
 
             // set length


### PR DESCRIPTION
Otherwise OpenFile fails with 

```
System.IO.DirectoryNotFoundException: Could not find a part of the path 'D:\ethereum\nethermind_db\mainnet\state\paprika.db'.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.OpenHandle(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at Paprika.Store.PageManagers.MemoryMappedPageManager..ctor(Int64 size, Byte historyDepth, String dir, PersistenceOptions options)
```