### PR TITLE
Better Merkle prefetcher

### DIFF
--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -102,7 +102,7 @@ public class PrefetchingTests
             var random = new Random(seed);
 
             // Open prefetcher on blocks beyond first
-            IPreCommitPrefetcher? prefetcher = null;
+            var prefetcher = isFirst == false ? block.OpenPrefetcher() : null;
 
             for (var i = 0; i < contracts; i++)
             {

--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -70,6 +70,60 @@ public class PrefetchingTests
         }
     }
 
+    [Test]
+    public async Task Makes_all_decompression_on_prefetch()
+    {
+        using var db = PagedDb.NativeMemoryDb(8 * 1024 * 1024, 2);
+        var merkle = new ComputeMerkleBehavior(ComputeMerkleBehavior.ParallelismNone);
+        await using var blockchain = new Blockchain(db, merkle);
+
+        // Create one block with some values, commit it and finalize
+        var hash = Keccak.EmptyTreeHash;
+
+        hash = BuildBlock(blockchain, hash, 1);
+        blockchain.Finalize(hash);
+        await blockchain.WaitTillFlush(hash);
+
+        using (RlpMemo.NoDecompression())
+        {
+            hash = BuildBlock(blockchain, hash, 2);
+        }
+
+        return;
+
+        static Keccak BuildBlock(Blockchain blockchain, Keccak parent, uint number)
+        {
+            var isFirst = number == 1;
+
+            byte[] value = isFirst ? [17] : [23];
+
+            const int seed = 13;
+            const int contracts = 10;
+            const int slots = 10;
+
+            using var block = blockchain.StartNew(parent);
+            var random = new Random(seed);
+
+            for (var i = 0; i < contracts; i++)
+            {
+                var contract = random.NextKeccak();
+
+                if (isFirst)
+                {
+                    block.SetAccount(contract, new Account(1, 1, Keccak.Zero, Keccak.Zero));
+                }
+
+                for (var j = 0; j < slots; j++)
+                {
+                    var storage = random.NextKeccak();
+                    block.SetStorage(contract, storage, value);
+                }
+            }
+
+            return block.Commit(number);
+        }
+    }
+
     private static void Set(Keccak[] accounts, uint account, IWorldState start, UInt256 bigNonce)
     {
         ref var k = ref accounts[account];

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -100,7 +100,7 @@ public class Blockchain : IAsyncDisposable
         _cacheUsagePreCommit = _meter.CreateHistogram<int>("PreCommit transient cache usage per commit", "%",
             "How much used was the transient cache");
         _prefetchCount = _meter.CreateHistogram<int>("Prefetch count",
-            "Number of prefetches performed by the prefetcher", "count");
+            "Key count", "Keys prefetched in the background by the prefetcher");
 
         // pool
         _pool = new(1024, true, _meter);

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -792,6 +792,11 @@ public class Blockchain : IAsyncDisposable
                 }
             }
 
+            public void SpinTillPrefetchDone()
+            {
+                SpinWait.SpinUntil(() => _working == NotWorking);
+            }
+
             private bool ShouldPrefetch(ulong hash) => _prefetched.AddAtomic(hash);
 
             public void PrefetchStorage(in Keccak account, in Keccak storage)

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -38,10 +38,13 @@ public interface IPrefetcherContext
 
     /// <summary>
     /// Tries to retrieve the result stored under the given key.
-    /// If it fails to get it from the current state, it will fetch it from the ancestors and store it accordingly to the
-    /// <paramref name="entryMapping"/>.
+    /// If it fails to get it from the current state,
+    /// it will fetch it from the ancestors and store it after transforming it with <paramref name="transform"/>.
     /// </summary>
-    public ReadOnlySpanOwner<byte> Get(scoped in Key key, SpanFunc<EntryType> entryMapping);
+    public ReadOnlySpanOwner<byte> Get(scoped in Key key, TransformPrefetchedData transform);
 }
 
-public delegate TResult SpanFunc<TResult>(in ReadOnlySpan<byte> data);
+/// <summary>
+/// Transforms incoming <paramref name="data"/> to the result, providing the type of the entry as well.
+/// </summary>
+public delegate ReadOnlySpan<byte> TransformPrefetchedData(in ReadOnlySpan<byte> data, in Span<byte> workspace, out EntryType type);

--- a/src/Paprika/Chain/IPreCommitPrefetcher.cs
+++ b/src/Paprika/Chain/IPreCommitPrefetcher.cs
@@ -27,6 +27,11 @@ public interface IPreCommitPrefetcher
     /// <param name="account">The account to be prefetched.</param>
     /// <param name="storage">The storage slot</param>
     void PrefetchStorage(in Keccak account, in Keccak storage);
+
+    /// <summary>
+    /// <see cref="SpinWait.SpinUntil(System.Func{bool})"/> the prefetch is done.
+    /// </summary>
+    void SpinTillPrefetchDone();
 }
 
 /// <summary>

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -757,7 +757,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
             public IChildCommit GetChild() => new ChildCommit(parent, commit.GetChild());
 
-            public bool Owns(object? actualSpanOwner) => ReferenceEquals(actualSpanOwner, commit);
+            public bool Owns(object? actualSpanOwner) => ReferenceEquals(actualSpanOwner, parent);
 
             public IReadOnlyDictionary<Keccak, int> Stats =>
                 throw new NotImplementedException("No stats for the child commit");

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1438,8 +1438,39 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         PrefetchImpl(account, storage, context);
     }
 
+    private static ReadOnlySpan<byte> Transform(in ReadOnlySpan<byte> data, in Span<byte> workspace, out EntryType type)
+    {
+        if (data.IsEmpty || Node.Header.GetTypeFrom(data) != Node.Type.Branch)
+        {
+            type = EntryType.UseOnce;
+            return data;
+        }
+
+        Debug.Assert(Node.Header.GetTypeFrom(data) == Node.Type.Branch);
+
+        // Branch should be always persistent, already copied and ready to work with.
+        type = EntryType.Persistent;
+
+        var leftoverLength = Node.Branch.ReadFrom(data, out var branch).Length;
+        if (leftoverLength == RlpMemo.Size)
+        {
+            // Rlp memo is decompressed, good to be stored as is.
+            return data;
+        }
+
+        // RlpMemo not decompressed.
+
+        // Write branch first
+        var leftover = branch.WriteToWithLeftover(workspace);
+
+        // Decompress to the leftover
+        RlpMemo.Decompress(leftover, branch.Children, leftover);
+
+        return workspace[..(workspace.Length - leftover.Length + RlpMemo.Size)];
+    }
+
     [SkipLocalsInit]
-    private static void PrefetchImpl(in Keccak account, in Keccak storage, IPrefetcherContext context)
+    private void PrefetchImpl(in Keccak account, in Keccak storage, IPrefetcherContext context)
     {
         var isAccountPrefetch = Unsafe.IsNullRef(in storage);
         var accountPath = NibblePath.FromKey(account);
@@ -1461,7 +1492,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             var leftoverPath = path.SliceFrom(i);
 
             // Query for the node
-            using var owner = context.Get(key, GetEntryType);
+            using var owner = context.Get(key, Transform);
 
             if (owner.IsEmpty)
             {


### PR DESCRIPTION
This PR changes the `Prefetcher` component to fix a bug. It also addresses a few issues in the construction and usage of the prefetcher in regards to the `ComputeMerkleBehavior`. It makes the following changes:

1. `Prefetcher` always owns the `cache` / `preCommit` explicitly with a lock. The lock will not be contended as there will be only one `IThreadPoolWorkItem` executing at any time. This allows for a simple ownership of this dictionary that should be owned either by `Prefetcher` (when possible and spinning to prefetch things) or `ComputeMerkleBehavior` when performing the computation.
2. `RlpMemo.Decompress` is from now on called on by `Prefetcher` whenever the `Branch` is not loaded into the current block yet. Previously, compressed `RlpMemo` was stored, which resulted in `MarkPathAsDirty` and other calls sites, decompressing `RlpMemo` in the hot path. Now, with the data decompressed. It should just use data.
3. `ChildCommit` now delegates the ownership to its parent, similar to what #420 did for `Prefixing`. This should limit the number of copies further, directly writing to the parent commit as the data are fetched already by `Prefetcher`


