### PR TITLE
Remove Compression & Decompression from RLPMemo

### DIFF
--- a/src/Paprika.Tests/Chain/PrefetchingTests.cs
+++ b/src/Paprika.Tests/Chain/PrefetchingTests.cs
@@ -71,67 +71,6 @@ public class PrefetchingTests
         }
     }
 
-    [Test]
-    public async Task Makes_all_decompression_on_prefetch()
-    {
-        using var db = PagedDb.NativeMemoryDb(8 * 1024 * 1024, 2);
-        var merkle = new ComputeMerkleBehavior(ComputeMerkleBehavior.ParallelismNone);
-        await using var blockchain = new Blockchain(db, merkle);
-
-        // Create one block with some values, commit it and finalize
-        var hash = Keccak.EmptyTreeHash;
-
-        hash = BuildBlock(blockchain, hash, 1);
-        blockchain.Finalize(hash);
-        await blockchain.WaitTillFlush(hash);
-
-        hash = BuildBlock(blockchain, hash, 2);
-
-        return;
-
-        static Keccak BuildBlock(Blockchain blockchain, Keccak parent, uint number)
-        {
-            var isFirst = number == 1;
-
-            byte[] value = isFirst ? [17] : [23];
-
-            const int seed = 13;
-            const int contracts = 10;
-            const int slots = 10;
-
-            using var block = blockchain.StartNew(parent);
-            var random = new Random(seed);
-
-            // Open prefetcher on blocks beyond first
-            var prefetcher = isFirst == false ? block.OpenPrefetcher() : null;
-
-            for (var i = 0; i < contracts; i++)
-            {
-                var contract = random.NextKeccak();
-                prefetcher?.PrefetchAccount(contract);
-
-                if (isFirst)
-                {
-                    block.SetAccount(contract, new Account(1, 1, Keccak.Zero, Keccak.Zero));
-                }
-
-                for (var j = 0; j < slots; j++)
-                {
-                    var storage = random.NextKeccak();
-                    prefetcher?.PrefetchStorage(contract, storage);
-                    block.SetStorage(contract, storage, value);
-                }
-            }
-
-            prefetcher?.SpinTillPrefetchDone();
-
-            using (RlpMemo.NoDecompression())
-            {
-                return block.Commit(number);
-            }
-        }
-    }
-
     private static void Set(Keccak[] accounts, uint account, IWorldState start, UInt256 bigNonce)
     {
         ref var k = ref accounts[account];

--- a/src/Paprika.Tests/Merkle/RlpMemoTests.cs
+++ b/src/Paprika.Tests/Merkle/RlpMemoTests.cs
@@ -200,7 +200,7 @@ public class RlpMemoTests
         var children = new NibbleSet();
 
         Span<byte> keccak = new byte[Keccak.Size];
-        keccak.Fill(0xFF);            
+        keccak.Fill(0xFF);
 
         for (var i = 0; i < RlpMemo.MaxSize - NibbleSet.MaxByteSize; i++)
         {

--- a/src/Paprika.Tests/Merkle/RlpMemoTests.cs
+++ b/src/Paprika.Tests/Merkle/RlpMemoTests.cs
@@ -49,7 +49,7 @@ public class RlpMemoTests
         InsertRandomKeccak(ref memo, children, out var data, workingMemory);
 
         memo.Length.Should().Be(GetExpectedSize(children.SetCount));
-        
+
         var random = new Random(13);
 
         for (byte i = 0; i < NibbleSet.NibbleCount; i++)
@@ -421,9 +421,8 @@ public class RlpMemoTests
             else
             {
                 memo.TryGetKeccak(child.Key, out var k).Should().BeTrue();
-                k.SequenceEqual(child.Value.Span).Should().BeTrue();                
+                k.SequenceEqual(child.Value.Span).Should().BeTrue();
             }
-            
         }
 
         memo.Length.Should().Be(GetExpectedSize(data.Count));

--- a/src/Paprika.Tests/Merkle/RlpMemoTests.cs
+++ b/src/Paprika.Tests/Merkle/RlpMemoTests.cs
@@ -320,6 +320,7 @@ public class RlpMemoTests
     [Test]
     public void Keccak_to_rlp_children()
     {
+        const string prefix = "ccccccccccccccccccccddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeb";
         NibbleSet.Readonly children = new NibbleSet(1, 2);
         Span<byte> workingMemory = new byte[RlpMemo.MaxSize];
 
@@ -332,9 +333,9 @@ public class RlpMemoTests
         // leaves without any key and very small value cause to be inlined in branch
         // encoded branch rlp is also < 32 bytes which causes it to be encoded as RLP in extension node
         Keccak storageKey1 =
-            new Keccak(Convert.FromHexString("ccccccccccccccccccccddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeb1"));
+            new Keccak(Convert.FromHexString(prefix + "1"));
         Keccak storageKey2 =
-            new Keccak(Convert.FromHexString("ccccccccccccccccccccddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeb2"));
+            new Keccak(Convert.FromHexString(prefix + "2"));
 
         var commit = new Commit();
         commit.Set(Key.Account(Values.Key0),
@@ -347,9 +348,7 @@ public class RlpMemoTests
         merkle.BeforeCommit(commit, CacheBudget.Options.None.Build());
 
         // Update the branch with memo
-        commit.SetBranch(
-            Key.Raw(NibblePath.FromKey(Values.Key0), DataType.Merkle,
-                NibblePath.Parse("CCCCCCCCCCCCCCCCCCCCDDDDDDDDDDDDDDDDEEEEEEEEEEEEEEEEEEEEEEEEEEB")), children,
+        commit.SetBranch(Key.Raw(NibblePath.FromKey(Values.Key0), DataType.Merkle, NibblePath.Parse(prefix)), children,
             memo.Raw);
 
         merkle.RecalculateStorageTrie(commit, Values.Key0, CacheBudget.Options.None.Build());

--- a/src/Paprika.Tests/Merkle/RlpMemoTests.cs
+++ b/src/Paprika.Tests/Merkle/RlpMemoTests.cs
@@ -320,7 +320,6 @@ public class RlpMemoTests
     [Test]
     public void Keccak_to_rlp_children()
     {
-        const string prefix = "ccccccccccccccccccccddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeb";
         NibbleSet.Readonly children = new NibbleSet(1, 2);
         Span<byte> workingMemory = new byte[RlpMemo.MaxSize];
 
@@ -332,6 +331,7 @@ public class RlpMemoTests
         //            ->L
         // leaves without any key and very small value cause to be inlined in branch
         // encoded branch rlp is also < 32 bytes which causes it to be encoded as RLP in extension node
+        const string prefix = "ccccccccccccccccccccddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeb";
         Keccak storageKey1 =
             new Keccak(Convert.FromHexString(prefix + "1"));
         Keccak storageKey2 =

--- a/src/Paprika.Tests/Merkle/RlpMemoTests.cs
+++ b/src/Paprika.Tests/Merkle/RlpMemoTests.cs
@@ -183,7 +183,7 @@ public class RlpMemoTests
 
         for (var i = 0; i < NibbleSet.NibbleCount; i++)
         {
-            children[(byte)i] = false;
+            children[(byte)i] = true;
         }
 
         var memo = new RlpMemo(raw);

--- a/src/Paprika.Tests/Merkle/RlpMemoTests.cs
+++ b/src/Paprika.Tests/Merkle/RlpMemoTests.cs
@@ -409,6 +409,7 @@ public class RlpMemoTests
 
     private static void CompareMemoAndDict(RlpMemo memo, Dictionary<byte, Keccak> data)
     {
+        // All the elements in dictionary should be in the memo.
         foreach (var child in data)
         {
             memo.Exists(child.Key).Should().BeTrue();
@@ -422,6 +423,25 @@ public class RlpMemoTests
             {
                 memo.TryGetKeccak(child.Key, out var k).Should().BeTrue();
                 k.SequenceEqual(child.Value.Span).Should().BeTrue();
+            }
+        }
+
+        // All the elements in the memo should be in the dictionary.
+        for (byte i = 0; i < NibbleSet.NibbleCount; i++)
+        {
+            if (memo.Exists(i))
+            {
+                data.ContainsKey(i).Should().BeTrue();
+
+                if (memo.TryGetKeccak(i, out var k))
+                {
+                    k.SequenceEqual(data[i].Span).Should().BeTrue();
+                }
+                else
+                {
+                    k.IsEmpty.Should().BeTrue();
+                    Keccak.Zero.Span.SequenceEqual(data[i].Span).Should().BeTrue();
+                }
             }
         }
 

--- a/src/Paprika.Tests/Merkle/RlpMemoTests.cs
+++ b/src/Paprika.Tests/Merkle/RlpMemoTests.cs
@@ -5,6 +5,7 @@ using Paprika.Merkle;
 
 namespace Paprika.Tests.Merkle;
 
+[Ignore("Needs refactoring as RLPMemo compression/decompression is removed")]
 public class RlpMemoTests
 {
     public const bool OddKey = true;
@@ -64,8 +65,8 @@ public class RlpMemoTests
 
         // clear zeroes
         var memo = new RlpMemo(raw);
-        memo.Clear((byte)zero0);
-        memo.Clear((byte)zero1);
+        memo.Clear((byte)zero0, NibbleSet.Readonly.All);
+        memo.Clear((byte)zero1, NibbleSet.Readonly.All);
 
         Run(raw, RlpMemo.Size - 2 * Keccak.Size + NibbleSet.MaxByteSize, NibbleSet.Readonly.All, OddKey);
     }
@@ -123,17 +124,5 @@ public class RlpMemoTests
         Span<byte> writeTo = stackalloc byte[compressedSize];
         var written = RlpMemo.Compress(key, memo.Raw, children, writeTo);
         written.Should().Be(compressedSize);
-
-        if (!isOdd && children.SetCount == 2)
-        {
-            // cleanup
-            var decompressed = RlpMemo.Decompress(writeTo, children, stackalloc byte[RlpMemo.Size]);
-            decompressed.Raw.SequenceEqual(RlpMemo.Empty).Should().BeTrue();
-        }
-        else
-        {
-            var decompressed = RlpMemo.Decompress(writeTo, children, stackalloc byte[RlpMemo.Size]);
-            decompressed.Raw.SequenceEqual(memoRaw).Should().BeTrue();
-        }
     }
 }

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -2014,8 +2014,18 @@ public class Blockchain : IAsyncDisposable
             {
                 set[childNibbles[i]] = true;
                 if (childHashes[i] != Keccak.Zero)
-                    memo.Set(childHashes[i].Span, childNibbles[i]);
+                {
+                    if (memo.Exists(childNibbles[i]))
+                    {
+                        memo.Set(childHashes[i].Span, childNibbles[i]);
+                    }
+                    else
+                    {
+                        memo = RlpMemo.Insert(memo, childNibbles[i], childHashes[i].Span, rlpMemoization);
+                    }
+                }
             }
+
             _current.SetBranch(key, set, memo.Raw, persist ? EntryType.Persistent : EntryType.Proof);
         }
 

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -1499,7 +1499,7 @@ public class Blockchain : IAsyncDisposable
         public void ProcessProofNodes(Keccak accountKeccak, Span<byte> packedProofPaths, int proofCount)
         {
             Span<byte> workingSpan = stackalloc byte[NibblePath.MaxLengthValue * 2 + 1];
-            Span<byte> rlpMemoization = stackalloc byte[RlpMemo.Size];
+            Span<byte> rlpMemoization = stackalloc byte[RlpMemo.MaxSize];
             Span<byte> targetKeySpan = stackalloc byte[NibblePath.FullKeccakByteLength * 2 + 1];
             Span<byte> nodeWorkingSpan = stackalloc byte[Node.Extension.MaxByteLength];
 
@@ -1536,7 +1536,7 @@ public class Blockchain : IAsyncDisposable
 
                         bool allChildrenPersisted = true;
 
-                        RlpMemo memo = RlpMemo.Decompress(leftover, branch.Children, rlpMemoization);
+                        var memo = RlpMemo.Copy(leftover, rlpMemoization);
 
                         for (byte i = 0; i < NibbleSet.NibbleCount; i++)
                         {
@@ -2007,14 +2007,14 @@ public class Blockchain : IAsyncDisposable
             Key key = account == Keccak.Zero ? Key.Merkle(storagePath) : Key.Raw(NibblePath.FromKey(account), DataType.Merkle, storagePath);
 
             NibbleSet set = new NibbleSet();
-            Span<byte> rlpMemoization = stackalloc byte[RlpMemo.Size];
+            Span<byte> rlpMemoization = stackalloc byte[RlpMemo.MaxSize];
             RlpMemo memo = new RlpMemo(rlpMemoization);
 
             for (int i = 0; i < childNibbles.Length; i++)
             {
                 set[childNibbles[i]] = true;
                 if (childHashes[i] != Keccak.Zero)
-                    memo.Set(childHashes[i], childNibbles[i]);
+                    memo.Set(childHashes[i].Span, childNibbles[i]);
             }
             _current.SetBranch(key, set, memo.Raw, persist ? EntryType.Persistent : EntryType.Proof);
         }

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -42,6 +42,7 @@ public static class CommitExtensions
         EntryType type = EntryType.Persistent)
     {
         var branch = new Branch(children);
+        Debug.Assert(rlp.Length == 0 || rlp.Length == (children.SetCount * Keccak.Size));
         commit.Set(key, branch.WriteTo(stackalloc byte[Branch.MaxByteLength]), rlp, type);
     }
 

--- a/src/Paprika/Merkle/CommitExtensions.cs
+++ b/src/Paprika/Merkle/CommitExtensions.cs
@@ -42,7 +42,6 @@ public static class CommitExtensions
         EntryType type = EntryType.Persistent)
     {
         var branch = new Branch(children);
-        Debug.Assert(rlp.Length == 0 || rlp.Length == (children.SetCount * Keccak.Size));
         commit.Set(key, branch.WriteTo(stackalloc byte[Branch.MaxByteLength]), rlp, type);
     }
 

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -734,14 +734,21 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                 stream.Encode(value);
                 if (memoize)
                 {
+                    memoizedUpdated = true;
+
                     if (value.Length == Keccak.Size)
                     {
-                        memoizedUpdated = true;
-                        memo.SetRaw(value, i, branch.Children);
+                        if (memo.Exists(i, branch.Children))
+                        {
+                            memo.SetRaw(value, i, branch.Children);
+                        }
+                        else
+                        {
+                            memo = RlpMemo.Insert(memo, i, branch.Children, value, rlpMemoization);
+                        }
                     }
-                    else
+                    else if (memo.Exists(i, branch.Children))
                     {
-                        memoizedUpdated = true;
                         memo.Clear(i, branch.Children);
                     }
                 }

--- a/src/Paprika/Merkle/ComputeMerkleBehavior.cs
+++ b/src/Paprika/Merkle/ComputeMerkleBehavior.cs
@@ -587,7 +587,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
         const int rlpSlice = 1024;
 
         var rlp = buffer.Span[..rlpSlice];
-        var rlpMemoization = buffer.Span.Slice(rlpSlice, RlpMemo.Size);
+        var rlpMemoization = buffer.Span.Slice(rlpSlice, RlpMemo.MaxSize);
         var memoizedUpdated = false;
 
         RlpMemo memo = default;
@@ -610,7 +610,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
 
         if (!runInParallel)
         {
-            var childSpan = buffer.Span[(RlpMemo.Size + rlpSlice)..];
+            var childSpan = buffer.Span[(RlpMemo.MaxSize + rlpSlice)..];
 
             for (byte i = 0; i < NibbleSet.NibbleCount; i++)
             {
@@ -1062,6 +1062,7 @@ public class ComputeMerkleBehavior : IPreCommitBehavior, IDisposable
                 memo = new RlpMemo(MakeRlpWritable(leftover));
             }
 
+            // If this child still exists, only clear the memo. Otherwise, delete it from the memo.
             if (memo.Exists(nibble, children))
             {
                 memo.Clear(nibble, children);

--- a/src/Paprika/Merkle/NibbleSet.cs
+++ b/src/Paprika/Merkle/NibbleSet.cs
@@ -55,6 +55,13 @@ public struct NibbleSet
 
     public int SetCount => BitOperations.PopCount(_value);
 
+    public int SetCountBefore(byte nibble)
+    {
+        // Compute the number of set bits before `nibble` (including itself).
+        var leftChildren = (ushort)(_value & ((1U << (nibble + 1)) - 1));
+        return BitOperations.PopCount(leftChildren);
+    }
+
     public byte SmallestNibbleSet => (byte)BitOperations.TrailingZeroCount(_value);
 
     public byte BiggestNibbleSet => (byte)(31 - BitOperations.LeadingZeroCount((uint)_value));
@@ -102,9 +109,13 @@ public struct NibbleSet
 
         public static Readonly AllWithout(byte nibble) => new((ushort)(AllSetValue & ~(1 << nibble)));
 
+        public static Readonly None => new(0);
+
         public bool AllSet => _value == AllSetValue;
 
         public int SetCount => new NibbleSet(_value).SetCount;
+
+        public int SetCountBefore(byte nibble) => new NibbleSet(_value).SetCountBefore(nibble);
 
         public byte SmallestNibbleSet => new NibbleSet(_value).SmallestNibbleSet;
         public byte SmallestNibbleNotSet => new NibbleSet(_value).SmallestNibbleNotSet;

--- a/src/Paprika/Merkle/RlpMemo.cs
+++ b/src/Paprika/Merkle/RlpMemo.cs
@@ -128,19 +128,18 @@ public readonly ref struct RlpMemo
 
         if (memo.Length != 0)
         {
-            var remainingBytes = (children.SetCount - insertIndex - 1) * Keccak.Size;
+            // Copy all the elements before the new element
+            if (insertOffset > 0)
+            {
+                memo._buffer.Slice(0, insertOffset).CopyTo(span);
+            }
 
             // Copy all the elements after the new element
+            var remainingBytes = (children.SetCount - insertIndex - 1) * Keccak.Size;
             if (remainingBytes > 0)
             {
                 memo._buffer.Slice(insertOffset, remainingBytes)
                     .CopyTo(span.Slice(insertOffset + Keccak.Size));
-            }
-
-            // Copy elements before the new element
-            if (insertOffset > 0)
-            {
-                memo._buffer.Slice(0, insertOffset).CopyTo(span);
             }
         }
         else
@@ -176,18 +175,18 @@ public readonly ref struct RlpMemo
         var deleteIndex = BitOperations.PopCount(leftChildren);
         var deleteOffset = deleteIndex * Keccak.Size;
 
-        // Copy elements after the deleted element
-        int remainingBytes = (children.SetCount - deleteIndex) * Keccak.Size;
+        // Copy all the elements before the deleted element
+        if (deleteOffset > 0)
+        {
+            memo._buffer.Slice(0, deleteOffset).CopyTo(span);
+        }
+
+        // Copy all the elements after the deleted element
+        var remainingBytes = (children.SetCount - deleteIndex) * Keccak.Size;
         if (remainingBytes > 0)
         {
             memo._buffer.Slice(deleteOffset + Keccak.Size, remainingBytes)
                 .CopyTo(span.Slice(deleteOffset));
-        }
-
-        // Copy elements before the deleted element
-        if (deleteOffset > 0)
-        {
-            memo._buffer.Slice(0, deleteOffset).CopyTo(span);
         }
 
         return new RlpMemo(span);

--- a/src/Paprika/Merkle/RlpMemo.cs
+++ b/src/Paprika/Merkle/RlpMemo.cs
@@ -10,22 +10,15 @@ namespace Paprika.Merkle;
 
 public readonly ref struct RlpMemo
 {
-    public static readonly byte[] FullyEmpty = new byte[Size];
-
     public static readonly byte[] Empty = [];
 
     private readonly Span<byte> _buffer;
 
-    public const int Size = NibbleSet.NibbleCount * Keccak.Size;
+    public const int MaxSize = NibbleSet.NibbleCount * Keccak.Size;
 
     public RlpMemo(Span<byte> buffer)
     {
         _buffer = buffer;
-    }
-
-    public RlpMemo(int count)
-    {
-        _buffer = new byte[count * Keccak.Size];
     }
 
     public ReadOnlySpan<byte> Raw => _buffer;
@@ -35,7 +28,7 @@ public readonly ref struct RlpMemo
     public void SetRaw(ReadOnlySpan<byte> keccak, byte nibble, NibbleSet.Readonly children)
     {
         var span = GetAtNibble(nibble, children);
-        Debug.Assert(span != null);
+        Debug.Assert(!span.IsEmpty);
         Debug.Assert(_buffer.Length == (children.SetCount * Keccak.Size));
 
         keccak.CopyTo(span);
@@ -44,7 +37,7 @@ public readonly ref struct RlpMemo
     public void Set(in KeccakOrRlp keccakOrRlp, byte nibble, NibbleSet.Readonly children)
     {
         var span = GetAtNibble(nibble, children);
-        Debug.Assert(span != null);
+        Debug.Assert(!span.IsEmpty);
         Debug.Assert(_buffer.Length == (children.SetCount * Keccak.Size));
 
         if (keccakOrRlp.DataType == KeccakOrRlp.Type.Keccak)
@@ -63,7 +56,7 @@ public readonly ref struct RlpMemo
         var span = GetAtNibble(nibble, children);
         Debug.Assert(_buffer.Length == 0 || _buffer.Length == (children.SetCount * Keccak.Size));
 
-        if (span != null)
+        if (!span.IsEmpty)
         {
             span.Clear();
         }
@@ -74,7 +67,7 @@ public readonly ref struct RlpMemo
         var span = GetAtNibble(nibble, children);
         Debug.Assert(_buffer.Length == 0 || _buffer.Length == (children.SetCount * Keccak.Size));
 
-        if (span != null && span.IndexOfAnyExcept((byte)0) >= 0)
+        if (span.IndexOfAnyExcept((byte)0) >= 0)
         {
             keccak = span;
             return true;
@@ -86,10 +79,8 @@ public readonly ref struct RlpMemo
 
     public bool Exists(byte nibble, NibbleSet.Readonly children)
     {
-        var leftChildren = (ushort)((ushort)children & ((1U << (nibble + 1)) - 1));
-
         // Check if the element exists
-        if (_buffer.Length == 0 || (leftChildren & (1U << nibble)) == 0)
+        if (_buffer.Length == 0 || ((ushort)children & (1U << nibble)) == 0)
         {
             return false;
         }
@@ -104,7 +95,7 @@ public readonly ref struct RlpMemo
         // Check if the element exists
         if (_buffer.Length == 0 || (leftChildren & (1U << nibble)) == 0)
         {
-            return null;
+            return [];
         }
 
         var index = BitOperations.PopCount(leftChildren) - 1;
@@ -200,139 +191,5 @@ public readonly ref struct RlpMemo
         }
 
         return new RlpMemo(span);
-    }
-
-    public static RlpMemo Decompress(scoped in ReadOnlySpan<byte> leftover, NibbleSet.Readonly children,
-        scoped in Span<byte> workingSet)
-    {
-        if (_decompressionForbidden)
-        {
-            ThrowDecompressionForbidden();
-        }
-
-        var span = workingSet[..Size];
-
-        if (leftover.IsEmpty)
-        {
-            // no RLP cached yet
-            span.Clear();
-            return new RlpMemo(span);
-        }
-
-        if (leftover.Length == Size)
-        {
-            leftover.CopyTo(span);
-            return new RlpMemo(span);
-        }
-
-        // It's neither empty nor full. It must be the compressed form, prepare setup first
-        span.Clear();
-        var memo = new RlpMemo(span);
-
-        // Extract empty bits if any
-        NibbleSet.Readonly empty;
-
-        // The empty bytes length is anything that is not aligned to the Keccak size
-        var emptyBytesLength = leftover.Length % Keccak.Size;
-        if (emptyBytesLength > 0)
-        {
-            var bits = leftover[^emptyBytesLength..];
-            NibbleSet.Readonly.ReadFrom(bits, out empty);
-        }
-        else
-        {
-            empty = default;
-        }
-
-        var at = 0;
-        for (byte i = 0; i < NibbleSet.NibbleCount; i++)
-        {
-            if (children[i] && empty[i] == false)
-            {
-                var keccak = leftover.Slice(at * Keccak.Size, Keccak.Size);
-                at++;
-
-                memo.SetRaw(keccak, i, children);
-            }
-        }
-
-        return memo;
-
-        [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static void ThrowDecompressionForbidden() => throw new InvalidOperationException("Decompression is forbidden.");
-    }
-
-    [SkipLocalsInit]
-    public static int Compress(in Key key, scoped in ReadOnlySpan<byte> memoizedRlp, NibbleSet.Readonly children, scoped in Span<byte> writeTo)
-    {
-        // Optimization, omitting some of the branches to memoize.
-        // It omits only these with two children where the cost of the recompute is not big.
-        // To prevent an attack of spawning multiple levels of such branches, only even are skipped
-        if (children.SetCount == 2 && (key.Path.Length + key.StoragePath.Length) % 2 == 0)
-        {
-            return 0;
-        }
-
-        var memo = new RlpMemo(ComputeMerkleBehavior.MakeRlpWritable(memoizedRlp));
-        var at = 0;
-
-        var empty = new NibbleSet();
-
-        for (byte i = 0; i < NibbleSet.NibbleCount; i++)
-        {
-            if (children[i])
-            {
-                if (memo.TryGetKeccak(i, out var keccak, children))
-                {
-                    var dest = writeTo.Slice(at * Keccak.Size, Keccak.Size);
-                    at++;
-                    keccak.CopyTo(dest);
-                }
-                else
-                {
-                    empty[i] = true;
-                }
-            }
-        }
-
-        Debug.Assert(at != 16 || empty.SetCount == 0, "If at = 16, empty should be empty");
-
-        if (empty.SetCount == children.SetCount)
-        {
-            // None of children has their Keccak memoized. Instead of reporting it, return nothing written.
-            return 0;
-        }
-
-        if (empty.SetCount > 0)
-        {
-            var dest = writeTo.Slice(at * Keccak.Size, NibbleSet.MaxByteSize);
-            new NibbleSet.Readonly(empty).WriteToWithLeftover(dest);
-            return at * Keccak.Size + NibbleSet.MaxByteSize;
-        }
-
-        // Return only children that were written
-        return at * Keccak.Size;
-    }
-
-    /// <summary>
-    /// Test only method to forbid decompression.
-    /// </summary>
-    /// <returns></returns>
-    public static NoDecompressionScope NoDecompression() => new();
-
-    private static volatile bool _decompressionForbidden;
-
-    public readonly struct NoDecompressionScope : IDisposable
-    {
-        public NoDecompressionScope()
-        {
-            _decompressionForbidden = true;
-        }
-
-        public void Dispose()
-        {
-            _decompressionForbidden = false;
-        }
     }
 }


### PR DESCRIPTION
Currently the memoised RLPs are stored in a compressed form when flushing to the PageDb, but when stored in-memory, these are in the decompressed form.

This PR removes compression & decompression altogether by always storing the memorized RLPs in compressed form. To achieve this, a NibbleSet index (2 bytes) is stored at the end of RLPMemo buffer which indicates whether each element is currently stored in the memo. For example, `[k1 | k2 | k5]` in RLPMemo would also store NibbleSet `{1, 2, 5}` or `0b0000 0000 0010 0110` to show that only 1, 2 & 5 index children's keccaks are currently memoized.

Also note that due to an existing optimization done during DB write operation to not store memoized RLPs for top level state branches (`SkipRlpMemoizationForTopLevelsCount`), the RLPMemo data structure supports storing empty buffer even if there are children for that branch.

Metrics with importing mainnet data  (with parallelization enabled along with a few optimizations):

![image](https://github.com/user-attachments/assets/734b32df-ea3a-4736-b5f2-31ac8e30ca23)

`Root: 0xe64f828043054f23455c65871e737b3f03c98599f7feb5bea4f450c7ca089dd4 was being imported to Paprika in 4:54:04.5507713 and resulted in 0xe64f828043054f23455c65871e737b3f03c98599f7feb5bea4f450c7ca089dd4`

For comparison the baseline `importer` branch was also used for a partial import (~70GB DB size, NOT a full import)

![image](https://github.com/user-attachments/assets/6cbb227f-a0a1-4000-8abd-7790bee2c2ca)

Most of the metrics look similar except for the buffer pool size and commit time, which is better with the rlpmemo changes. 
Overall, the changes simplify the way memoization is done by removing the overhead of compression & decompression from various places (write to DB, prefetch etc.).



