### PR TITLE
Merkle amendments

### DIFF
--- a/src/Paprika.Tests/Merkle/Commit.cs
+++ b/src/Paprika.Tests/Merkle/Commit.cs
@@ -33,11 +33,15 @@ public class Commit(bool skipMemoizedRlpCheck = false) : ICommitWithStats
         _before[GetKey(key)] = value.ToArray();
         //to enable storage root calculation for tests
 
+        if (key.Path.Length == NibblePath.KeccakNibbleCount)
+        {
+            _touchedAccounts.Add(key.Path.UnsafeAsKeccak);
+        }
+
         if (!key.IsState)
         {
             var keccak = key.Path.UnsafeAsKeccak;
 
-            _touchedAccounts.Add(keccak);
             if (key.StoragePath.Length == NibblePath.KeccakNibbleCount)
             {
                 ref var stats = ref CollectionsMarshal.GetValueRefOrAddDefault(_storageSlots, keccak, out var exists);

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -125,7 +125,7 @@ public class RootHashFuzzyTests
     }
 
     [TestCase(nameof(Accounts_10_000), 256 * 1024 * 1024L, 8)]
-    [TestCase(nameof(Accounts_1_000_000), 2 * 1024 * 1024 * 1024L, 28, Category = Categories.LongRunning)]
+    [TestCase(nameof(Accounts_1_000_000), 2 * 1024 * 1024 * 1024L, 32, Category = Categories.LongRunning)]
     public async Task CalculateThenDelete(string test, long size, int blockchainPoolSizeMB)
     {
         var generator = Build(test);

--- a/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
+++ b/src/Paprika.Tests/Merkle/RootHashFuzzyTests.cs
@@ -207,11 +207,11 @@ public class RootHashFuzzyTests
 
         public void Run(Commit commit)
         {
-            Run((ICommit)commit);
+            RunImpl(commit);
             commit.MergeAfterToBefore();
         }
 
-        public void Run(ICommit commit)
+        public void RunImpl(Commit commit)
         {
             var random = GetRandom();
             Span<byte> account = stackalloc byte[Account.MaxByteCount];

--- a/src/Paprika/Account.cs
+++ b/src/Paprika/Account.cs
@@ -12,8 +12,6 @@ namespace Paprika;
 /// </summary>
 public readonly struct Account : IEquatable<Account>
 {
-    public static readonly Account Empty = default;
-
     public readonly UInt256 Balance;
     public readonly UInt256 Nonce;
     public readonly Keccak CodeHash;

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -952,6 +952,8 @@ public class Blockchain : IAsyncDisposable
         {
             _hash = null;
 
+            _touchedAccounts.Add(address);
+
             var searched = NibblePath.FromKey(address);
 
             var account = Key.Account(address);

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -25,7 +25,7 @@ public static class CommitExtensions
             return;
         }
 
-        var leaf = new Node.Leaf(leafPath);
+        var leaf = new Leaf(leafPath);
         commit.Set(key, leaf.WriteTo(stackalloc byte[Leaf.MaxByteLength]), type);
     }
 
@@ -33,7 +33,7 @@ public static class CommitExtensions
     public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children,
         EntryType type = EntryType.Persistent)
     {
-        var branch = new Node.Branch(children);
+        var branch = new Branch(children);
         commit.Set(key, branch.WriteTo(stackalloc byte[Branch.MaxByteLength]), RlpMemo.Empty, type);
     }
 
@@ -41,7 +41,7 @@ public static class CommitExtensions
     public static void SetBranch(this ICommit commit, in Key key, NibbleSet.Readonly children, ReadOnlySpan<byte> rlp,
         EntryType type = EntryType.Persistent)
     {
-        var branch = new Node.Branch(children);
+        var branch = new Branch(children);
         commit.Set(key, branch.WriteTo(stackalloc byte[Branch.MaxByteLength]), rlp, type);
     }
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -1345,6 +1345,8 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
             return new Account(0, 0);
         }
+
+        public override string ToString() => $"{AccountKeccak}: {Written}";
     }
 
 


### PR DESCRIPTION
This PR amends the Merkle behavior in a few minor ways:

1. page rental is moved closer to the execution so that the page is rented and returned as soon as possible, both for `Storage` and `State`
1. both, `State` and `Storage` are based on stats now and none of them uses `.Visit` that was shown to be much slower
1. `.ToString` to log properly all work items

![image](https://github.com/user-attachments/assets/11d251e6-ae2a-4aea-b326-961bc54a9df4)
