### PR TITLE
CLI verify prints the original root hash first

### DIFF
--- a/src/Paprika.Cli/VerifyWholeTreeSettings.cs
+++ b/src/Paprika.Cli/VerifyWholeTreeSettings.cs
@@ -16,12 +16,13 @@ public class VerifyWholeTreeSettings : BasePaprikaSettings
             using var read = db.BeginReadOnlyBatch();
             using var latest = Blockchain.StartReadOnlyLatestFromDb(db);
 
-            AnsiConsole.WriteLine("Checking whole tree...");
+
+            AnsiConsole.WriteLine($"The latest state root hash persisted: {latest.Hash}.");
+            AnsiConsole.WriteLine("Verification of the whole state tree in progress...");
 
             var keccak = new ComputeMerkleBehavior().CalculateStateRootHash(latest);
 
-            AnsiConsole.WriteLine($"Keccak {keccak.ToString()}");
-
+            AnsiConsole.WriteLine($"The computed state root hash {keccak.ToString()}");
 
             return 0;
         }


### PR DESCRIPTION
`Paprika.CLI` now prints the original hash first so that the user of `Paprika.Cli.exe verify` can compare them

![image](https://github.com/user-attachments/assets/a82a31a2-91c0-43e2-94ed-45cd0bfe4276)
