### PR TITLE
Fix SyncBlockState hash collision issue

### DIFF
--- a/src/Paprika.Tests/Values.cs
+++ b/src/Paprika.Tests/Values.cs
@@ -27,8 +27,12 @@ public static class Values
     public static readonly UInt256 Balance0 = 13;
     public static readonly UInt256 Balance1 = 17;
     public static readonly UInt256 Balance2 = 19;
+    public static readonly UInt256 Balance3 = 23;
+    public static readonly UInt256 Balance4 = 29;
 
     public static readonly UInt256 Nonce0 = 23;
     public static readonly UInt256 Nonce1 = 29;
     public static readonly UInt256 Nonce2 = 31;
+    public static readonly UInt256 Nonce3 = 37;
+    public static readonly UInt256 Nonce4 = 41;
 }

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -1419,7 +1419,6 @@ public class Blockchain : IAsyncDisposable
     private class SyncBlockState : BlockState
     {
         private readonly PooledSpanDictionary _proofKeys;
-        private readonly HashSet<ulong> _proofHashSet;
 
         public SyncBlockState(Keccak parentStateRoot, IReadOnlyBatch batch, CommittedBlockState[] ancestors,
             Blockchain blockchain) : base(parentStateRoot, batch, ancestors, blockchain)
@@ -1428,7 +1427,6 @@ public class Blockchain : IAsyncDisposable
                 _proofKeys.Dispose();
 
             _proofKeys = new PooledSpanDictionary(Pool, true);
-            _proofHashSet = new HashSet<ulong>();
         }
 
         public override ReadOnlySpanOwnerWithMetadata<byte> Get(scoped in Key key)
@@ -1436,7 +1434,7 @@ public class Blockchain : IAsyncDisposable
             var hash = GetHash(key);
             var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
 
-            if (_proofHashSet.Contains(hash) && _proofKeys.TryGet(keyWritten, hash, out var span))
+            if (_proofKeys.TryGet(keyWritten, hash, out var span))
             {
                 AcquireLease();
                 return new ReadOnlySpanOwner<byte>(span, this).WithDepth(0);
@@ -1450,17 +1448,16 @@ public class Blockchain : IAsyncDisposable
             _hash = null;
 
             var hash = GetHash(key);
-            var k = key.WriteTo(stackalloc byte[key.MaxByteLength]);
+            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
 
-            if (type == EntryType.Proof || (type == EntryType.Persistent && _proofHashSet.Contains(hash)))
+            if (type == EntryType.Proof || (type == EntryType.Persistent && _proofKeys.TryGet(keyWritten, hash, out _)))
             {
-                _proofKeys.Set(k, hash, payload, (byte)type);
-                _proofHashSet.Add(hash);
+                _proofKeys.Set(keyWritten, hash, payload, (byte)type);
                 return;
             }
 
             _filter.Add(hash);
-            dict.Set(k, hash, payload, (byte)type);
+            dict.Set(keyWritten, hash, payload, (byte)type);
         }
 
         protected override void SetImpl(in Key key, in ReadOnlySpan<byte> payload0, in ReadOnlySpan<byte> payload1, EntryType type, PooledSpanDictionary dict)
@@ -1469,22 +1466,20 @@ public class Blockchain : IAsyncDisposable
             _hash = null;
 
             var hash = GetHash(key);
-            var k = key.WriteTo(stackalloc byte[key.MaxByteLength]);
+            var keyWritten = key.WriteTo(stackalloc byte[key.MaxByteLength]);
 
-            if (type == EntryType.Proof || (type == EntryType.Persistent && _proofHashSet.Contains(hash)))
+            if (type == EntryType.Proof || (type == EntryType.Persistent && _proofKeys.TryGet(keyWritten, hash, out _)))
             {
-                _proofKeys.Set(k, hash, payload0, payload1, (byte)type);
-                _proofHashSet.Add(hash);
+                _proofKeys.Set(keyWritten, hash, payload0, payload1, (byte)type);
                 return;
             }
 
             _filter.Add(hash);
-            dict.Set(k, hash, payload0, payload1, (byte)type);
+            dict.Set(keyWritten, hash, payload0, payload1, (byte)type);
         }
 
         protected override void CleanUp()
         {
-            _proofHashSet.Clear();
             _proofKeys.Dispose();
             base.CleanUp();
         }
@@ -1550,8 +1545,7 @@ public class Blockchain : IAsyncDisposable
                                 var childHash = GetHash(childKey);
 
                                 bool isPersisted;
-                                //double check due to potential hash collision
-                                if (_proofHashSet.Contains(childHash) && proofNodeResults.TryGetValue(childHash, out bool thisRoundPersisted))
+                                if (proofNodeResults.TryGetValue(childHash, out bool thisRoundPersisted))
                                 {
                                     isPersisted = thisRoundPersisted;
                                 }
@@ -1588,7 +1582,7 @@ public class Blockchain : IAsyncDisposable
                             : Key.Merkle(extChildPath);
                         var extChildHash = GetHash(extChildKey);
 
-                        if (_proofHashSet.Contains(extChildHash) && proofNodeResults[extChildHash] || IsPersisted(accountKeccak, extChildPath))
+                        if (proofNodeResults[extChildHash] || IsPersisted(accountKeccak, extChildPath))
                         {
                             proofNodeResults[hash] = true;
                             _preCommit.Set(k, hash, ext.WriteTo(nodeWorkingSpan), (byte)EntryType.Persistent);


### PR DESCRIPTION
Remove dependency on `HashSet` in `SyncBlockState` - use `PooledSpanDictionary` only which handles hash collision internally.
Resolves #459 