### PR TITLE
Merkle Decompress fix

### DIFF
--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -11,6 +11,7 @@ using Paprika.Store;
 
 namespace Paprika.Tests.Chain;
 
+[Parallelizable(ParallelScope.None)]
 public class PrefetchingTests
 {
     [Test]


### PR DESCRIPTION
The `NoDecompression` scope introduced in #435 introduced a scope dependency in tests. For now, the suite is set as non-parallelizable to fix it. The scoping behavior is not altered as it's used only for sake of tests.