### PR TITLE
Storage L3 gone

### DIFF
--- a/src/Paprika.Tests/Chain/RawStateTests.cs
+++ b/src/Paprika.Tests/Chain/RawStateTests.cs
@@ -134,7 +134,7 @@ public class RawStateTests
         var account2 = new Keccak(new byte[]
             { 18, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, });
 
-        using var db = PagedDb.NativeMemoryDb(64 * 1024, 2);
+        using var db = PagedDb.NativeMemoryDb(128 * 1024, 2);
         var merkle = new ComputeMerkleBehavior();
 
         await using var blockchain = new Blockchain(db, merkle);
@@ -153,7 +153,8 @@ public class RawStateTests
         //check account 1 is still present and account 2 is deleted
         using var read = db.BeginReadOnlyBatch();
         read.TryGet(Key.Account(account1), out _).Should().BeTrue();
-        read.TryGet(Key.Account(account2), out _).Should().BeFalse();
+
+        read.AssertNoAccount(account2);
 
         //let's re-add 2nd account and delete using empty prefix
         using var raw2 = blockchain.StartRaw();
@@ -275,7 +276,7 @@ public class RawStateTests
     [Test]
     public void ProcessProofNodes()
     {
-        using var remoteDb = PagedDb.NativeMemoryDb(32 * 1024, 2);
+        using var remoteDb = PagedDb.NativeMemoryDb(128 * 1024, 2);
         var merkle = new ComputeMerkleBehavior();
 
         var remoteBlockchain = new Blockchain(remoteDb, merkle);
@@ -298,7 +299,7 @@ public class RawStateTests
         var hashAccount4 = raw.GetHash(NibblePath.Parse("02"), false);
         var hashBranch2 = raw.GetHash(NibblePath.Parse("0"), false);
 
-        using var localDb = PagedDb.NativeMemoryDb(32 * 1024, 2);
+        using var localDb = PagedDb.NativeMemoryDb(128 * 1024, 2);
         var localBlockchain = new Blockchain(localDb, merkle);
 
         using var syncRaw = localBlockchain.StartRaw();

--- a/src/Paprika.Tests/Data/BitVectorTests.cs
+++ b/src/Paprika.Tests/Data/BitVectorTests.cs
@@ -1,17 +1,17 @@
-﻿using FluentAssertions;
-using NUnit.Framework;
+﻿using System.Collections.Specialized;
+using FluentAssertions;
 using Paprika.Data;
 
 namespace Paprika.Tests.Data;
 
-public class BitVector1024Tests
+public class BitVectorTests
 {
     [Test]
     public void Set_reset()
     {
         var v = new BitVector.Of1024();
 
-        for (int i = 0; i < BitVector.Of1024.Count; i++)
+        for (var i = 0; i < BitVector.Of1024.Count; i++)
         {
             v[i].Should().BeFalse();
             v[i] = true;
@@ -51,5 +51,27 @@ public class BitVector1024Tests
         }
 
         v.HasEmptyBits.Should().Be(anyNotSet);
+    }
+
+    [TestCase(0)]
+    [TestCase(63)]
+    [TestCase(64)]
+    [TestCase(127)]
+    [TestCase(128)]
+    [TestCase(BitVector.Of256.Count - 2)]
+    [TestCase(BitVector.Of256.Count - 1)]
+    public void HighestSmallerOrEqualThan(int set)
+    {
+        var v = new BitVector.Of256
+        {
+            [set] = true
+        };
+
+        for (var i = 0; i < BitVector.Of256.Count; i++)
+        {
+            var expected = i < set ? BitVector.NotFound : set;
+
+            v.HighestSmallerOrEqualThan(i).Should().Be(expected);
+        }
     }
 }

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -84,10 +84,10 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(24, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(764, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(17610, 4000, 200, false,
+    [TestCase(21822, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(43981, 10_000, 50, false,
+    [TestCase(55534, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(103345, 20_000, 50, true,

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -90,7 +90,7 @@ public class AbandonedTests : BasePageTests
     [TestCase(51117, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
-    [TestCase(118364, 20_000, 50, true,
+    [TestCase(103345, 20_000, 50, true,
         TestName = "Storage - 20_000 accounts with a single storage slot",
         Category = Categories.LongRunning)]
     public async Task Reuse_in_limited_environment(int pageCount, int accounts, int repeats, bool isStorage)

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -174,7 +174,7 @@ public class AbandonedTests : BasePageTests
     public async Task Work_proper_bookkeeping_when_lots_of_reads()
     {
         const int repeats = 1_000;
-        const int multiplier = 2 + 1; // fanout page + data page + abandoned page per commit
+        const int multiplier = 3 + 1; // fanout page + data page + abandoned page per commit
         const int historyDepth = 2;
 
         var account = Keccak.EmptyTreeHash;

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -82,12 +82,12 @@ public class AbandonedTests : BasePageTests
 
     private const int HistoryDepth = 2;
 
-    [TestCase(20, 1, 10_000, false, TestName = "Accounts - 1")]
-    [TestCase(428, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(20067, 4000, 200, false,
+    [TestCase(24, 1, 10_000, false, TestName = "Accounts - 1")]
+    [TestCase(764, 100, 10_000, false, TestName = "Accounts - 100")]
+    [TestCase(17673, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(51117, 10_000, 50, false,
+    [TestCase(44337, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(103345, 20_000, 50, true,

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -84,10 +84,10 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(24, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(764, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(17672, 4000, 200, false,
+    [TestCase(17610, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(44334, 10_000, 50, false,
+    [TestCase(43981, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(103345, 20_000, 50, true,

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -84,10 +84,10 @@ public class AbandonedTests : BasePageTests
 
     [TestCase(24, 1, 10_000, false, TestName = "Accounts - 1")]
     [TestCase(764, 100, 10_000, false, TestName = "Accounts - 100")]
-    [TestCase(17673, 4000, 200, false,
+    [TestCase(17672, 4000, 200, false,
         TestName = "Accounts - 4000 to get a bit reuse",
         Category = Categories.LongRunning)]
-    [TestCase(44337, 10_000, 50, false,
+    [TestCase(44334, 10_000, 50, false,
         TestName = "Accounts - 10000 to breach the AbandonedPage",
         Category = Categories.LongRunning)]
     [TestCase(103345, 20_000, 50, true,

--- a/src/Paprika.Tests/Store/AbandonedTests.cs
+++ b/src/Paprika.Tests/Store/AbandonedTests.cs
@@ -217,7 +217,7 @@ public class AbandonedTests : BasePageTests
 
         byte[] value = [13];
 
-        using var db = PagedDb.NativeMemoryDb(2048 * Page.PageSize);
+        using var db = PagedDb.NativeMemoryDb(4096 * Page.PageSize);
 
         for (var i = 0; i < repeats; i++)
         {

--- a/src/Paprika.Tests/Store/BasePageTests.cs
+++ b/src/Paprika.Tests/Store/BasePageTests.cs
@@ -16,6 +16,7 @@ public abstract class BasePageTests
 
     internal class TestBatchContext(uint batchId, Stack<DbAddress>? reusable = null) : BatchContextBase(batchId)
     {
+        private const uint StartAddress = 1U;
         private readonly Dictionary<DbAddress, Page> _address2Page = new();
         private readonly Dictionary<UIntPtr, DbAddress> _page2Address = new();
         private readonly Stack<DbAddress> _reusable = reusable ?? new Stack<DbAddress>();
@@ -23,7 +24,7 @@ public abstract class BasePageTests
 
         // data pages should start at non-null addresses
         // 0-N is take by metadata pages
-        private uint _pageCount = 1U;
+        private uint _pageCount = StartAddress;
 
         public override Page GetAt(DbAddress address) => _address2Page[address];
 
@@ -103,7 +104,7 @@ public abstract class BasePageTests
             return next;
         }
 
-        public uint PageCount => _pageCount;
+        public uint PageCount => _pageCount - StartAddress;
     }
 
     internal static TestBatchContext NewBatch(uint batchId) => new(batchId);

--- a/src/Paprika.Tests/Store/ClearableTests.cs
+++ b/src/Paprika.Tests/Store/ClearableTests.cs
@@ -26,9 +26,6 @@ public unsafe class ClearableTests : IDisposable
     public void StorageFanOut_Level2Page() => TestPage<StorageFanOut.Level2Page>();
 
     [Test]
-    public void StorageFanOut_Level3Page() => TestPage<StorageFanOut.Level3Page>();
-
-    [Test]
     public void DbAddressList_Of4() => TestDbAddressList<DbAddressList.Of4>();
 
     [Test]

--- a/src/Paprika.Tests/Store/DataPageTests.cs
+++ b/src/Paprika.Tests/Store/DataPageTests.cs
@@ -53,6 +53,6 @@ public class DataPageTests : BasePageTests
                 .BeTrue($"Failed to read value of {j}");
         }
 
-        batch.PageCount.Should().BeLessThan(100);
+        batch.PageCount.Should().BeLessThan(500);
     }
 }

--- a/src/Paprika.Tests/TestExtensions.cs
+++ b/src/Paprika.Tests/TestExtensions.cs
@@ -50,7 +50,10 @@ public static class TestExtensions
 
     public static void AssertNoAccount(this IReadOnlyBatch read, in Keccak key)
     {
-        read.TryGet(Key.Account(key), out _).Should().BeFalse();
+        if (read.TryGet(Key.Account(key), out var account))
+        {
+            account.IsEmpty.Should().BeTrue();
+        }
     }
 
     public static Account GetAccount(this IReadOnlyBatch read, in Keccak key)

--- a/src/Paprika/Data/BitVector.cs
+++ b/src/Paprika/Data/BitVector.cs
@@ -1,6 +1,11 @@
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using Paprika.Store;
+using static System.Runtime.CompilerServices.Unsafe;
 
 namespace Paprika.Data;
 
@@ -13,6 +18,9 @@ public static class BitVector
 
     private const int BitsPerByte = 8;
     private const int Shift = 6;
+    private const int Mask = (1 << Shift) - 1;
+
+    public const int NotFound = -1;
 
     [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
     public struct Of1024 : IBitVector
@@ -33,6 +41,72 @@ public static class BitVector
         public bool HasEmptyBits => HasEmptyBits(this);
 
         static ushort IBitVector.Count => Count;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
+    public struct Of256 : IBitVector
+    {
+        public const int Size = Count / BitsPerByte;
+        public const ushort Count = 256;
+
+        private byte _start;
+
+        public bool this[int bit]
+        {
+            readonly get => Get(in _start, bit);
+            set => Set(ref _start, bit, value);
+        }
+
+        public ushort FirstNotSet => FirstNotSet(this);
+
+        public bool HasEmptyBits => HasEmptyBits(this);
+
+        public bool HasAnySet => Vector256.EqualsAll(Vector256.LoadUnsafe(in _start), Vector256<byte>.Zero) == false;
+        public bool HasAllSet => Vector256.EqualsAll(Vector256.LoadUnsafe(in _start), Vector256<byte>.AllBitsSet);
+
+        static ushort IBitVector.Count => Count;
+
+        [Pure]
+        public int HighestSmallerOrEqualThan(int maxAt)
+        {
+            Debug.Assert(maxAt < Count);
+
+            var allowedLane = maxAt >> Shift;
+            var allowedBit = maxAt & Mask;
+
+            // Loop from the lane that contains maxAt down to lane 0.
+            for (var lane = allowedLane; lane >= 0; lane--)
+            {
+                const int chunk = sizeof(ulong);
+                var bits = ReadUnaligned<ulong>(ref Add(ref _start, chunk * lane));
+
+                // For the lane where maxAt lies, mask out bits above allowedBit.
+                if (lane == allowedLane)
+                {
+                    var mask = allowedBit < 63 ? ((1UL << (allowedBit + 1)) - 1UL) : ~0UL;
+                    bits &= mask;
+                }
+
+                // If any bit is set in this lane, compute the highest set bit.
+                if (bits != 0)
+                {
+                    var highestInLane = 63 - BitOperations.LeadingZeroCount(bits);
+                    return lane * BitsPerByte * chunk + highestInLane;
+                }
+            }
+
+            return NotFound;
+        }
+
+        public Of256 AndNot(in Of256 value)
+        {
+            var a = Vector256.LoadUnsafe(in _start);
+            var b = Vector256.LoadUnsafe(in value._start);
+
+            Of256 result = default;
+            Vector256.AndNot(a, b).StoreUnsafe(ref result._start);
+            return result;
+        }
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = sizeof(byte), Size = Size)]
@@ -72,9 +146,9 @@ public static class BitVector
         for (var i = 0; i < count; i++)
         {
             var skip = i * chunk;
-            ref var b = ref Unsafe.As<TBitVector, byte>(ref Unsafe.AsRef(in vector));
+            ref var b = ref As<TBitVector, byte>(ref AsRef(in vector));
 
-            var v = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, skip));
+            var v = ReadUnaligned<ulong>(ref Add(ref b, skip));
             if (BitOperations.PopCount(v) != chunk * BitsPerByte)
             {
                 return (ushort)(skip * BitsPerByte + BitOperations.TrailingZeroCount(~v));
@@ -84,12 +158,32 @@ public static class BitVector
         return TBitVector.Count;
     }
 
+    public static bool HasAnySet<TBitVector>(in TBitVector vector)
+        where TBitVector : struct, IBitVector
+    {
+        var size = TBitVector.Count / BitsPerByte;
+        const int chunk = sizeof(ulong);
+        var count = size / chunk;
+
+        for (var i = 0; i < count; i++)
+        {
+            var skip = i * chunk;
+            ref var b = ref As<TBitVector, byte>(ref AsRef(in vector));
+
+            var v = ReadUnaligned<ulong>(ref Add(ref b, skip));
+            if (v != 0)
+                return true;
+        }
+
+        return false;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool Get(in byte b, int bit)
     {
         var at = (uint)bit >> Shift;
-        var selector = 1L << bit;
-        ref var @byte = ref Unsafe.Add(ref Unsafe.As<byte, long>(ref Unsafe.AsRef(in b)), at);
+        var selector = 1L << (bit & Mask);
+        ref var @byte = ref Add(ref As<byte, long>(ref AsRef(in b)), at);
         return (@byte & selector) != 0;
     }
 
@@ -97,8 +191,8 @@ public static class BitVector
     private static void Set(ref byte b, int bit, bool value)
     {
         var at = (uint)bit >> Shift;
-        var selector = 1L << bit;
-        ref var @byte = ref Unsafe.Add(ref Unsafe.As<byte, long>(ref b), at);
+        var selector = 1L << (bit & Mask);
+        ref var @byte = ref Add(ref As<byte, long>(ref b), at);
 
         if (value)
         {

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -205,7 +205,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
         // Allocate the new child
         Debug.Assert(Data.Buckets[index].IsNull);
-        batch.GetNewPage<BottomPage>(out var addr, (byte)(Header.Level + 1));
+        batch.GetNewPage<ChildBottomPage>(out var addr, (byte)(Header.Level + 1));
         Data.Buckets[index] = addr;
 
         // Never flush down from the main map first to the child. It could be the case that it will have not enough space to handle data from the child on the left.
@@ -217,7 +217,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
         // Migrate from the previously matching
         var prevAddr = Data.Buckets[previouslyMatching];
-        var prevChild = new BottomPage(batch.EnsureWritableCopy(ref prevAddr));
+        var prevChild = new ChildBottomPage(batch.EnsureWritableCopy(ref prevAddr));
         Data.Buckets[previouslyMatching] = prevAddr;
 
         // Pass the previous child as the source and construct the map to only point to the new child mask. Assert that everything what is needed is copied properly.

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -1,4 +1,5 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -228,7 +228,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         var (_, written) = GatherChildrenInfo(batch);
         MoveToChildPages(map, batch, written, false);
 
-        AssertChildrenRangeInvariant(batch);
+        //AssertChildrenRangeInvariant(batch);
 
         return true;
     }
@@ -241,7 +241,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
             var childAddress = Data.Buckets[i];
             if (childAddress.IsNull == false)
             {
-                var child = new BottomPage(batch.GetAt(childAddress));
+                var child = new ChildBottomPage(batch.GetAt(childAddress));
                 foreach (var item in child.Map.EnumerateAll())
                 {
                     Debug.Assert(item.Key.IsEmpty == false);
@@ -462,7 +462,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
             if (i != ChildNotFound)
             {
                 var addr = Data.Buckets[i];
-                var child = new BottomPage(batch.EnsureWritableCopy(ref addr));
+                var child = new ChildBottomPage(batch.EnsureWritableCopy(ref addr));
                 Data.Buckets[i] = addr;
 
                 child.Map.DeleteByPrefix(prefix);
@@ -486,7 +486,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         var i = FindMatchingChild(key);
 
 
-        return i != ChildNotFound && new BottomPage(batch.GetAt(Data.Buckets[i])).Map.TryGet(key, out result);
+        return i != ChildNotFound && new ChildBottomPage(batch.GetAt(Data.Buckets[i])).Map.TryGet(key, out result);
     }
 
     private const int ChildNotFound = -1;
@@ -530,7 +530,7 @@ public readonly unsafe struct ChildBottomPage(Page page) : IPage<ChildBottomPage
 
     public static ChildBottomPage Wrap(Page page) => Unsafe.As<Page, ChildBottomPage>(ref page);
 
-    public static PageType DefaultType => PageType.Bottom;
+    public static PageType DefaultType => PageType.ChildBottom;
 
     public bool IsClean => Data.IsClean;
 

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Diagnostics;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using Paprika.Data;
 using static Paprika.Data.NibbleSelector;
@@ -25,7 +23,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     {
         using var scope = visitor.On(ref builder, this, addr);
 
-        for (var i = 0; i < ChildCount; i++)
+        for (var i = 0; i < DataPage.BucketCount; i++)
         {
             var child = Data.Buckets[i];
             if (child.IsNull == false)
@@ -53,13 +51,11 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
             return page;
         }
 
-        // Failed to add to map. Count existing children
-        var (existing, writtenThisBatch) = GatherChildrenInfo(batch);
-        if (existing == 0)
-        {
-            // No children yet. Create the first, flush there and set.
-            Debug.Assert(Data.Buckets[0].IsNull);
+        // Failed to add to map. Need to move data to child pages
 
+        if (Data.Buckets[0].IsNull)
+        {
+            // The case where the first child was not allocated yet.
             var child = batch.GetNewPage<BottomPage>(out var childAddr, (byte)(Header.Level + 1));
             Data.Buckets[0] = childAddr;
 
@@ -67,16 +63,15 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
             map.MoveNonEmptyKeysTo<All>(child.Map, true);
 
             // All non-empty keys moved down. The map should is ready to accept the set.
-            if (map.TrySet(key, data) == false)
-            {
-                UnableToSet();
-            }
+            map.Set(key, data);
 
             return page;
         }
 
+        var (existing, writtenThisBatch) = GatherChildrenInfo(batch);
+
         // If there are any children that were written this batch, try to write to them first.
-        if (writtenThisBatch != 0)
+        if (writtenThisBatch.HasAnySet)
         {
             // Flush down to the children written in this batch does not require COW as they were already copied during this batch.
             if (MoveToChildPages(map, batch, existing, false))
@@ -89,8 +84,8 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         }
 
         // If there are any children that exist, but weren't written this batch.
-        var childrenNotWrittenThisBatch = (ushort)(existing & ~writtenThisBatch);
-        if (childrenNotWrittenThisBatch != 0)
+        var childrenNotWrittenThisBatch = existing.AndNot(writtenThisBatch);
+        if (childrenNotWrittenThisBatch.HasAnySet)
         {
             // There are children that were not COWed during this batch. Try to move using COW now.
             if (MoveToChildPages(map, batch, existing, true))
@@ -103,8 +98,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         }
 
         // Ensure that all the children are created first before turning into the data page
-        const ushort allChildrenExist = 0b1111_1111_1111_1111;
-        while (existing != allChildrenExist)
+        while (existing.HasAllSet == false)
         {
             if (!AllocateNewChild(batch, map))
             {
@@ -174,22 +168,18 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         child.Map.Delete(key);
     }
 
-    private (ushort existing, ushort writtenThisBatch) GatherChildrenInfo(IBatchContext batch)
+    private (BitVector.Of256 existing, BitVector.Of256 writtenThisBatch) GatherChildrenInfo(IBatchContext batch)
     {
-        ushort existing = 0;
-        ushort writtenThisBatch = 0;
+        BitVector.Of256 existing = default;
+        BitVector.Of256 writtenThisBatch = default;
 
-        for (var i = 0; i < ChildCount; i++)
+        for (var i = 0; i < DataPage.BucketCount; i++)
         {
             var addr = Data.Buckets[i];
             if (addr.IsNull == false)
             {
-                var mask = (ushort)(1 << i);
-                existing |= mask;
-                if (batch.WasWritten(addr))
-                {
-                    writtenThisBatch |= mask;
-                }
+                existing[i] = true;
+                writtenThisBatch[i] = batch.WasWritten(addr);
             }
         }
 
@@ -199,8 +189,8 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     private bool AllocateNewChild(IBatchContext batch, in SlottedArray map)
     {
         // Gather size stats and find the biggest one that can help.
-        Span<ushort> sizes = stackalloc ushort[16];
-        map.GatherSizeStats1Nibble(sizes);
+        Span<ushort> sizes = stackalloc ushort[256];
+        map.GatherNonEmptySizeStats(sizes, static key => DataPage.GetBucket(key));
 
         var index = FindBestNotAllocatedChild(sizes, batch);
         if (index == ChildNotFound)
@@ -219,7 +209,10 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
         // Never flush down from the main map first to the child. It could be the case that it will have not enough space to handle data from the child on the left.
         // First, create the mask and migrate the data from the previously matching
-        var childMask = (ushort)(1 << index);
+        var childMask = new BitVector.Of256
+        {
+            [index] = true
+        };
 
         // Migrate from the previously matching
         var prevAddr = Data.Buckets[previouslyMatching];
@@ -242,7 +235,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     [Conditional("DEBUG")]
     private void AssertChildrenRangeInvariant(IBatchContext batch)
     {
-        for (var i = 0; i < ChildCount; i++)
+        for (var i = 0; i < DataPage.BucketCount; i++)
         {
             var childAddress = Data.Buckets[i];
             if (childAddress.IsNull == false)
@@ -251,7 +244,6 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
                 foreach (var item in child.Map.EnumerateAll())
                 {
                     Debug.Assert(item.Key.IsEmpty == false);
-                    Debug.Assert(item.Key.Nibble0 >= i);
                 }
             }
         }
@@ -269,9 +261,9 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         // Single loop: track free ranges based solely on their start and cumulative weight.
         int i;
 
-        for (i = 0; i < ChildCount; i++)
+        for (i = 0; i < DataPage.BucketCount; i++)
         {
-            if ((allocatedMask & (1 << i)) == 0)
+            if (allocatedMask[i] == false)
             {
                 if (curStart == -1)
                     curStart = i;
@@ -304,7 +296,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         var cumulative = 0;
         i = bestStart;
 
-        while (i < ChildCount && (allocatedMask & (1 << i)) == 0)
+        while (i < DataPage.BucketCount && allocatedMask[i] == false)
         {
             cumulative += sizes[i];
             if (cumulative >= halfTotal)
@@ -315,7 +307,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         return i - 1; // Return the last free nibble in the range.
     }
 
-    private bool MoveToChildPages(in SlottedArray source, IBatchContext batch, ushort childIndexes, bool cow,
+    private bool MoveToChildPages(in SlottedArray source, IBatchContext batch, BitVector.Of256 childIndexes, bool cow,
         bool assertAllCopied = false)
     {
         var moved = false;
@@ -327,8 +319,6 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
                 continue;
 
             var at = GetExistingChildIndexWhereKeyBelongsTo(k, childIndexes);
-
-            Debug.Assert(at <= k.Nibble0);
 
             if (at < 0)
             {
@@ -360,8 +350,6 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
             var childMap = new BottomPage(child).Map;
 
-            Debug.Assert(k.Nibble0 >= at);
-
             if (item.RawData.IsEmpty)
             {
                 // It's a deletion, delete in original and in the child
@@ -384,34 +372,41 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         return moved;
     }
 
-    private static int GetExistingChildIndexWhereKeyBelongsTo(in NibblePath key, ushort children)
+    private static int GetExistingChildIndexWhereKeyBelongsTo(in NibblePath key, in BitVector.Of256 children)
     {
-        var start = key.Nibble0;
-
-        // for 0, makes it 0b00000001
-        // for 1, makes it 0b00000011
-        // It's a mask where it can write to easily intersect.
-        var ableToWriteTo = (uint)((1 << (start + 1)) - 1);
-
-        var ushortLeadingZeroCount = BitOperations.LeadingZeroCount(children & ableToWriteTo) - 16;
-        return 15 - ushortLeadingZeroCount;
+        return children.HighestSmallerOrEqualThan(DataPage.GetBucket(key));
     }
 
     private DataPage TurnToDataPage(IBatchContext batch)
     {
+        // We need to turn this page into a full data page.
+        // To make it work we need to ensure that invariant of the data page is preserved.
+        // The invariant is that keys that are ShouldBeKeptLocal, should be kept in the data page locally
+        // To ensure that this invariant is preserved, we copy the whole map of the main BottomPage and insert it later.
+        // Additionally, when moving children, we do select these that should be kept locally as well.
+
+        // Copy the main
+        var required = Data.DataSpan.Length;
+        var mainArray = ArrayPool<byte>.Shared.Rent(required);
+        var mainBuffer = mainArray.AsSpan(0, required);
+        Data.DataSpan.CopyTo(mainBuffer);
+        var mainCopy = new SlottedArray(mainBuffer);
+        var dp = new DataPage(page);
+
+        // then clear the main
+        new SlottedArray(Data.DataSpan).Clear();
+
         // The bottom page has the same layout as the DataPage. It can be directly turned into one.
         Header.PageType = DataPage.DefaultType;
         Header.Metadata = 0; // clear metadata
 
         // The child pages though are different because they don't have their prefix truncated.
         // Each of them needs to be turned into a bottom page with children truncated by one nibble.
-
-        var required = Data.DataSpan.Length;
         var array = ArrayPool<byte>.Shared.Rent(required);
         var buffer = array.AsSpan(0, required);
         var copy = new SlottedArray(buffer);
 
-        for (var i = 0; i < ChildCount; i++)
+        for (var i = 0; i < DataPage.BucketCount; i++)
         {
             if (Data.Buckets[i].IsNull)
                 continue;
@@ -424,13 +419,17 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
             foreach (var item in child.Map.EnumerateAll())
             {
-                Debug.Assert(item.Key.IsEmpty == false);
-                var nibble0 = item.Key.Nibble0;
+                if (DataPage.ShouldBeKeptLocal(item.Key))
+                {
+                    // The key should be kept locally, use the DataPage method to do it.
+                    dp.Set(item.Key, item.RawData, batch);
+                    continue;
+                }
 
-                Debug.Assert(nibble0 >= i);
+                var sliced = item.Key.SliceFrom(DataPage.ConsumedNibbles);
+                var bucket = DataPage.GetBucket(item.Key);
 
-                var sliced = item.Key.SliceFrom(1);
-                if (nibble0 == i)
+                if (bucket == i)
                 {
                     // A match on nibble, this is the value we should be writing to
                     copy.TrySet(sliced, item.RawData);
@@ -439,11 +438,11 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
                 {
                     // The case, where the nibble is from a child that was not created.
                     // Let's ensure it's created and move to the other child.
-                    var otherAddr = Data.Buckets[nibble0];
+                    var otherAddr = Data.Buckets[bucket];
                     var otherChild = otherAddr.IsNull
-                        ? batch.GetNewPage<BottomPage>(out otherAddr, (byte)(Header.Level + 1))
+                        ? batch.GetNewPage<BottomPage>(out otherAddr, (byte)(Header.Level + DataPage.ConsumedNibbles))
                         : new BottomPage(batch.EnsureWritableCopy(ref otherAddr));
-                    Data.Buckets[nibble0] = otherAddr;
+                    Data.Buckets[bucket] = otherAddr;
 
                     // There will always be a place for it.
                     // If the nibble is up front, don't set the sliced data there as it will be reevaluated later.
@@ -457,7 +456,14 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
         ArrayPool<byte>.Shared.Return(array);
 
-        return new DataPage(page);
+        // Time to move the values from the copy of the main
+        foreach (var item in mainCopy.EnumerateAll())
+        {
+            dp.Set(item.Key, item.RawData, batch);
+        }
+
+        ArrayPool<byte>.Shared.Return(mainArray);
+        return dp;
     }
 
     public Page DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
@@ -473,7 +479,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
         if (prefix.Length == 0)
         {
-            for (var i = 0; i < ChildCount; i++)
+            for (var i = 0; i < DataPage.BucketCount; i++)
             {
                 if (Data.Buckets[i].IsNull == false)
                 {
@@ -499,11 +505,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         return page;
     }
 
-    public void Clear()
-    {
-        Map.Clear();
-        Data.Buckets.Clear();
-    }
+    public void Clear() => Data.Clear();
 
     [SkipLocalsInit]
     public bool TryGet(IPageResolver batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
@@ -521,13 +523,12 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     }
 
     private const int ChildNotFound = -1;
-    private const int ChildCount = DbAddressList.Of16.Count;
 
-    private int FindMatchingChild(in NibblePath key) => FindMatchingChild(key.Nibble0);
+    private int FindMatchingChild(in NibblePath key) => FindMatchingChild(DataPage.GetBucket(key));
 
-    private int FindMatchingChild(byte nibble)
+    private int FindMatchingChild(int index)
     {
-        int i = nibble;
+        var i = index;
         while (i >= 0 && Data.Buckets[i].IsNull)
         {
             i--;
@@ -540,5 +541,5 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
     public static PageType DefaultType => PageType.Bottom;
 
-    public bool IsClean => Map.IsEmpty && Data.Buckets.IsClean;
+    public bool IsClean => Data.IsClean;
 }

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -377,7 +377,6 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         var mainBuffer = mainArray.AsSpan(0, required);
         Data.DataSpan.CopyTo(mainBuffer);
         var mainCopy = new SlottedArray(mainBuffer);
-        var dp = new DataPage(page);
 
         // Then clear the main
         new SlottedArray(Data.DataSpan).Clear();
@@ -386,7 +385,8 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         var children = Data.Buckets;
 
         // Clear the original. It will be the DataPage that is responsible for setting things up.
-        Data.Buckets.Clear();
+        var dp = new DataPage(page);
+        dp.Clear();
 
         foreach (var child in children)
         {

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -23,7 +23,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     {
         using var scope = visitor.On(ref builder, this, addr);
 
-        for (var i = 0; i < DataPage.BucketCount; i++)
+        for (var i = 0; i < BucketCount; i++)
         {
             var child = Data.Buckets[i];
             if (child.IsNull == false)
@@ -170,7 +170,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         BitVector.Of256 existing = default;
         BitVector.Of256 writtenThisBatch = default;
 
-        for (var i = 0; i < DataPage.BucketCount; i++)
+        for (var i = 0; i < BucketCount; i++)
         {
             var addr = Data.Buckets[i];
             if (addr.IsNull == false)
@@ -241,7 +241,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         // Single loop: track free ranges based solely on their start and cumulative weight.
         int i;
 
-        for (i = 0; i < DataPage.BucketCount; i++)
+        for (i = 0; i < BucketCount; i++)
         {
             if (allocatedMask[i] == false)
             {
@@ -276,7 +276,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
         var cumulative = 0;
         i = bestStart;
 
-        while (i < DataPage.BucketCount && allocatedMask[i] == false)
+        while (i < BucketCount && allocatedMask[i] == false)
         {
             cumulative += sizes[i];
             if (cumulative >= halfTotal)

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -498,7 +498,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     public struct Payload
     {
         public const int Size = Page.PageSize - PageHeader.Size;
-        private const int BucketSize = DbAddressList.Of256.Size;
+        private const int BucketSize = DbAddressList.Of16.Size;
 
         /// <summary>
         /// The size of the raw byte data held in this page. Must be long aligned.
@@ -507,7 +507,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
 
         private const int DataOffset = Size - DataSize;
 
-        [FieldOffset(0)] public DbAddressList.Of256 Buckets;
+        [FieldOffset(0)] public DbAddressList.Of16 Buckets;
 
         /// <summary>
         /// The first item of map of frames to allow ref to it.

--- a/src/Paprika/Store/BottomPage.cs
+++ b/src/Paprika/Store/BottomPage.cs
@@ -356,7 +356,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     {
         return children.HighestSmallerOrEqualThan(GetBucket(key));
     }
-    
+
     private static int GetBucket(in NibblePath key) => key.Nibble0;
 
     private DataPage TurnToDataPage(IBatchContext batch)
@@ -492,7 +492,7 @@ public readonly unsafe struct BottomPage(Page page) : IPage<BottomPage>
     public bool IsClean => Data.IsClean;
 
     public const int BucketCount = DbAddressList.Of16.Count;
-    
+
     /// <summary>
     /// Represents the data of this data page. This type of payload stores data in 16 nibble-addressable buckets.
     /// These buckets are used to store up to <see cref="DataSize"/> entries before flushing them down as other pages

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -425,5 +425,5 @@ public readonly unsafe struct DataPage(Page page) : IPage<DataPage>
         }
     }
 
-    public static int GetBucket(in NibblePath key) => key.Nibble0;
+    private static int GetBucket(in NibblePath key) => key.Nibble0;
 }

--- a/src/Paprika/Store/DataPage.cs
+++ b/src/Paprika/Store/DataPage.cs
@@ -146,7 +146,10 @@ public readonly unsafe struct DataPage(Page page) : IPage<DataPage>
         return false;
     }
 
-    private const int MerkleInMapToNibble = 2;
+    /// <summary>
+    /// The highest single nibble path that will be stored in local map. 
+    /// </summary>
+    private const int MerkleInMapToNibble = 3;
     private const int MerkleInRightFromInclusive = 9;
 
     private static void SetLocally(in NibblePath key, ReadOnlySpan<byte> data, IBatchContext batch, ref Payload payload,
@@ -255,7 +258,7 @@ public readonly unsafe struct DataPage(Page page) : IPage<DataPage>
     private static bool ShouldBeKeptLocal(in NibblePath key) => key.IsEmpty || key.Length == 1;
 
     /// <summary>
-    /// Whether the key belong always in the local map.
+    /// Whether the key belong always in the local <see cref="SlottedArray"/> over <see cref="Payload.BucketSize"/>.
     /// </summary>
     private static bool ShouldBeKeptLocalInMap(in NibblePath key) => key.IsEmpty || key.Nibble0 < MerkleInMapToNibble;
 

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -49,6 +49,17 @@ public interface IBatchContext : IReadOnlyBatchContext
         return result;
     }
 
+    TPage EnsureWritableOrGetNew<TPage>(ref DbAddress addr, byte level = 0)
+        where TPage : struct, IPage<TPage>, IClearable
+    {
+        if (addr.IsNull)
+            return GetNewPage<TPage>(out addr, level);
+        
+        var copy = EnsureWritableCopy(ref addr);
+        Debug.Assert(TPage.DefaultType == copy.Header.PageType);
+        return TPage.Wrap(copy);
+    }
+
     /// <summary>
     /// Gets a writable copy of the page.
     /// </summary>

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -54,7 +54,7 @@ public interface IBatchContext : IReadOnlyBatchContext
     {
         if (addr.IsNull)
             return GetNewPage<TPage>(out addr, level);
-        
+
         var copy = EnsureWritableCopy(ref addr);
         Debug.Assert(TPage.DefaultType == copy.Header.PageType);
         return TPage.Wrap(copy);

--- a/src/Paprika/Store/PageDataExtensions.cs
+++ b/src/Paprika/Store/PageDataExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Paprika.Data;
+
+namespace Paprika.Store;
+
+public static class PageDataExtensions
+{
+    public static bool TryGet(this Page page, IPageResolver batch, scoped in NibblePath key,
+        out ReadOnlySpan<byte> result)
+    {
+        return page.Header.PageType switch
+        {
+            PageType.DataPage => new DataPage(page).TryGet(batch, key, out result),
+            PageType.StateRoot => new StateRootPage(page).TryGet(batch, key, out result),
+            PageType.Bottom => new BottomPage(page).TryGet(batch, key, out result),
+            PageType.ChildBottom => new ChildBottomPage(page).TryGet(batch, key, out result),
+            _ => ThrowOnType(page.Header.PageType, out result)
+        };
+    }
+
+    public static void Set(this Page page, in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
+    {
+        Debug.Assert(batch.WasWritten(batch.GetAddress(page)));
+
+        switch (page.Header.PageType)
+        {
+            case PageType.DataPage:
+                new DataPage(page).Set(key, data, batch);
+                break;
+            case PageType.StateRoot:
+                new StateRootPage(page).Set(key, data, batch);
+                break;
+            case PageType.Bottom:
+                new BottomPage(page).Set(key, data, batch);
+                break;
+            case PageType.ChildBottom:
+                new ChildBottomPage(page).Set(key, data, batch);
+                break;
+            default:
+                ThrowOnType(page.Header.PageType, out _);
+                break;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ThrowOnType(PageType type, out ReadOnlySpan<byte> result) =>
+        throw new Exception($"Page type is not handled:{type}");
+}

--- a/src/Paprika/Store/PageDataExtensions.cs
+++ b/src/Paprika/Store/PageDataExtensions.cs
@@ -43,6 +43,30 @@ public static class PageDataExtensions
         }
     }
 
+    public static void DeleteByPrefix(this Page page, in NibblePath prefix, IBatchContext batch)
+    {
+        Debug.Assert(batch.WasWritten(batch.GetAddress(page)));
+
+        switch (page.Header.PageType)
+        {
+            case PageType.DataPage:
+                new DataPage(page).DeleteByPrefix(prefix, batch);
+                break;
+            case PageType.StateRoot:
+                new StateRootPage(page).DeleteByPrefix(prefix, batch);
+                break;
+            case PageType.Bottom:
+                new BottomPage(page).DeleteByPrefix(prefix, batch);
+                break;
+            case PageType.ChildBottom:
+                new ChildBottomPage(page).DeleteByPrefix(prefix, batch);
+                break;
+            default:
+                ThrowOnType(page.Header.PageType, out _);
+                break;
+        }
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool ThrowOnType(PageType type, out ReadOnlySpan<byte> result) =>
         throw new Exception($"Page type is not handled:{type}");

--- a/src/Paprika/Store/PageType.cs
+++ b/src/Paprika/Store/PageType.cs
@@ -25,7 +25,12 @@ public enum PageType : byte
     Bottom = 4,
 
     /// <summary>
+    /// <see cref="ChildBottomPage"/>
+    /// </summary>
+    ChildBottom = 5,
+
+    /// <summary>
     /// <see cref="StorageFanOut"/>
     /// </summary>
-    FanOutPage = 5,
+    FanOutPage = 6,
 }

--- a/src/Paprika/Store/StateRootPage.cs
+++ b/src/Paprika/Store/StateRootPage.cs
@@ -156,7 +156,7 @@ public readonly unsafe struct StateRootPage(Page page) : IPage
         public Span<byte> DataSpan => MemoryMarshal.CreateSpan(ref DataStart, DataSize);
     }
 
-    public bool TryGet(IReadOnlyBatchContext batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
+    public bool TryGet(IPageResolver batch, scoped in NibblePath key, out ReadOnlySpan<byte> result)
     {
         if (key.Length < ConsumedNibbles)
         {

--- a/src/Paprika/Store/StateRootPage.cs
+++ b/src/Paprika/Store/StateRootPage.cs
@@ -79,17 +79,17 @@ public readonly unsafe struct StateRootPage(Page page) : IPage
             if (prefix.Length == 1)
             {
                 var idx = prefix.Nibble0 << NibblePath.NibbleShift;
-                for (int i = 0; i < 16; i++)
+                for (var i = 0; i < 16; i++)
                 {
-                    ref var addrShort = ref DeleteAll(Data.Buckets, idx + i);
+                    DeleteAll(batch, Data.Buckets, idx + i);
                 }
             }
             else if (prefix.IsEmpty)
             {
                 //can all pages be freed here?
-                for (int i = 0; i < BucketCount; i++)
+                for (var i = 0; i < BucketCount; i++)
                 {
-                    ref var addrShort = ref DeleteAll(Data.Buckets, i);
+                    DeleteAll(batch, Data.Buckets, i);
                 }
             }
 
@@ -102,21 +102,22 @@ public readonly unsafe struct StateRootPage(Page page) : IPage
 
         if (!addr.IsNull)
         {
-            addr = batch.GetAddress(new DataPage(batch.GetAt(addr)).DeleteByPrefix(sliced, batch));
+            var child = batch.EnsureWritableCopy(ref addr);
+            child.DeleteByPrefix(sliced, batch);
         }
 
         return page;
 
-        ref DbAddress DeleteAll(Span<DbAddress> buckets, int addrIndex)
+        static void DeleteAll(IBatchContext batch, Span<DbAddress> buckets, int addrIndex)
         {
-            ref var addrShort = ref buckets[addrIndex];
+            var addr = buckets[addrIndex];
+            if (addr.IsNull)
+                return;
 
-            if (!addrShort.IsNull)
-            {
-                addrShort = batch.GetAddress(new DataPage(batch.GetAt(addrShort)).DeleteByPrefix(NibblePath.Empty, batch));
-            }
+            var child = batch.EnsureWritableCopy(ref addr);
+            buckets[addrIndex] = addr;
 
-            return ref addrShort;
+            child.DeleteByPrefix(NibblePath.Empty, batch);
         }
     }
 

--- a/src/Paprika/Store/StatisticsVisitor.cs
+++ b/src/Paprika/Store/StatisticsVisitor.cs
@@ -83,10 +83,6 @@ public class StatisticsVisitor : IPageVisitor
         {
             StorageFanOutLevels[2] += 1;
         }
-        else if (t == typeof(StorageFanOut.Level3Page))
-        {
-            StorageFanOutLevels[3] += 1;
-        }
         else
         {
             var length = prefix.Current.Length;

--- a/src/Paprika/Store/StatisticsVisitor.cs
+++ b/src/Paprika/Store/StatisticsVisitor.cs
@@ -100,6 +100,10 @@ public class StatisticsVisitor : IPageVisitor
                     _current.BottomPageCountPerNibblePathDepth[length + bottomLevel] += 1;
                     _current.ReportBottomPageMap(length, new BottomPage(p).Map);
                     return new BottomLevelUp(_current);
+                case PageType.ChildBottom:
+                    _current.BottomPageCountPerNibblePathDepth[length + 1] += 1;
+                    _current.ReportBottomPageMap(length, new ChildBottomPage(p).Map);
+                    break;
                 case PageType.StateRoot:
                     break;
                 default:

--- a/src/Paprika/Store/StatisticsVisitor.cs
+++ b/src/Paprika/Store/StatisticsVisitor.cs
@@ -35,7 +35,7 @@ public class StatisticsVisitor : IPageVisitor
         public readonly int[] DataPagePageCountPerNibblePathDepth = new int[Levels];
         public readonly int[] BottomPageCountPerNibblePathDepth = new int[Levels];
 
-        public int BottomLevel = 0;
+        public int CurrentLevel = 0;
 
         /// <summary>
         /// A histogram of used space in inner <see cref="DataPage"/>.
@@ -49,7 +49,6 @@ public class StatisticsVisitor : IPageVisitor
 
         public void ReportDataPageMap(int length, in SlottedArray map) =>
             ReportMap(DataPagePercentageUsed, length, map);
-
 
         public void ReportBottomPageMap(int length, in SlottedArray map) =>
             ReportMap(BottomPagePercentageUsed, length, map);
@@ -78,55 +77,55 @@ public class StatisticsVisitor : IPageVisitor
         if (t == typeof(StorageFanOut.Level1Page))
         {
             StorageFanOutLevels[1] += 1;
+            return NoopDisposable.Instance;
         }
-        else if (t == typeof(StorageFanOut.Level2Page))
+
+        if (t == typeof(StorageFanOut.Level2Page))
         {
             StorageFanOutLevels[2] += 1;
+            return NoopDisposable.Instance;
         }
-        else
+
+        var lvl = _current.CurrentLevel;
+
+        var p = page.AsPage();
+
+        switch (p.Header.PageType)
         {
-            var length = prefix.Current.Length;
-
-            var p = page.AsPage();
-
-            switch (p.Header.PageType)
-            {
-                case PageType.DataPage:
-                    _current.DataPagePageCountPerNibblePathDepth[length] += 1;
-                    _current.ReportDataPageMap(length, new DataPage(p).Map);
-                    break;
-                case PageType.Bottom:
-                    var bottomLevel = _current.BottomLevel;
-                    _current.BottomPageCountPerNibblePathDepth[length + bottomLevel] += 1;
-                    _current.ReportBottomPageMap(length, new BottomPage(p).Map);
-                    return new BottomLevelUp(_current);
-                case PageType.ChildBottom:
-                    _current.BottomPageCountPerNibblePathDepth[length + 1] += 1;
-                    _current.ReportBottomPageMap(length, new ChildBottomPage(p).Map);
-                    break;
-                case PageType.StateRoot:
-                    break;
-                default:
-                    throw new Exception($"Not handled type {p.Header.PageType}");
-            }
+            case PageType.DataPage:
+                _current.DataPagePageCountPerNibblePathDepth[lvl] += 1;
+                _current.ReportDataPageMap(lvl, new DataPage(p).Map);
+                break;
+            case PageType.Bottom:
+                _current.BottomPageCountPerNibblePathDepth[lvl] += 1;
+                _current.ReportBottomPageMap(lvl, new BottomPage(p).Map);
+                break;
+            case PageType.ChildBottom:
+                _current.BottomPageCountPerNibblePathDepth[lvl] += 1;
+                _current.ReportBottomPageMap(lvl, new ChildBottomPage(p).Map);
+                break;
+            case PageType.StateRoot:
+                break;
+            default:
+                throw new Exception($"Not handled type {p.Header.PageType}");
         }
 
-        return NoopDisposable.Instance;
+        return new LevelUp(_current);
     }
 
-    private sealed class BottomLevelUp : IDisposable
+    private sealed class LevelUp : IDisposable
     {
         private readonly Stats _stats;
 
-        public BottomLevelUp(Stats stats)
+        public LevelUp(Stats stats)
         {
             _stats = stats;
-            _stats.BottomLevel++;
+            _stats.CurrentLevel++;
         }
 
         public void Dispose()
         {
-            _stats.BottomLevel--;
+            _stats.CurrentLevel--;
         }
     }
 

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -235,7 +235,10 @@ public static class StorageFanOut
                     return false;
                 }
 
-                return DataPage.Wrap(batch.GetAt(addr)).TryGet(batch, key, out result);
+                var p = batch.GetAt(addr);
+                return p.Header.PageType == PageType.Bottom
+                    ? new BottomPage(p).TryGet(batch, key, out result)
+                    : new DataPage(p).TryGet(batch, key, out result);
             }
 
             Debug.Assert(type == Type.Storage);

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -373,9 +373,12 @@ public static class StorageFanOut
     {
         private const int LocalKeySize = NibblePath.KeccakNibbleCount + 2;
 
+        // Align path creation and the oddity of the level of the page.
+        private const int PathOddity = 1;
+
         private static NibblePath BuildLocalKey(in NibblePath key, byte bucket, scoped Span<byte> workingSet)
         {
-            return NibblePath.Single(bucket, 1).Append(key, workingSet);
+            return NibblePath.Single(bucket, PathOddity).Append(key, workingSet);
         }
 
         private static (byte bucket, int index) GetIndex(uint at)
@@ -437,8 +440,9 @@ public static class StorageFanOut
             var addr = Data.Addresses[index];
 
             var child = addr.IsNull
-                ? batch.GetNewCleanPage<BottomPage>(out addr).AsPage()
+                ? batch.GetNewCleanPage<BottomPage>(out addr, PathOddity).AsPage()
                 : batch.EnsureWritableCopy(ref addr);
+
             Data.Addresses[index] = addr;
 
             var localKey = BuildLocalKey(key, next, stackalloc byte[LocalKeySize]);

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Numerics;
@@ -23,7 +24,7 @@ namespace Paprika.Store;
 /// </summary>
 public static class StorageFanOut
 {
-    public const int LevelCount = 3;
+    public const int LevelCount = 2;
 
     public const string ScopeIds = "Ids";
     public const string ScopeStorage = "Storage";
@@ -368,9 +369,30 @@ public static class StorageFanOut
     }
 
     [method: DebuggerStepThrough]
-    public readonly unsafe struct Level2Page(Page page) : IPage<Level2Page>, IClearable
+    public readonly unsafe struct Level2Page(Page page) : IPage<Level2Page>
     {
+        private const int LocalKeySize = NibblePath.KeccakNibbleCount + 2;
+
+        private static NibblePath BuildLocalKey(in NibblePath key, byte bucket, scoped Span<byte> workingSet)
+        {
+            return NibblePath.Single(bucket, 1).Append(key, workingSet);
+        }
+
+        private static (byte bucket, int index) GetIndex(uint at)
+        {
+            Debug.Assert(at < FanOutCount * 16);
+
+            var bucket = (byte)(at & NibblePath.NibbleMask);
+            var index = (int)(at >> NibblePath.NibbleShift);
+
+            Debug.Assert(index < FanOutCount);
+            Debug.Assert(bucket <= NibblePath.NibbleMask);
+
+            return (bucket, index);
+        }
+
         private const int Level = 2;
+        private const int FanOutCount = DbAddressList.Of256.Count;
         public static Level2Page Wrap(Page page) => Unsafe.As<Page, Level2Page>(ref page);
         public static PageType DefaultType => PageType.FanOutPage;
 
@@ -385,7 +407,7 @@ public static class StorageFanOut
         public bool TryGet(IPageResolver batch, uint at, scoped in NibblePath key,
             out ReadOnlySpan<byte> result)
         {
-            var (next, index) = GetIndex(at, Level);
+            var (bucket, index) = GetIndex(at);
 
             var addr = Data.Addresses[index];
             if (addr.IsNull)
@@ -394,7 +416,12 @@ public static class StorageFanOut
                 return false;
             }
 
-            return Level3Page.Wrap(batch.GetAt(addr)).TryGet(batch, next, key, out result);
+            var localKey = BuildLocalKey(key, bucket, stackalloc byte[LocalKeySize]);
+            var child = batch.GetAt(addr);
+
+            return child.Header.PageType == PageType.Bottom
+                ? new BottomPage(child).TryGet(batch, localKey, out result)
+                : new DataPage(child).TryGet(batch, localKey, out result);
         }
 
         public Page Set(uint at, in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
@@ -406,15 +433,22 @@ public static class StorageFanOut
                 return new Level2Page(writable).Set(at, key, data, batch);
             }
 
-            var (next, index) = GetIndex(at, Level);
+            var (next, index) = GetIndex(at);
             var addr = Data.Addresses[index];
 
-            if (addr.IsNull)
-            {
-                batch.GetNewCleanPage<Level3Page>(out addr);
-            }
+            var child = addr.IsNull
+                ? batch.GetNewCleanPage<BottomPage>(out addr).AsPage()
+                : batch.EnsureWritableCopy(ref addr);
+            Data.Addresses[index] = addr;
 
-            Data.Addresses[index] = batch.GetAddress(Level3Page.Wrap(batch.GetAt(addr)).Set(next, key, data, batch));
+            var localKey = BuildLocalKey(key, next, stackalloc byte[LocalKeySize]);
+
+            Debug.Assert(batch.WasWritten(addr));
+
+            if (child.Header.PageType == PageType.Bottom)
+                new BottomPage(child).Set(localKey, data, batch);
+            else
+                new DataPage(child).Set(localKey, data, batch);
 
             return page;
         }
@@ -428,7 +462,7 @@ public static class StorageFanOut
                 return new Level2Page(writable).DeleteByPrefix(at, prefix, batch);
             }
 
-            var (next, index) = GetIndex(at, Level);
+            var (next, index) = GetIndex(at);
             var addr = Data.Addresses[index];
 
             if (addr.IsNull)
@@ -436,8 +470,19 @@ public static class StorageFanOut
                 return page;
             }
 
-            Data.Addresses[index] =
-                batch.GetAddress(Level3Page.Wrap(batch.GetAt(addr)).DeleteByPrefix(next, prefix, batch));
+            var child = addr.IsNull
+                ? batch.GetNewCleanPage<BottomPage>(out addr).AsPage()
+                : batch.EnsureWritableCopy(ref addr);
+            Data.Addresses[index] = addr;
+
+            var localKey = BuildLocalKey(prefix, next, stackalloc byte[LocalKeySize]);
+
+            Debug.Assert(batch.WasWritten(addr));
+
+            if (child.Header.PageType == PageType.Bottom)
+                new BottomPage(child).DeleteByPrefix(localKey, batch);
+            else
+                new DataPage(child).DeleteByPrefix(localKey, batch);
 
             return page;
         }
@@ -448,13 +493,17 @@ public static class StorageFanOut
 
             using var scope = visitor.On(ref builder, this, addr);
 
-            for (var i = 0; i < DbAddressList.Of1024.Length; i++)
+            for (var i = 0; i < FanOutCount; i++)
             {
                 var bucket = Data.Addresses[i];
 
                 if (!bucket.IsNull)
                 {
-                    Level3Page.Wrap(resolver.GetAt(bucket)).Accept(ref builder, visitor, resolver, bucket);
+                    var child = resolver.GetAt(bucket);
+                    if (child.Header.PageType == PageType.Bottom)
+                        new BottomPage(child).Accept(ref builder, visitor, resolver, bucket);
+                    else
+                        new DataPage(child).Accept(ref builder, visitor, resolver, bucket);
                 }
             }
         }
@@ -464,241 +513,7 @@ public static class StorageFanOut
         {
             private const int Size = Page.PageSize - PageHeader.Size;
 
-            [FieldOffset(0)] public DbAddressList.Of1024 Addresses;
-        }
-    }
-
-    [method: DebuggerStepThrough]
-    public readonly unsafe struct Level3Page(Page page) : IPage<Level3Page>, IClearable
-    {
-        public static Level3Page Wrap(Page page) => Unsafe.As<Page, Level3Page>(ref page);
-        public static PageType DefaultType => PageType.FanOutPage;
-
-        private ref PageHeader Header => ref page.Header;
-
-        private ref Payload Data => ref Unsafe.AsRef<Payload>(page.Payload);
-
-        public void Clear()
-        {
-            // ref var iteration to do not clear copies!
-            foreach (ref var bucket in Data.Buckets)
-            {
-                bucket.Clear();
-            }
-        }
-
-        public bool IsClean
-        {
-            get
-            {
-                foreach (ref readonly var bucket in Data.Buckets)
-                {
-                    if (bucket.IsClean == false)
-                        return false;
-                }
-
-                return true;
-            }
-        }
-
-        public bool TryGet(IPageResolver batch, uint at, in NibblePath key, out ReadOnlySpan<byte> result)
-        {
-            return Data.Buckets[(int)at].TryGet(batch, key, out result);
-        }
-
-        public Page Set(uint at, in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
-        {
-            if (Header.BatchId != batch.BatchId)
-            {
-                // the page is from another batch, meaning, it's readonly. Copy
-                var writable = batch.GetWritableCopy(page);
-                return new Level3Page(writable).Set(at, key, data, batch);
-            }
-
-            Data.Buckets[(int)at].Set(key, data, batch);
-
-            return page;
-        }
-
-        public Page DeleteByPrefix(uint at, in NibblePath prefix, IBatchContext batch)
-        {
-            if (Header.BatchId != batch.BatchId)
-            {
-                // the page is from another batch, meaning, it's readonly. Copy
-                var writable = batch.GetWritableCopy(page);
-                return new Level3Page(writable).DeleteByPrefix(at, prefix, batch);
-            }
-
-            Data.Buckets[(int)at].DeleteByPrefix(prefix, batch);
-
-            return page;
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = Size)]
-        private struct Payload
-        {
-            private const int Size = Page.PageSize - PageHeader.Size;
-
-            [FieldOffset(Bucket.Size * 0)] private Bucket Bucket0;
-
-            public Span<Bucket> Buckets => MemoryMarshal.CreateSpan(ref Bucket0, Size / Bucket.Size);
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = Size)]
-        private struct Bucket : IClearable
-        {
-            public const int Size = 1016;
-            private const int DataSize = Size - DbAddress.Size;
-
-            [FieldOffset(0)] public DbAddress Root;
-
-            [FieldOffset(DbAddress.Size)] private byte _first;
-
-            private SlottedArray Map => new(MemoryMarshal.CreateSpan(ref _first, DataSize));
-
-            public void Clear()
-            {
-                Root = default;
-                Map.Clear();
-            }
-
-            public bool IsClean => Root.IsNull && Map.IsEmpty;
-
-            public bool TryGet(IPageResolver batch, in NibblePath key, out ReadOnlySpan<byte> result)
-            {
-                if (Map.TryGet(key, out result))
-                {
-                    return true;
-                }
-
-                // If key is empty it should be in the bucket, if root is null, not progress as well
-                if (key.IsEmpty || Root.IsNull)
-                    return false;
-
-                var root = batch.GetAt(Root);
-
-                return root.Header.PageType == PageType.DataPage
-                    ? new DataPage(root).TryGet(batch, key, out result)
-                    : new BottomPage(root).TryGet(batch, key, out result);
-            }
-
-            public void Set(in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
-            {
-                Page root;
-
-                // Try writing through if the key is non-empty, the root exists and the Root was written in this batch
-                if (key.IsEmpty == false && Root.IsNull == false && batch.WasWritten(Root))
-                {
-                    // Root exists, and was written in this batch. Write through.
-                    Map.Delete(key);
-
-                    root = batch.GetAt(Root);
-                    root = root.Header.PageType == PageType.DataPage
-                        ? new DataPage(root).Set(key, data, batch)
-                        : new BottomPage(root).Set(key, data, batch);
-
-                    Debug.Assert(batch.GetAddress(root) == Root, "Should have been COWed before");
-                    return;
-                }
-
-                if (Map.TrySet(key, data))
-                    return;
-
-                if (Root.IsNull)
-                {
-                    batch.GetNewCleanPage<BottomPage>(out Root);
-                }
-
-                // Ensure COWed
-                root = batch.EnsureWritableCopy(ref Root);
-
-                foreach (var item in Map.EnumerateAll())
-                {
-                    if (item.Key.IsEmpty)
-                    {
-                        // Omit flushing down the empty key
-                        continue;
-                    }
-
-                    root = root.Header.PageType == PageType.DataPage
-                        ? new DataPage(root).Set(item.Key, item.RawData, batch)
-                        : new BottomPage(root).Set(item.Key, item.RawData, batch);
-
-                    Debug.Assert(batch.GetAddress(root) == Root, "Should have been COWed before");
-
-                    // Delete each item that is moved
-                    Map.Delete(item);
-                }
-
-                if (key.IsEmpty)
-                {
-                    if (Map.TrySet(key, data))
-                    {
-                        return;
-                    }
-
-                    throw new Exception("Should be able to set the value");
-                }
-
-                Debug.Assert(key.IsEmpty == false, "Key should not be empty here");
-
-                // Set below
-                if (root.Header.PageType == PageType.DataPage)
-                    new DataPage(root).Set(key, data, batch);
-                else
-                    new BottomPage(root).Set(key, data, batch);
-            }
-
-            public void DeleteByPrefix(in NibblePath prefix, IBatchContext batch)
-            {
-                Map.DeleteByPrefix(prefix);
-
-                if (Root.IsNull)
-                    return;
-
-                var root = batch.GetAt(Root);
-
-                root = root.Header.PageType == PageType.DataPage
-                    ? new DataPage(root).DeleteByPrefix(prefix, batch)
-                    : new BottomPage(root).DeleteByPrefix(prefix, batch);
-
-                Root = batch.GetAddress(root);
-            }
-
-            public void Accept(ref NibblePath.Builder builder, IPageVisitor visitor, IPageResolver resolver)
-            {
-                if (Root.IsNull)
-                    return;
-
-                var root = resolver.GetAt(Root);
-                if (root.Header.PageType == PageType.DataPage)
-                    new DataPage(root).Accept(ref builder, visitor, resolver, Root);
-                else
-                    new BottomPage(root).Accept(ref builder, visitor, resolver, Root);
-            }
-
-            public void Prefetch(IPageResolver resolver)
-            {
-                if (Root.IsNull)
-                    return;
-
-                resolver.Prefetch(Root);
-            }
-        }
-
-        public void Accept(ref NibblePath.Builder builder, IPageVisitor visitor, IPageResolver resolver, DbAddress addr)
-        {
-            using var scope = visitor.On(ref builder, this, addr);
-
-            foreach (ref var bucket in Data.Buckets)
-            {
-                bucket.Prefetch(resolver);
-            }
-
-            foreach (ref var bucket in Data.Buckets)
-            {
-                bucket.Accept(ref builder, visitor, resolver);
-            }
+            [FieldOffset(0)] public DbAddressList.Of256 Addresses;
         }
     }
 }

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -429,9 +429,7 @@ public static class StorageFanOut
             var localKey = BuildLocalKey(key, bucket, stackalloc byte[LocalKeySize]);
             var child = batch.GetAt(addr);
 
-            return child.Header.PageType == PageType.Bottom
-                ? new BottomPage(child).TryGet(batch, localKey, out result)
-                : new DataPage(child).TryGet(batch, localKey, out result);
+            return child.TryGet(batch, localKey, out result);
         }
 
         public Page Set(uint at, in NibblePath key, in ReadOnlySpan<byte> data, IBatchContext batch)
@@ -456,10 +454,7 @@ public static class StorageFanOut
 
             Debug.Assert(batch.WasWritten(addr));
 
-            if (child.Header.PageType == PageType.Bottom)
-                new BottomPage(child).Set(localKey, data, batch);
-            else
-                new DataPage(child).Set(localKey, data, batch);
+            child.Set(localKey, data, batch);
 
             return page;
         }

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -381,8 +381,17 @@ public static class StorageFanOut
     {
         private const int LocalKeySize = NibblePath.KeccakNibbleCount + 2;
 
-        // Align path creation and the oddity of the level of the page.
+        /// <summary>
+        /// The path oddity that is used for the local keys so that the concatenated with ease.
+        /// </summary>
+        /// <remarks>Not used as the level of the child page. This might be confusing at first,
+        /// but we want to have the DataPage starting at even number so that it can fan out with ease.</remarks>
         private const int PathOddity = 1;
+
+        /// <summary>
+        /// <see cref="PathOddity"/>
+        /// </summary>
+        private const int StartLevel = 0;
 
         private static NibblePath BuildLocalKey(in NibblePath key, byte bucket, scoped Span<byte> workingSet)
         {
@@ -445,7 +454,8 @@ public static class StorageFanOut
             var addr = Data.Addresses[index];
 
             var child = addr.IsNull
-                ? batch.GetNewCleanPage<BottomPage>(out addr, PathOddity).AsPage()
+
+                ? batch.GetNewCleanPage<BottomPage>(out addr, StartLevel).AsPage()
                 : batch.EnsureWritableCopy(ref addr);
 
             Data.Addresses[index] = addr;

--- a/src/Paprika/Store/StorageFanOut.cs
+++ b/src/Paprika/Store/StorageFanOut.cs
@@ -394,7 +394,6 @@ public static class StorageFanOut
             return (bucket, index);
         }
 
-        private const int Level = 2;
         private const int FanOutCount = DbAddressList.Of256.Count;
         public static Level2Page Wrap(Page page) => Unsafe.As<Page, Level2Page>(ref page);
         public static PageType DefaultType => PageType.FanOutPage;


### PR DESCRIPTION
This PR removes L3 level of the `StorageFanOut` and replaces it with a reduction of L2 to 256 buckets and leaving 16 nibbles to be added to the path. This introduced one path concatenation, but is expected to build a shallow fanout for storage, where:

- L0 with fan out of 1024, is kept in the root, no lookup
- L1 with fan out of 1024, is a separate page
- L2 provides a fan out 256 and points to a regular page (Data/Bottom)

The last step removes L3 and makes L2 more robust and more prone to keep the database small. Additionally, it may remove one in the tree depth.

`DataPage` from now can change themselves into higher fanout reducing the depth and the size even further.

### Benchmarks

`Mainnet` db size reduced from `237GB` to `227GB`, by 4%.

![image](https://github.com/user-attachments/assets/0311a2b0-0647-4224-84a5-31d7200a8330)

![image](https://github.com/user-attachments/assets/e2b1ab81-95ae-49c4-a72c-f2a10f7e1222)

