### PR TITLE
RLPMemo Index Optimization (Part 1)

### DIFF
--- a/src/Paprika/Merkle/NibbleSet.cs
+++ b/src/Paprika/Merkle/NibbleSet.cs
@@ -130,6 +130,11 @@ public struct NibbleSet
             return destination.Slice(MaxByteSize);
         }
 
+        public static Readonly ReadFrom(ReadOnlySpan<byte> source)
+        {
+            return new Readonly(BinaryPrimitives.ReadUInt16LittleEndian(source));
+        }
+
         public static ReadOnlySpan<byte> ReadFrom(ReadOnlySpan<byte> source, out Readonly set)
         {
             set = new Readonly(BinaryPrimitives.ReadUInt16LittleEndian(source));


### PR DESCRIPTION
Move the index to start in RLPMemo as described in https://github.com/NethermindEth/Paprika/issues/461

Perf metrics:

![image](https://github.com/user-attachments/assets/d1ad4db8-7325-41f7-b61d-2af589c329b8)

`Root: 0xe64f828043054f23455c65871e737b3f03c98599f7feb5bea4f450c7ca089dd4 was being imported to Paprika in 4:33:22.8327645 and resulted in 0xe64f828043054f23455c65871e737b3f03c98599f7feb5bea4f450c7ca089dd4`

Previous metrics for reference (without this change):
![image](https://github.com/user-attachments/assets/ce32a86a-3a3f-4303-8e8c-54b4ae3f864d)
