### PR TITLE
Reduce RLP Compression & Decompression

### DIFF
--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -304,8 +304,6 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
             return data;
         }
 
-        //Debug.Assert(memoizedRlp.Length == RlpMemo.Size, $"Unexpected status of {memoizedRlp.Length}");
-
         // There are RLPs here, compress them
         var dataLength = data.Length - memoizedRlp.Length;
         data[..dataLength].CopyTo(workingSet);
@@ -910,7 +908,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         static void UpdateBranchOnDelete(ICommit commit, in Node.Branch branch, NibbleSet.Readonly children,
             ReadOnlySpan<byte> leftover, ReadOnlySpanOwnerWithMetadata<byte> owner, byte nibble, in Key key)
         {
-            var childRlpRequiresUpdate = owner.IsOwnedBy(commit) == false || leftover.Length != RlpMemo.Size;
+            var childRlpRequiresUpdate = owner.IsOwnedBy(commit) == false;
             RlpMemo memo;
             byte[]? rlpWorkingSet = null;
 
@@ -1181,8 +1179,9 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                         var nibble = path[i];
 
                         var childRlpRequiresUpdate = owner.IsOwnedBy(commit) == false || leftover.Length != RlpMemo.Size;
+
                         var memo = childRlpRequiresUpdate
-                            ? RlpMemo.Copy(leftover, rlpMemoWorkingSet)
+                            ? RlpMemo.Decompress(leftover, branch.Children, rlpMemoWorkingSet)
                             : new RlpMemo(MakeRlpWritable(leftover));
 
                         memo.Clear(nibble);


### PR DESCRIPTION
Currently the memoised RLPs are stored in a compressed form when flushing to the `PageDb`, but when stored in-memory, these are in the decompressed form.

This PR makes RLPMemo's `Clear/Get` operation work on the compressed data, thus avoiding decompression. The `Set` operation still requires decompressed data since it may require extra allocation when operating with the compressed form. The current approach avoids any de-allocations/allocations with multiple `Clear/Set` operations as memory is handled by the caller. Also note that these changes optimize the `Compress` operation by making it possible to compress an already (partially) compressed RLPMemo, e.g. `Compress` -> `Clear(x)` ->`Clear(y)` -> `Compress` would make it optimally compressed without performing any de-allocations in the `Clear` operation.

Multiple approaches were considered to reduce the decompressions, including RLPMemo handling its own memory, allocating/de-allocating strategically while operating on the compressed data (double/half the size similar to std::Vector). But the current approach requires minimal changes/overhead to the existing code while providing a few optimizations.