### PR TITLE
New BottomPage

### DIFF
--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -84,10 +84,10 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(20, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(428, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(21796, 4000, 200, false,
+    [TestCase(20067, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(55480, 10_000, 50, false,
+    [TestCase(51117, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(118364, 20_000, 50, true,

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -195,7 +195,7 @@ public class DbTests
             return address;
         }
     }
-    
+
     [Test]
     public async Task Cross_block_entries()
     {
@@ -209,14 +209,14 @@ public class DbTests
             using (var batch = db.BeginNextBatch())
             {
                 var address = GetStorageAddress(i);
-                
+
                 batch.SetAccount(Key0, GetValue(i));
                 batch.SetStorage(Key0, address, GetValue(i));
 
                 await batch.Commit(CommitOptions.FlushDataAndRoot);
             }
         }
-        
+
         using (var read = db.BeginReadOnlyBatch())
         {
             for (int i = 0; i < count; i++)

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -195,6 +195,47 @@ public class DbTests
             return address;
         }
     }
+    
+    [Test]
+    public async Task Cross_block_entries()
+    {
+        const int size = MB64;
+        using var db = PagedDb.NativeMemoryDb(size);
+
+        const int count = 1600;
+
+        for (var i = 0; i < count; i++)
+        {
+            using (var batch = db.BeginNextBatch())
+            {
+                var address = GetStorageAddress(i);
+                
+                batch.SetAccount(Key0, GetValue(i));
+                batch.SetStorage(Key0, address, GetValue(i));
+
+                await batch.Commit(CommitOptions.FlushDataAndRoot);
+            }
+        }
+        
+        using (var read = db.BeginReadOnlyBatch())
+        {
+            for (int i = 0; i < count; i++)
+            {
+                var address = GetStorageAddress(i);
+                read.AssertStorageValue(Key0, address, GetValue(i));
+            }
+        }
+
+        AssertPageMetadataAssigned(db);
+        return;
+
+        static Keccak GetStorageAddress(int i)
+        {
+            var address = Key1A;
+            BinaryPrimitives.WriteInt32LittleEndian(address.BytesAsSpan, i);
+            return address;
+        }
+    }
 
     [Test]
     public async Task Spin_large()

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -433,7 +433,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
                     // Let's ensure it's created and move to the other child.
                     var otherAddr = Data.Buckets[nibble0];
                     var otherChild = otherAddr.IsNull
-                        ? batch.GetNewPage<BottomPage>(out otherAddr)
+                        ? batch.GetNewPage<BottomPage>(out otherAddr, (byte)(Header.Level + 1))
                         : new BottomPage(batch.EnsureWritableCopy(ref otherAddr));
                     Data.Buckets[nibble0] = otherAddr;
 

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -54,10 +54,12 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         if (existing == 0)
         {
             // No children yet. Create the first, flush there and set.
+            Debug.Assert(Data.Buckets[0].IsNull);
+
             var child = batch.GetNewPage<BottomPage>(out var childAddr, (byte)(Header.Level + 1));
             Data.Buckets[0] = childAddr;
 
-            // Move all down. Ensure that deletes are treated as tombsones.
+            // Move all down. Ensure that deletes are treated as tombstones.
             map.MoveNonEmptyKeysTo<All>(child.Map, true);
 
             map.Clear();
@@ -369,6 +371,8 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
             // Copy back the span
             buffer.CopyTo(child.Data.DataSpan);
         }
+
+        AssertChildrenRangeInvariant(batch);
 
         ArrayPool<byte>.Shared.Return(array);
 

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -312,7 +312,7 @@ public readonly unsafe struct DataPage(Page page) : IPage<DataPage>
 
     /// <summary>
     /// Represents the data of this data page. This type of payload stores data in 16 nibble-addressable buckets.
-    /// These buckets is used to store up to <see cref="DataSize"/> entries before flushing them down as other pages
+    /// These buckets are used to store up to <see cref="DataSize"/> entries before flushing them down as other pages
     /// like page split.
     /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = Size)]

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -584,6 +584,11 @@ public static class StorageFanOut
 
             public void Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
             {
+                if (key.GetHashCode() == 1906005005)
+                {
+                    Debugger.Break();
+                }
+
                 Page root;
 
                 // Try writing through if the key is non empty, the root exists and the Root was written in this batch

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -584,14 +584,9 @@ public static class StorageFanOut
 
             public void Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
             {
-                if (key.GetHashCode() == 1906005005)
-                {
-                    Debugger.Break();
-                }
-
                 Page root;
 
-                // Try writing through if the key is non empty, the root exists and the Root was written in this batch
+                // Try writing through if the key is non-empty, the root exists and the Root was written in this batch
                 if (key.IsEmpty == false && Root.IsNull == false && batch.WasWritten(Root))
                 {
                     // Root exists, and was written in this batch. Write through.


### PR DESCRIPTION
A brand new structure of the `BottomPage` that handles data distribution in a better way. 

First, when the bottom with no children is full, one child is allocated. This makes the bottom page half-full on average.

When no more space, the main map is tried to be flushed down to existing ones. If it fails a new one is allocated and data are redistributed to satisfy `nibble0 >= child_index` assertion. Effectively, if a child is inserted in the middle (it will always have as the first one is allocated at 0), it will steal data from its left neighbor. Then the main map is tried to be redistributed again.

When there's no more option to make progress, the bottom page is transformed into a `DataPage`. This is done without copying the main page as it has the same payload structure as `DataPage`. The only thing that is accessed is the child redistribution.

### Benchmarks

The Ethereum `mainnet` database has been shrunk from `275GB` to `237GB` which gives ~14% reduction in size

#### Import

![image](https://github.com/user-attachments/assets/1a58bfc0-b433-4d28-9bec-0316c9cf14fb)

#### CLI stats

CLI `stats` show reduction in tree depth. The state is now 5 levels deep (beside the root that allows to jump first 2 nibbles). The storage with 3 levels of fan out at the top (the first is in the root), followed by 7 levels of the storage. This means that for a single storage read max 7 SlottedArrays will be scanned.

```ps
Paprika\src\Paprika.Cli > dotnet run -c Release -- stats E:\db\ 320 64
```

![image](https://github.com/user-attachments/assets/72d1d56f-38b9-48cf-98ff-9c2df0cd9a72)

