### PR TITLE
Side-car Merkle

### DIFF
--- a/src/Paprika.Tests/Chain/RawStateTests.cs
+++ b/src/Paprika.Tests/Chain/RawStateTests.cs
@@ -298,7 +298,7 @@ public class RawStateTests
         var hashAccount4 = raw.GetHash(NibblePath.Parse("02"), false);
         var hashBranch2 = raw.GetHash(NibblePath.Parse("0"), false);
 
-        using var localDb = PagedDb.NativeMemoryDb(32 * 1024, 2);
+        using var localDb = PagedDb.NativeMemoryDb(64 * 1024, 2);
         var localBlockchain = new Blockchain(localDb, merkle);
 
         using var syncRaw = localBlockchain.StartRaw();

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -90,7 +90,7 @@ public class AbandonedTests : BasePageTests
     [TestCase(43153, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
-    [TestCase(90936, 20_000, 50, true,
+    [TestCase(165222, 20_000, 50, true,
         TestName = "Storage - 20_000 accounts with a single storage slot",
         Category = Categories.LongRunning)]
     public async Task Reuse_in_limited_environment(int pageCount, int accounts, int repeats, bool isStorage)

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -84,10 +84,10 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(20, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(428, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(20067, 4000, 200, false,
+    [TestCase(16841, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(51117, 10_000, 50, false,
+    [TestCase(43153, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(118364, 20_000, 50, true,

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -90,7 +90,7 @@ public class AbandonedTests : BasePageTests
     [TestCase(43153, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
-    [TestCase(118364, 20_000, 50, true,
+    [TestCase(90936, 20_000, 50, true,
         TestName = "Storage - 20_000 accounts with a single storage slot",
         Category = Categories.LongRunning)]
     public async Task Reuse_in_limited_environment(int pageCount, int accounts, int repeats, bool isStorage)

--- a/src/Paprika.Tests/Store/ClearableTests.cs
+++ b/src/Paprika.Tests/Store/ClearableTests.cs
@@ -26,9 +26,6 @@ public unsafe class ClearableTests : IDisposable
     public void StorageFanOut_Level2Page() => TestPage<StorageFanOut.Level2Page>();
 
     [Test]
-    public void StorageFanOut_Level3Page() => TestPage<StorageFanOut.Level3Page>();
-
-    [Test]
     public void DbAddressList_Of4() => TestDbAddressList<DbAddressList.Of4>();
 
     [Test]

--- a/src/Paprika.Tests/Store/DbTests.cs
+++ b/src/Paprika.Tests/Store/DbTests.cs
@@ -78,7 +78,7 @@ public class DbTests
             {
                 for (var account = 0; account < accountsCount; account++)
                 {
-                    batch.SetAccount(GetKey(i), GetValue(i));
+                    batch.SetAccount(GetKey(account), GetValue(account));
                 }
 
                 await batch.Commit(CommitOptions.FlushDataOnly);

--- a/src/Paprika.Tests/Store/PagedDbTests.cs
+++ b/src/Paprika.Tests/Store/PagedDbTests.cs
@@ -1,9 +1,7 @@
 using System.Buffers.Binary;
-using System.Diagnostics;
 using FluentAssertions;
 using Paprika.Crypto;
 using Paprika.Data;
-using Paprika.Merkle;
 using Paprika.Store;
 
 namespace Paprika.Tests.Store;

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -477,6 +477,8 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
             dpMap.Delete(item);
         }
 
+        dp.ReturnUnusedChildBottomPages(batch);
+
         return dp;
     }
 

--- a/src/Paprika/Store/FanOutPage.cs
+++ b/src/Paprika/Store/FanOutPage.cs
@@ -1,0 +1,315 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Paprika.Data;
+
+namespace Paprika.Store;
+
+/// <summary>
+/// A fan out page that fans out to 256 nibbles.
+/// </summary>
+/// <param name="page"></param>
+[method: DebuggerStepThrough]
+public readonly unsafe struct FanOutPage(Page page) : IPage<FanOutPage>
+{
+    /// <summary>
+    /// The maximum length of the key that will be offloaded to the sidecar.
+    /// </summary>
+    private const int MerkleSideCarMaxKeyLength = 1;
+    private const int ConsumedNibbles = 2;
+    private const int BucketCount = DbAddressList.Of256.Count;
+
+    public static FanOutPage Wrap(Page page) => Unsafe.As<Page, FanOutPage>(ref page);
+    public static PageType DefaultType => PageType.FanOut256;
+    public bool IsClean => Data.IsClean;
+
+    private ref PageHeader Header => ref page.Header;
+
+    private ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
+
+    public Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
+    {
+        if (Header.BatchId != batch.BatchId)
+        {
+            // the page is from another batch, meaning, it's readonly. Copy
+            var writable = batch.GetWritableCopy(page);
+            return new FanOutPage(writable).DeleteByPrefix(prefix, batch);
+        }
+
+        Map.DeleteByPrefix(prefix);
+
+        if (ShouldBeInSideCar(prefix) && Data.SideCar.IsNull == false)
+        {
+            new BottomPage(batch.EnsureWritableCopy(ref Data.SideCar)).DeleteByPrefix(prefix, batch);
+        }
+
+        ref var buckets = ref Data.Buckets;
+
+        if (prefix.Length >= ConsumedNibbles)
+        {
+            var index = GetIndex(prefix);
+            var childAddr = buckets[index];
+
+            if (childAddr.IsNull == false)
+            {
+                var sliced = prefix.SliceFrom(ConsumedNibbles);
+                var child = batch.GetAt(childAddr);
+                child = child.Header.PageType == PageType.DataPage ?
+                    new DataPage(child).DeleteByPrefix(sliced, batch) :
+                    new BottomPage(child).DeleteByPrefix(sliced, batch);
+                buckets[index] = batch.GetAddress(child);
+            }
+        }
+
+        return page;
+    }
+
+    public Page Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        if (Header.BatchId != batch.BatchId)
+        {
+            // The page is from another batch, meaning, it's readonly. Copy on write.
+            var writable = batch.GetWritableCopy(page);
+            return new FanOutPage(writable).Set(key, data, batch);
+        }
+
+        if (ShouldBeInSideCar(key))
+        {
+            if (data.IsEmpty && Data.SideCar.IsNull)
+            {
+                // No side-car, nothing to remove
+                return page;
+            }
+
+            // Ensure side-car exists
+            var sideCar = Data.SideCar.IsNull
+                ? batch.GetNewPage<BottomPage>(out Data.SideCar, page.Header.Level)
+                : new BottomPage(batch.EnsureWritableCopy(ref Data.SideCar));
+
+            sideCar.Set(key, data, batch);
+            return page;
+        }
+
+        Debug.Assert(ShouldBeInSideCar(key) == false);
+
+        if (TryWriteInAlreadyWrittenChild(key, data, batch))
+            return page;
+
+        // Try to write in the map
+        if (Map.TrySet(key, data))
+        {
+            return page;
+        }
+
+        FlushDown(batch);
+
+        if (TryWriteInAlreadyWrittenChild(key, data, batch))
+            return page;
+
+        // Write back in the map
+        if (Map.TrySet(key, data) == false)
+        {
+            ThrowNoSpace();
+        }
+
+        return page;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowNoSpace() => throw new Exception("Should have place in map");
+
+    private bool TryWriteInAlreadyWrittenChild(in NibblePath key, ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        var childAddr = Data.Buckets[GetIndex(key)];
+        if (childAddr.IsNull || !batch.WasWritten(childAddr))
+            return false;
+
+        // Delete the key in this page just to ensure that the write-through will write the last value.
+        Map.Delete(key);
+
+        var sliced = key.SliceFrom(ConsumedNibbles);
+        var child = batch.GetAt(childAddr);
+
+        SetInChild(child, sliced, data, batch);
+
+        return true;
+    }
+
+    private static void SetInChild(Page child, in NibblePath key, ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        Debug.Assert(batch.WasWritten(batch.GetAddress(child)));
+
+        if (child.Header.PageType == PageType.Bottom)
+        {
+            new BottomPage(child).Set(key, data, batch);
+        }
+        else
+        {
+            new DataPage(child).Set(key, data, batch);
+        }
+    }
+
+    private static bool ShouldBeInSideCar(in NibblePath k) => k.Length <= MerkleSideCarMaxKeyLength;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte GetIndex(in NibblePath k) => (byte)(k.Nibble0 << NibblePath.NibbleShift | k.GetAt(1));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static (byte nibble0, byte nibble1) ParseIndex(int index) => ((byte)(index >> NibblePath.NibbleShift),
+        (byte)(index & NibblePath.NibbleMask));
+
+    public void Clear() => Data.Clear();
+
+    private void FlushDown(IBatchContext batch)
+    {
+        var map = Map;
+
+        foreach (var item in map.EnumerateAll())
+        {
+            var index = GetIndex(item.Key);
+
+            var childAddr = Data.Buckets[index];
+            Page child = default;
+
+            if (childAddr.IsNull)
+            {
+                child = batch.GetNewPage<BottomPage>(out childAddr, (byte)(page.Header.Level + ConsumedNibbles)).AsPage();
+                Data.Buckets[index] = childAddr;
+            }
+            else if (batch.WasWritten(childAddr) == false)
+            {
+                child = batch.EnsureWritableCopy(ref childAddr);
+                Data.Buckets[index] = childAddr;
+            }
+            else
+            {
+                child = batch.GetAt(childAddr);
+            }
+
+            Debug.Assert(batch.WasWritten(childAddr));
+            map.Delete(item);
+            SetInChild(child, item.Key.SliceFrom(ConsumedNibbles), item.RawData, batch);
+        }
+    }
+
+    /// <summary>
+    /// Represents the data of this data page. This type of payload stores data in 16 nibble-addressable buckets.
+    /// These buckets are used to store up to <see cref="DataSize"/> entries before flushing them down as other pages
+    /// like page split.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    public struct Payload
+    {
+        private const int Size = Page.PageSize - PageHeader.Size;
+        private const int BucketSize = DbAddressList.Of256.Size;
+
+        /// <summary>
+        /// The size of the raw byte data held in this page. Must be long aligned.
+        /// </summary>
+        private const int DataSize = Size - BucketSize - DbAddress.Size;
+
+        private const int DataOffset = Size - DataSize;
+
+        [FieldOffset(0)] public DbAddressList.Of256 Buckets;
+
+        [FieldOffset(DbAddressList.Of256.Size)] public DbAddress SideCar;
+
+        /// <summary>
+        /// The first item of map of frames to allow ref to it.
+        /// </summary>
+        [FieldOffset(DataOffset)] private byte DataStart;
+
+        /// <summary>
+        /// Writable area.
+        /// </summary>
+        public Span<byte> DataSpan => MemoryMarshal.CreateSpan(ref DataStart, DataSize);
+
+        public bool IsClean => new SlottedArray(DataSpan).IsEmpty && Buckets.IsClean && SideCar.IsNull;
+
+        public void Clear()
+        {
+            new SlottedArray(DataSpan).Clear();
+            Buckets.Clear();
+            SideCar = default;
+        }
+    }
+
+    public bool TryGet(IPageResolver batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
+    {
+        if (ShouldBeInSideCar(key))
+        {
+            if (Data.SideCar.IsNull)
+            {
+                result = default;
+                return false;
+            }
+
+            return new BottomPage(batch.GetAt(Data.SideCar)).TryGet(batch, key, out result);
+        }
+
+        if (Map.TryGet(key, out result))
+        {
+            return result.IsEmpty == false;
+        }
+
+        // non-null page jump, follow it!
+        var childAddr = Data.Buckets[GetIndex(key)];
+        if (childAddr.IsNull)
+        {
+            return false;
+        }
+
+        var sliced = key.SliceFrom(ConsumedNibbles);
+        var child = batch.GetAt(childAddr);
+
+        return child.Header.PageType == PageType.Bottom
+            ? new BottomPage(child).TryGet(batch, sliced, out result)
+            : new DataPage(child).TryGet(batch, sliced, out result);
+    }
+
+    private SlottedArray Map => new(Data.DataSpan);
+
+    public void Accept(ref NibblePath.Builder builder, IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
+    {
+        resolver.Prefetch(Data.Buckets);
+
+        using (visitor.On(ref builder, this, addr))
+        {
+            for (var i = 0; i < BucketCount; i++)
+            {
+                var bucket = Data.Buckets[i];
+                if (bucket.IsNull)
+                {
+                    continue;
+                }
+
+                var child = resolver.GetAt(bucket);
+                var type = child.Header.PageType;
+
+                var (nibble0, nibble1) = ParseIndex(i);
+
+                builder.Push(nibble0, nibble1);
+                {
+                    if (type == PageType.DataPage)
+                    {
+                        new DataPage(child).Accept(ref builder, visitor, resolver, bucket);
+                    }
+                    else if (type == PageType.Bottom)
+                    {
+                        new BottomPage(child).Accept(ref builder, visitor, resolver, bucket);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Invalid page type {type}");
+                    }
+                }
+                builder.Pop(2);
+            }
+
+            if (Data.SideCar.IsNull == false)
+            {
+                new BottomPage(resolver.GetAt(Data.SideCar)).Accept(ref builder, visitor, resolver, Data.SideCar);
+            }
+        }
+    }
+}

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -110,8 +110,6 @@ public interface IReadOnlyBatchContext : IPageResolver
     /// Gets the current <see cref="IBatch"/> id.
     /// </summary>
     uint BatchId { get; }
-
-    IDictionary<Keccak, uint> IdCache { get; }
 }
 
 /// <summary>

--- a/src/Paprika/Store/PageType.cs
+++ b/src/Paprika/Store/PageType.cs
@@ -28,4 +28,9 @@ public enum PageType : byte
     /// <see cref="StorageFanOut"/>
     /// </summary>
     FanOutPage = 5,
+
+    /// <summary>
+    /// The fan out page of 256.
+    /// </summary>
+    FanOut256 = 6,
 }

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -230,7 +230,6 @@ public readonly unsafe struct RootPage(Page root) : IPage
         var updated = new StateRootPage(data).Set(path, rawData, batch);
         root = batch.GetAddress(updated);
     }
-
 }
 
 [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -108,30 +108,9 @@ public readonly unsafe struct RootPage(Page root) : IPage
             return new StateRootPage(batch.GetAt(Data.StateRoot)).TryGet(batch, key.Path, out result);
         }
 
-        var id = BuildIdIndex(key.Path);
-
-        return Data.Storage.TryGetStorage(id, key.Path.UnsafeAsKeccak, key.StoragePath, out result, batch);
+        return Data.Storage.TryGetStorage(key.Path.UnsafeAsKeccak, key.StoragePath, out result, batch);
     }
 
-    private const int IdConsumedNibbles = 5;
-    public const int SlicedAccountByteLength = Keccak.Size - IdConsumedNibbles;
-
-    private const int MaxId = 1 << (IdConsumedNibbles * NibblePath.NibbleShift);
-
-    private static uint BuildIdIndex(in NibblePath path)
-    {
-        Debug.Assert(path.Length == NibblePath.KeccakNibbleCount);
-        Debug.Assert(path.IsOdd == false);
-
-        ref var span = ref path.UnsafeSpan;
-
-        var i = (span << (3 * NibblePath.NibbleShift)) |
-                 (Unsafe.Add(ref span, 1) << NibblePath.NibbleShift) |
-                 (Unsafe.Add(ref span, 2) >> NibblePath.NibbleShift);
-        Debug.Assert(i < MaxId);
-
-        return (uint)i;
-    }
 
     public void SetRaw(in Key key, IBatchContext batch, ReadOnlySpan<byte> rawData)
     {
@@ -141,9 +120,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         }
         else
         {
-            var id = BuildIdIndex(key.Path);
-
-            Data.Storage.SetStorage(id, key.Path.UnsafeAsKeccak, key.StoragePath, rawData, batch);
+            Data.Storage.SetStorage(key.Path.UnsafeAsKeccak, key.StoragePath, rawData, batch);
         }
     }
 
@@ -166,8 +143,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         }
         else
         {
-            var id = BuildIdIndex(prefix.Path);
-            Data.Storage.DeleteStorageByPrefix(id, prefix.Path.UnsafeAsKeccak, prefix.StoragePath, batch);
+            Data.Storage.DeleteStorageByPrefix(prefix.Path.UnsafeAsKeccak, prefix.StoragePath, batch);
         }
     }
 

--- a/src/Paprika/Store/StatisticsVisitor.cs
+++ b/src/Paprika/Store/StatisticsVisitor.cs
@@ -83,10 +83,6 @@ public class StatisticsVisitor : IPageVisitor
         {
             StorageFanOutLevels[2] += 1;
         }
-        else if (t == typeof(StorageFanOut.Level3Page))
-        {
-            StorageFanOutLevels[3] += 1;
-        }
         else
         {
             var length = prefix.Current.Length;
@@ -156,9 +152,6 @@ public class StatisticsVisitor : IPageVisitor
 
         switch (name)
         {
-            case StorageFanOut.ScopeIds:
-                _current = Ids;
-                return new ModeScope(this, previous);
             case StorageFanOut.ScopeStorage:
                 _current = Storage;
                 return new ModeScope(this, previous);

--- a/src/Paprika/Store/StatisticsVisitor.cs
+++ b/src/Paprika/Store/StatisticsVisitor.cs
@@ -106,6 +106,8 @@ public class StatisticsVisitor : IPageVisitor
                     return new BottomLevelUp(_current);
                 case PageType.StateRoot:
                     break;
+                case PageType.FanOut256:
+                    break;
                 default:
                     throw new Exception($"Not handled type {p.Header.PageType}");
             }


### PR DESCRIPTION
This PR builds on top of #472 by adding a side-car page to keep Merkle related data. This allows keeping the Merkle off the main `DataPage` map, leaving it as a whole for the write-through caching purposes. The side-car itself uses the new scaling design of the `BottomPage`. 

This PR does not change neither the database size nor the number of pages used per commit when running `Importer`. 

The depth and the shape of the tree is yet to be searched for using `Cli stats`. In the current, non-prefetched (see: #396) way of scanning it takes much too long.