### PR TITLE
Fix extension node handling when processing proof nodes for snap sync

### DIFF
--- a/src/Paprika.Tests/Chain/RawStateTests.cs
+++ b/src/Paprika.Tests/Chain/RawStateTests.cs
@@ -443,7 +443,7 @@ public class RawStateTests
         using var rootExtensionNodeData2 = syncRaw3.Get(Key.Raw(NibblePath.FromKey(accountHash), DataType.Merkle, NibblePath.Empty));
         rootExtensionNodeData2.IsEmpty.Should().BeFalse();
 
-        var leftover = Node.ReadFrom(out var type, out var _, out var ext, out var _, rootExtensionNodeData2.Span);
+        Node.ReadFrom(out var type, out var _, out var ext, out var _, rootExtensionNodeData2.Span);
         type.Should().Be(Node.Type.Extension);
 
         //recalculate ignoring RlpMemo cache to verify correctness

--- a/src/Paprika.Tests/Chain/RawStateTests.cs
+++ b/src/Paprika.Tests/Chain/RawStateTests.cs
@@ -353,5 +353,103 @@ public class RawStateTests
         syncRaw3.GetHash(NibblePath.Parse("0"), false).Should().Be(hashBranch2);
     }
 
+    [Test]
+    public void ProcessProofNodesStorageWithExtension()
+    {
+        //setup remote trie
+        using var remoteDb = PagedDb.NativeMemoryDb(32 * 1024, 2);
+        var merkle = new ComputeMerkleBehavior();
+
+        var remoteBlockchain = new Blockchain(remoteDb, merkle);
+
+        using var raw = remoteBlockchain.StartRaw();
+
+        Span<byte> leafValue = stackalloc byte[32];
+        GetRandom().NextBytes(leafValue);
+        var accountHash = Values.Key2;
+
+        //E -> B -> L1
+        //       -> L2
+        //       -> L3
+        //       -> L4
+        var storage1 = new Keccak(Convert.FromHexString("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab1bbbbbbbbbbbbbbbb11"));
+        var storage2 = new Keccak(Convert.FromHexString("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab2bbbbbbbbbbbbbbbb22"));
+        var storage3 = new Keccak(Convert.FromHexString("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab3bbbbbbbbbbbbbbbb33"));
+        var storage4 = new Keccak(Convert.FromHexString("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab4bbbbbbbbbbbbbbbb44"));
+
+        raw.SetStorage(accountHash, storage1, leafValue);
+        raw.SetStorage(accountHash, storage2, leafValue);
+        raw.SetStorage(accountHash, storage3, leafValue);
+        raw.SetStorage(accountHash, storage4, leafValue);
+
+        raw.Commit(true, true);
+        var remoteStorageHash = raw.GetStorageHash(in accountHash, NibblePath.Empty, false);
+
+        //1st sync pass
+        var hashStorage3 = raw.GetStorageHash(in accountHash, NibblePath.Parse("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab3"), false);
+        var hashStorage4 = raw.GetStorageHash(in accountHash, NibblePath.Parse("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab4"), false);
+
+        using var localDb = PagedDb.NativeMemoryDb(64 * 1024, 2);
+        var localBlockchain = new Blockchain(localDb, merkle);
+
+        using var syncRaw = localBlockchain.StartRaw();
+
+        var branchPath = NibblePath.Parse("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab");
+        syncRaw.CreateMerkleExtension(accountHash, NibblePath.Empty, branchPath, false);
+        syncRaw.CreateMerkleBranch(accountHash, NibblePath.Parse("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), [1, 2, 3, 4], [Keccak.Zero, Keccak.Zero, hashStorage3, hashStorage4], false);
+
+        syncRaw.SetStorage(accountHash, storage1, leafValue);
+        syncRaw.SetStorage(accountHash, storage2, leafValue);
+
+        var localHash = syncRaw.RecalculateStorageRoot(in accountHash, true);
+
+        localHash.Should().Be(remoteStorageHash);
+
+        Span<byte> packed = stackalloc byte[2 * 33];
+        packed[0 * 33] = branchPath.Length;
+        branchPath.RawSpan.CopyTo(packed.Slice(0 * 33 + 1));
+        packed[1 * 33] = NibblePath.Empty.Length;
+        NibblePath.Empty.RawSpan.CopyTo(packed.Slice(1 * 33 + 1));
+
+        syncRaw.ProcessProofNodes(accountHash, packed, 1);
+        syncRaw.Commit(false);
+
+        //2nd sync pass
+        using var syncRaw2 = localBlockchain.StartRaw();
+
+        //check proof nodes from 1st pass were not persisted during commit
+        //neither branch nor it's parent extension should have been persisted as not all dependent children are
+        using var rootExtensionNodeData = syncRaw2.Get(Key.Raw(NibblePath.FromKey(accountHash), DataType.Merkle, NibblePath.Empty));
+        rootExtensionNodeData.IsEmpty.Should().BeTrue();
+        syncRaw2.GetHash(branchPath, false).Should().Be(Keccak.EmptyTreeHash);
+
+        var hashStorage1 = raw.GetStorageHash(in accountHash, NibblePath.Parse("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab1"), false);
+        var hashStorage2 = raw.GetStorageHash(in accountHash, NibblePath.Parse("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab2"), false);
+
+        syncRaw2.CreateMerkleExtension(accountHash, NibblePath.Empty, branchPath, false);
+        syncRaw2.CreateMerkleBranch(accountHash, NibblePath.Parse("000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), [1, 2, 3, 4], [hashStorage1, hashStorage2, Keccak.Zero, Keccak.Zero], false);
+
+        syncRaw2.SetStorage(accountHash, storage3, leafValue);
+        syncRaw2.SetStorage(accountHash, storage4, leafValue);
+
+        localHash = syncRaw2.RecalculateStorageRoot(in accountHash, true);
+        localHash.Should().Be(remoteStorageHash);
+
+        syncRaw2.ProcessProofNodes(accountHash, packed, 2);
+        syncRaw2.Commit(false);
+
+        //check the root extension is correctly persisted
+        using var syncRaw3 = localBlockchain.StartRaw();
+        using var rootExtensionNodeData2 = syncRaw3.Get(Key.Raw(NibblePath.FromKey(accountHash), DataType.Merkle, NibblePath.Empty));
+        rootExtensionNodeData2.IsEmpty.Should().BeFalse();
+
+        var leftover = Node.ReadFrom(out var type, out var _, out var ext, out var _, rootExtensionNodeData2.Span);
+        type.Should().Be(Node.Type.Extension);
+
+        //recalculate ignoring RlpMemo cache to verify correctness
+        var noCacheRootHash = syncRaw3.RecalculateStorageRoot(in accountHash, true);
+        noCacheRootHash.Should().Be(remoteStorageHash);
+    }
+
     private static Random GetRandom() => new(13);
 }

--- a/src/Paprika/Chain/Blockchain.cs
+++ b/src/Paprika/Chain/Blockchain.cs
@@ -1617,7 +1617,8 @@ public class Blockchain : IAsyncDisposable
                             : Key.Merkle(extChildPath);
                         var extChildHash = GetHash(extChildKey);
 
-                        if ((proofNodeResults.TryGetValue(extChildHash, out bool extChildPersisted) && extChildPersisted) || IsPersisted(accountKeccak, extChildPath))
+                        var isChildPersisted = proofNodeResults.TryGetValue(extChildHash, out bool extChildPersisted) ? extChildPersisted : IsPersisted(accountKeccak, extChildPath);
+                        if (isChildPersisted)
                         {
                             proofNodeResults[hash] = true;
                             _preCommit.Set(k, hash, ext.WriteTo(nodeWorkingSpan), (byte)EntryType.Persistent);


### PR DESCRIPTION
Fixes for correctly verifying extension node and it's child persistence when processing proof nodes during snap sync.