### PR TITLE
ContractId introduced

### DIFF
--- a/src/Paprika.Tests/Store/BasePageTests.cs
+++ b/src/Paprika.Tests/Store/BasePageTests.cs
@@ -65,7 +65,7 @@ public abstract class BasePageTests
                 .BeTrue($"Page at {addr} should not be registered as reusable before");
         }
 
-        public override Dictionary<Keccak, uint> IdCache { get; } = new();
+        public override Dictionary<Keccak, ContractId> IdCache { get; } = new();
 
         public override string ToString() => $"Batch context used {_pageCount} pages to write the data";
 

--- a/src/Paprika/Store/BatchContextBase.cs
+++ b/src/Paprika/Store/BatchContextBase.cs
@@ -43,7 +43,7 @@ abstract class BatchContextBase(uint batchId) : IBatchContext
 
     public virtual void NoticeAbandonedPageReused(Page page) { }
 
-    public abstract IDictionary<Keccak, uint> IdCache { get; }
+    public abstract IDictionary<Keccak, ContractId> IdCache { get; }
 
     /// <summary>
     /// Assigns the batch identifier to a given page, marking it writable by this batch.

--- a/src/Paprika/Store/ContractId.cs
+++ b/src/Paprika/Store/ContractId.cs
@@ -1,0 +1,17 @@
+﻿namespace Paprika.Store;
+
+/// <summary>
+/// Represents a contract id.
+/// </summary>
+/// <remarks>
+/// A contract id is an uint uniquely assigned to a contract. It's done by persisting a mapping between  
+/// between its address' Keccak and an auto-incremented uint.
+/// </remarks>
+/// <param name="Value">The underlying value.</param>
+public readonly record struct ContractId(uint Value)
+{
+    private const uint NullValue = 0;
+    public bool IsNull => Value == NullValue;
+
+    public static readonly ContractId Null = new(NullValue);
+}

--- a/src/Paprika/Store/IBatchContext.cs
+++ b/src/Paprika/Store/IBatchContext.cs
@@ -122,7 +122,7 @@ public interface IReadOnlyBatchContext : IPageResolver
     /// </summary>
     uint BatchId { get; }
 
-    IDictionary<Keccak, uint> IdCache { get; }
+    IDictionary<Keccak, ContractId> IdCache { get; }
 }
 
 /// <summary>

--- a/src/Paprika/Store/PagedDb.cs
+++ b/src/Paprika/Store/PagedDb.cs
@@ -471,9 +471,9 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
     private sealed class ReadOnlyBatch(PagedDb db, RootPage root, string name)
         : IVisitableReadOnlyBatch, IReadOnlyBatchContext
     {
-        [ThreadStatic] private static ConcurrentDictionary<Keccak, uint>? s_cache;
+        [ThreadStatic] private static ConcurrentDictionary<Keccak, ContractId>? s_cache;
 
-        private ConcurrentDictionary<Keccak, uint> _idCache = Interlocked.Exchange(ref s_cache, null) ?? new(
+        private ConcurrentDictionary<Keccak, ContractId> _idCache = Interlocked.Exchange(ref s_cache, null) ?? new(
             Environment.ProcessorCount,
             RootPage.IdCacheLimit);
 
@@ -522,7 +522,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 
         public uint BatchId => root.Header.BatchId;
 
-        public IDictionary<Keccak, uint> IdCache
+        public IDictionary<Keccak, ContractId> IdCache
         {
             get
             {
@@ -835,7 +835,7 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
 #endif
         }
 
-        public override Dictionary<Keccak, uint> IdCache { get; }
+        public override Dictionary<Keccak, ContractId> IdCache { get; }
 
         public void Dispose()
         {
@@ -865,11 +865,11 @@ public sealed class PagedDb : IPageResolver, IDb, IDisposable
             Page = new((byte*)NativeMemory.AlignedAlloc(Page.PageSize, (UIntPtr)UIntPtr.Size));
             Abandoned = new List<DbAddress>();
             Written = new HashSet<DbAddress>();
-            IdCache = new Dictionary<Keccak, uint>();
+            IdCache = new Dictionary<Keccak, ContractId>();
             ReusedImmediately = new Stack<DbAddress>();
         }
 
-        public Dictionary<Keccak, uint> IdCache { get; }
+        public Dictionary<Keccak, ContractId> IdCache { get; }
 
         public Page Page { get; }
 

--- a/src/Paprika/Store/RootPage.cs
+++ b/src/Paprika/Store/RootPage.cs
@@ -123,7 +123,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
 
         if (cache.TryGetValue(keccak, out var id))
         {
-            if (id == 0)
+            if (id.IsNull)
             {
                 result = default;
                 return false;
@@ -168,7 +168,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
                     Data.AccountCounter++;
 
                     // memoize in cache
-                    batch.IdCache[keccak] = id = Data.AccountCounter;
+                    batch.IdCache[keccak] = id = new ContractId(Data.AccountCounter);
 
                     // update root
                     Data.Storage.SetId(keccak, id, batch);
@@ -192,7 +192,7 @@ public readonly unsafe struct RootPage(Page root) : IPage
         var keccak = account.UnsafeAsKeccak;
 
         // Destroy the Id entry about it
-        Data.Storage.SetId(keccak, 0, batch);
+        Data.Storage.SetId(keccak, ContractId.Null, batch);
 
         // Destroy the account entry
         SetAtRoot(batch, account, ReadOnlySpan<byte>.Empty, ref Data.StateRoot);


### PR DESCRIPTION
This PR introduces a notion of `ContractId`. This is a simple high level wrap around an `uint` increasing readability of the codebase.