### PR TITLE
Span consecutive batching made simpler

### DIFF
--- a/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
+++ b/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
@@ -67,7 +67,7 @@ public class SpanExtensionsTests
         const int start1 = 3;
         const int start2 = 5;
         const int start3 = 7;
-        
+
         Span<int> span = [start0, start1, 4, start2, 6, start3];
 
         const int max = 2;

--- a/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
+++ b/src/Paprika.Tests/Utils/SpanExtensionsTests.cs
@@ -16,11 +16,12 @@ public class SpanExtensionsTests
     [Test]
     public void Batch_single_consecutive()
     {
-        Span<int> span = [1, 2, 3];
+        const int start0 = 1;
+        Span<int> span = [start0, 2, 3];
 
         var e = span.BatchConsecutive();
 
-        MoveNext(ref e, new(0, span.Length));
+        MoveNext(ref e, new(start0, span.Length));
 
         End(e);
     }
@@ -28,14 +29,16 @@ public class SpanExtensionsTests
     [Test]
     public void Batch_single_consecutive_with_max()
     {
-        Span<int> span = [1, 2, 3, 4];
+        const int start0 = 1;
+        const int start1 = 3;
+        Span<int> span = [start0, 2, start1, 4];
 
         const int max = 2;
 
         var e = span.BatchConsecutive(max);
 
-        MoveNext(ref e, new(0, max));
-        MoveNext(ref e, new(2, max));
+        MoveNext(ref e, new(start0, max));
+        MoveNext(ref e, new(start1, max));
 
         End(e);
     }
@@ -43,14 +46,16 @@ public class SpanExtensionsTests
     [Test]
     public void Batch_splits()
     {
-        Span<int> span = [1, 3, 4, 5, 6];
+        const int start0 = 1;
+        const int start1 = 3;
+        Span<int> span = [start0, start1, 4, 5, 6];
 
         const int at = 1;
 
         var e = span.BatchConsecutive();
 
-        MoveNext(ref e, new(0, at));
-        MoveNext(ref e, new(at, span.Length - at));
+        MoveNext(ref e, new(start0, at));
+        MoveNext(ref e, new(start1, span.Length - at));
 
         End(e);
     }
@@ -58,16 +63,21 @@ public class SpanExtensionsTests
     [Test]
     public void Batch_splits_with_max()
     {
-        Span<int> span = [1, 3, 4, 5, 6, 7];
+        const int start0 = 1;
+        const int start1 = 3;
+        const int start2 = 5;
+        const int start3 = 7;
+        
+        Span<int> span = [start0, start1, 4, start2, 6, start3];
 
         const int max = 2;
 
         var e = span.BatchConsecutive(max);
 
-        MoveNext(ref e, new(0, 1));
-        MoveNext(ref e, new(1, max));
-        MoveNext(ref e, new(3, max));
-        MoveNext(ref e, new(5, 1));
+        MoveNext(ref e, new(start0, 1));
+        MoveNext(ref e, new(start1, max));
+        MoveNext(ref e, new(start2, max));
+        MoveNext(ref e, new(start3, 1));
 
         End(e);
     }

--- a/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
+++ b/src/Paprika/Store/PageManagers/MemoryMappedPageManager.cs
@@ -127,8 +127,7 @@ public sealed class MemoryMappedPageManager : PointerPageManager
 
         foreach (var range in numbers.BatchConsecutive(MaxWriteBatch))
         {
-            var addr = span[range.Start];
-            _pendingWrites.Add(WriteAt(addr, (uint)range.Length).AsTask());
+            _pendingWrites.Add(WriteAt(new DbAddress(range.Start), (uint)range.Length).AsTask());
         }
 
         _fileWrites.Record(_pendingWrites.Count);

--- a/src/Paprika/Utils/SpanExtensions.cs
+++ b/src/Paprika/Utils/SpanExtensions.cs
@@ -82,10 +82,10 @@ public static class SpanExtensions
         }
 
         /// <summary>Gets the element at the current position of the enumerator.</summary>
-        public (int Start, int Length) Current
+        public (T Start, int Length) Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => new(_from, _length);
+            get => new(_span[_from], _length);
         }
     }
 }


### PR DESCRIPTION
Now batching consecutive numbers provides the actual value instead of having an additional lookup.