### PR TITLE
Different encoding for length and oddity

### DIFF
--- a/src/Paprika.Tests/Chain/RawStateTests.cs
+++ b/src/Paprika.Tests/Chain/RawStateTests.cs
@@ -321,7 +321,7 @@ public class RawStateTests
         for (int i = proofPath.Length; i >= 0; i--)
         {
             var currentPath = proofPath.SliceTo(i);
-            packed[i * 33] = currentPath.Length;
+            packed[i * 33] = (byte)currentPath.Length;
             currentPath.RawSpan.CopyTo(packed.Slice(i * 33 + 1));
         }
         syncRaw.ProcessProofNodes(Keccak.Zero, packed, 2);
@@ -407,9 +407,9 @@ public class RawStateTests
         localHash.Should().Be(remoteStorageHash);
 
         Span<byte> packed = stackalloc byte[2 * 33];
-        packed[0 * 33] = branchPath.Length;
+        packed[0 * 33] = (byte)branchPath.Length;
         branchPath.RawSpan.CopyTo(packed.Slice(0 * 33 + 1));
-        packed[1 * 33] = NibblePath.Empty.Length;
+        packed[1 * 33] = (byte)NibblePath.Empty.Length;
         NibblePath.Empty.RawSpan.CopyTo(packed.Slice(1 * 33 + 1));
 
         syncRaw.ProcessProofNodes(accountHash, packed, 1);

--- a/src/Paprika.Tests/Data/NibblePathTests.cs
+++ b/src/Paprika.Tests/Data/NibblePathTests.cs
@@ -304,7 +304,7 @@ public class NibblePathTests
 
         var appended = first.Append(second, stackalloc byte[NibblePath.FullKeccakByteLength]);
 
-        appended.Oddity.Should().Be(oddity);
+        appended.Odd.Should().Be(oddity);
         appended.SliceTo(1).Equals(first).Should().BeTrue();
         appended.SliceFrom(1).Equals(second).Should().BeTrue();
         appended.Length.Should().Be((byte)(1 + length));

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -1,4 +1,3 @@
-using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -100,15 +99,16 @@ public readonly ref struct NibblePath
     private const int OddBit = 1;
 
     private readonly ref byte _span;
-    private readonly byte _odd;
-    public readonly byte Length;
 
-    public bool IsOdd => _odd == OddBit;
-    public int Oddity => _odd;
+    private readonly int _lengthAndOdd;
+    
+    public bool IsOdd => Odd != 0;
+    public int Length => _lengthAndOdd >> LengthShift;
+    public int Odd => _lengthAndOdd & OddBit;
 
     public static NibblePath Empty => default;
 
-    public bool IsEmpty => Length == 0;
+    public bool IsEmpty => _lengthAndOdd == 0;
 
     public static NibblePath Parse(string hex)
     {
@@ -153,50 +153,6 @@ public readonly ref struct NibblePath
     public ref byte UnsafeSpan => ref _span;
 
     /// <summary>
-    /// Reuses the memory of this nibble path moving it to odd position.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnsafeMakeOdd()
-    {
-        Debug.Assert(_odd == 0, "Should not be applied to odd");
-
-        var i = (int)Length;
-        if (i == 1)
-        {
-            _span = (byte)(_span >> NibbleShift);
-            Unsafe.AsRef(in _odd) = OddBit;
-        }
-        else if (i <= 4)
-        {
-            var u = (uint)Unsafe.As<byte, ushort>(ref _span);
-            var s = BinaryPrimitives.ReverseEndianness(u) >> NibbleShift;
-            Unsafe.As<byte, ushort>(ref _span) = (ushort)BinaryPrimitives.ReverseEndianness(s);
-            if (i == 4)
-            {
-                var overflow = ((s & 0xf000) >> (NibbleShift * 2));
-                Unsafe.Add(ref _span, 2) = (byte)overflow;
-            }
-
-            Unsafe.AsRef(in _odd) = OddBit;
-        }
-        else
-        {
-            LargeUnsafeMakeOdd();
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void LargeUnsafeMakeOdd()
-    {
-        for (var i = (int)Length; i > 0; i--)
-        {
-            UnsafeSetAt(i, GetAt(i - 1));
-        }
-
-        Unsafe.AsRef(in _odd) = OddBit;
-    }
-
-    /// <summary>
     /// Creates the nibble path from preamble and raw slice
     /// </summary>
     public static NibblePath FromRaw(byte preamble, ReadOnlySpan<byte> slice)
@@ -229,17 +185,15 @@ public readonly ref struct NibblePath
     private NibblePath(ReadOnlySpan<byte> key, int nibbleFrom, int length)
     {
         _span = ref Unsafe.Add(ref MemoryMarshal.GetReference(key), nibbleFrom / 2);
-        _odd = (byte)(nibbleFrom & OddBit);
-        Length = (byte)length;
+        _lengthAndOdd = (length << LengthShift) | (nibbleFrom & OddBit);
     }
 
-    private NibblePath(ref byte span, byte odd, byte length)
+    private NibblePath(ref byte span, int odd, byte length)
     {
         _span = ref span;
-        _odd = odd;
-        Length = length;
+        _lengthAndOdd = (length << LengthShift) | odd;
     }
-
+    
     /// <summary>
     /// The estimate of the max length, used for stackalloc estimations.
     /// </summary>
@@ -271,15 +225,15 @@ public readonly ref struct NibblePath
         return destination.Slice(0, length);
     }
 
-    public byte RawPreamble => (byte)((_odd & OddBit) | (Length << LengthShift));
+    public byte RawPreamble => (byte)_lengthAndOdd;
 
     private int WriteImpl(Span<byte> destination)
     {
-        var odd = _odd & OddBit;
-        var length = (int)Length;
-        var spanLength = GetSpanLength(_odd, length);
+        var odd = Odd;
+        var length = Length;
+        var spanLength = GetSpanLength(odd, length);
 
-        destination[0] = (byte)(odd | (length << LengthShift));
+        destination[0] = (byte)_lengthAndOdd;
 
         ref var destStart = ref Unsafe.Add(ref MemoryMarshal.GetReference(destination), PreambleLength);
         if (spanLength == sizeof(byte))
@@ -322,8 +276,10 @@ public readonly ref struct NibblePath
         if (Length - start == 0)
             return Empty;
 
-        return new(ref Unsafe.Add(ref _span, (_odd + start) / 2),
-            (byte)((start & 1) ^ _odd), (byte)(Length - start));
+        var odd = _lengthAndOdd & OddBit;
+
+        return new(ref Unsafe.Add(ref _span, (odd + start) / 2),
+            (byte)((start & 1) ^ odd), (byte)(Length - start));
     }
 
     /// <summary>
@@ -332,7 +288,8 @@ public readonly ref struct NibblePath
     public NibblePath SliceTo(int length)
     {
         Debug.Assert(length <= Length, "Cannot slice the NibblePath beyond its Length");
-        return new NibblePath(ref _span, _odd, (byte)length);
+        
+        return new NibblePath(ref _span, Odd, (byte)length);
     }
 
     /// <summary>
@@ -341,15 +298,18 @@ public readonly ref struct NibblePath
     public NibblePath Slice(int start, int length)
     {
         Debug.Assert(start + length <= Length, "Cannot slice the NibblePath beyond its Length");
-        return new(ref Unsafe.Add(ref _span, (_odd + start) / 2),
-            (byte)((start & 1) ^ _odd), (byte)length);
+
+        var odd = Odd;
+        
+        return new(ref Unsafe.Add(ref _span, (odd + start) / 2),
+            (byte)((start & 1) ^ odd), (byte)length);
     }
 
     public byte this[int nibble] => GetAt(nibble);
 
     public byte GetAt(int nibble) => (byte)((GetRefAt(nibble) >> GetShift(nibble)) & NibbleMask);
 
-    private int GetShift(int nibble) => (1 - ((nibble + _odd) & OddBit)) * NibbleShift;
+    private int GetShift(int nibble) => (1 - ((nibble + Odd) & OddBit)) * NibbleShift;
 
     /// <summary>
     /// Sets a <paramref name="value"/> of the nibble at the given <paramref name="nibble"/> location.
@@ -365,7 +325,7 @@ public readonly ref struct NibblePath
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref byte GetRefAt(int nibble) => ref Unsafe.Add(ref _span, (nibble + _odd) / 2);
+    private ref byte GetRefAt(int nibble) => ref Unsafe.Add(ref _span, (nibble + Odd) / 2);
 
     /// <summary>
     /// Appends a <paramref name="nibble"/> to the end of the path,
@@ -385,7 +345,7 @@ public readonly ref struct NibblePath
         // TODO: do a ref comparison with Unsafe, if the same, no need to copy!
         WriteTo(workingSet);
 
-        var appended = new NibblePath(ref workingSet[PreambleLength], _odd, (byte)(Length + 1));
+        var appended = new NibblePath(ref workingSet[PreambleLength], Odd, (byte)(Length + 1));
         appended.UnsafeSetAt(Length, nibble);
         return appended;
     }
@@ -403,18 +363,21 @@ public readonly ref struct NibblePath
         // TODO: do a ref comparison with Unsafe, if the same, no need to copy!
         WriteTo(workingSet);
 
-        var length = (int)Length;
-        var appended = new NibblePath(ref workingSet[PreambleLength], _odd, (byte)(length + other.Length));
+        var length = Length;
+        var odd = Odd;
+        
+        var appended = new NibblePath(ref workingSet[PreambleLength], odd, (byte)(length + other.Length));
 
         // TODO: if aligned, can be based on bytes
         var i = 0;
 
-        if (other._odd == 0 && ((_odd + length) & OddBit) == other._odd)
+        var otherOdd = other.Odd;
+        if (otherOdd == 0 && ((odd + length) & OddBit) == otherOdd)
         {
             // Aligned, where the first ends, the second starts.
             for (; i < other.Length; i += 2)
             {
-                Unsafe.Add(ref appended._span, (_odd + length + i) / 2) = Unsafe.Add(ref other._span, i / 2);
+                Unsafe.Add(ref appended._span, (odd + length + i) / 2) = Unsafe.Add(ref other._span, i / 2);
             }
         }
 
@@ -426,64 +389,7 @@ public readonly ref struct NibblePath
         return appended;
     }
 
-    /// <summary>
-    /// Appends the <see cref="other1"/> and then <see cref="other2"/> path using the <paramref name="workingSet"/> as the working memory.
-    /// </summary>
-    [SkipLocalsInit]
-    public NibblePath Append(scoped in NibblePath other1, int hash, Span<byte> workingSet)
-    {
-        if (workingSet.Length <= MaxByteLength)
-        {
-            ThrowNotEnoughMemory();
-        }
-
-        WriteImpl(workingSet);
-
-        var length = (int)Length;
-        var appended = new NibblePath(ref workingSet[PreambleLength], _odd, (byte)(length + other1.Length + 2));
-
-        if (other1.IsEmpty == false)
-        {
-            var alignment = (_odd + Length) ^ other1._odd;
-            if ((alignment & OddBit) == 0)
-            {
-                // oddity aligned
-                if (_odd == OddBit)
-                {
-                    // it's odd, set odd first
-                    appended.UnsafeSetAt(length, other1[0]);
-                }
-
-                // unrolled version to copy byte by byte instead of nibbles
-                var i = 0;
-                for (; i < other1.Length - 1; i += 2)
-                {
-                    appended.GetRefAt(length + i + _odd) = other1.GetRefAt(i + _odd);
-                }
-
-                if (i < other1.Length)
-                {
-                    // it's odd, set odd first
-                    appended.UnsafeSetAt(length + other1.Length - 1, other1[other1.Length - 1]);
-                }
-            }
-            else
-            {
-                for (var i = 0; i < other1.Length; i++)
-                {
-                    appended.UnsafeSetAt(length + i, other1[i]);
-                }
-            }
-        }
-
-        var start = length + other1.Length;
-        appended.UnsafeSetAt(start + 0, (byte)((hash & 0xf0) >> NibbleShift));
-        appended.UnsafeSetAt(start + 1, (byte)(hash & 0xf));
-
-        return appended;
-    }
-
-    public byte Nibble0 => (byte)((_span >> ((1 - _odd) * NibbleShift)) & NibbleMask);
+    public byte Nibble0 => (byte)((_span >> ((1 - Odd) * NibbleShift)) & NibbleMask);
 
     private static int GetSpanLength(int odd, int length) => (length + 1 + odd) / 2;
 
@@ -492,7 +398,7 @@ public readonly ref struct NibblePath
     /// </summary>
     public ReadOnlySpan<byte> RawSpan => MemoryMarshal.CreateSpan(ref _span, RawSpanLength);
 
-    public int RawSpanLength => GetSpanLength(_odd, Length);
+    public int RawSpanLength => GetSpanLength(Odd, Length);
 
     public static ReadOnlySpan<byte> ReadFrom(ReadOnlySpan<byte> source, out NibblePath nibblePath)
     {
@@ -540,7 +446,9 @@ public readonly ref struct NibblePath
             return 0;
         }
 
-        if (_odd == other._odd)
+        var odd = Odd;
+        
+        if (odd == other.Odd)
         {
             // The most common case in Trie.
             // As paths will start on the same level, the odd will be encoded same way for them.
@@ -550,7 +458,7 @@ public readonly ref struct NibblePath
             ref var right = ref other._span;
 
             var position = 0;
-            var isOdd = (_odd & OddBit) != 0;
+            var isOdd = odd != 0;
             if (isOdd)
             {
                 // This means first byte is not a whole byte
@@ -623,19 +531,21 @@ public readonly ref struct NibblePath
     {
         destination[0] = (byte)(isLeaf ? LeafFlag : 0x000);
 
+        var odd = Odd;
+        
         // This is the usual fast path for leaves, as they are aligned with oddity and length.
         // length: odd, odd: 1
         // length: even, odd: 0
-        if ((Length & OddBit) == _odd)
+        if ((Length & OddBit) == odd)
         {
-            if (_odd == OddBit)
+            if (odd == OddBit)
             {
                 // store odd
                 destination[0] += (byte)(OddFlag + (_span & NibbleMask));
             }
 
             // copy the rest as is
-            MemoryMarshal.CreateSpan(ref Unsafe.Add(ref _span, _odd), Length / 2)
+            MemoryMarshal.CreateSpan(ref Unsafe.Add(ref _span, odd), Length / 2)
                 .CopyTo(destination.Slice(HexPreambleLength));
 
             return;
@@ -645,7 +555,7 @@ public readonly ref struct NibblePath
         ref var b = ref _span;
 
         // length: even, odd: 1
-        if (_odd == OddBit)
+        if (odd == OddBit)
         {
             // the length is even, no need to amend destination[0]
             for (var i = 0; i < Length / 2; i++)
@@ -686,7 +596,9 @@ public readonly ref struct NibblePath
         Span<char> path = stackalloc char[Length];
         ref var ch = ref path[0];
 
-        for (int i = _odd; i < Length + _odd; i++)
+        var odd = Odd;
+        
+        for (int i = odd; i < Length + odd; i++)
         {
             var b = Unsafe.Add(ref _span, i / 2);
             var nibble = (b >> ((1 - (i & OddBit)) * NibbleShift)) & NibbleMask;
@@ -710,7 +622,9 @@ public readonly ref struct NibblePath
         Span<char> path = stackalloc char[Length * 2];
         ref var ch = ref path[0];
 
-        for (int i = _odd; i < Length + _odd; i++)
+        var odd = Odd;
+        
+        for (int i = odd; i < Length + odd; i++)
         {
             var b = Unsafe.Add(ref _span, i / 2);
             var nibble = (b >> ((1 - (i & OddBit)) * NibbleShift)) & NibbleMask;
@@ -758,14 +672,14 @@ public readonly ref struct NibblePath
 
     public bool Equals(in NibblePath other)
     {
-        if (((other.Length ^ Length) | (other._odd ^ _odd)) > 0)
+        if (other._lengthAndOdd != _lengthAndOdd)
             return false;
 
         ref var left = ref _span;
         ref var right = ref other._span;
         var length = Length;
 
-        if (other._odd == OddBit)
+        if (other.Odd != 0)
         {
             // This means first byte is not a whole byte
             if (((left ^ right) & NibbleMask) > 0)
@@ -821,9 +735,9 @@ public readonly ref struct NibblePath
             ref var span = ref _span;
 
             uint hash = (uint)Length << 24;
-            nuint length = Length;
+            nuint length = (nuint)Length;
 
-            if (_odd == OddBit)
+            if (Odd != 0)
             {
                 // mix in first half
                 hash |= (uint)(_span & 0x0F) << 20;

--- a/src/Paprika/Data/NibblePath.cs
+++ b/src/Paprika/Data/NibblePath.cs
@@ -101,7 +101,7 @@ public readonly ref struct NibblePath
     private readonly ref byte _span;
 
     private readonly int _lengthAndOdd;
-    
+
     public bool IsOdd => Odd != 0;
     public int Length => _lengthAndOdd >> LengthShift;
     public int Odd => _lengthAndOdd & OddBit;
@@ -193,7 +193,7 @@ public readonly ref struct NibblePath
         _span = ref span;
         _lengthAndOdd = (length << LengthShift) | odd;
     }
-    
+
     /// <summary>
     /// The estimate of the max length, used for stackalloc estimations.
     /// </summary>
@@ -288,7 +288,7 @@ public readonly ref struct NibblePath
     public NibblePath SliceTo(int length)
     {
         Debug.Assert(length <= Length, "Cannot slice the NibblePath beyond its Length");
-        
+
         return new NibblePath(ref _span, Odd, (byte)length);
     }
 
@@ -300,7 +300,7 @@ public readonly ref struct NibblePath
         Debug.Assert(start + length <= Length, "Cannot slice the NibblePath beyond its Length");
 
         var odd = Odd;
-        
+
         return new(ref Unsafe.Add(ref _span, (odd + start) / 2),
             (byte)((start & 1) ^ odd), (byte)length);
     }
@@ -365,7 +365,7 @@ public readonly ref struct NibblePath
 
         var length = Length;
         var odd = Odd;
-        
+
         var appended = new NibblePath(ref workingSet[PreambleLength], odd, (byte)(length + other.Length));
 
         // TODO: if aligned, can be based on bytes
@@ -447,7 +447,7 @@ public readonly ref struct NibblePath
         }
 
         var odd = Odd;
-        
+
         if (odd == other.Odd)
         {
             // The most common case in Trie.
@@ -532,7 +532,7 @@ public readonly ref struct NibblePath
         destination[0] = (byte)(isLeaf ? LeafFlag : 0x000);
 
         var odd = Odd;
-        
+
         // This is the usual fast path for leaves, as they are aligned with oddity and length.
         // length: odd, odd: 1
         // length: even, odd: 0
@@ -597,7 +597,7 @@ public readonly ref struct NibblePath
         ref var ch = ref path[0];
 
         var odd = Odd;
-        
+
         for (int i = odd; i < Length + odd; i++)
         {
             var b = Unsafe.Add(ref _span, i / 2);
@@ -623,7 +623,7 @@ public readonly ref struct NibblePath
         ref var ch = ref path[0];
 
         var odd = Odd;
-        
+
         for (int i = odd; i < Length + odd; i++)
         {
             var b = Unsafe.Add(ref _span, i / 2);

--- a/src/Paprika/Data/SlottedArray.cs
+++ b/src/Paprika/Data/SlottedArray.cs
@@ -1528,13 +1528,13 @@ public readonly ref struct SlottedArray /*: IClearable */
 
             trimmed = NibblePath.Empty;
             var length = key.Length;
-            preamble = (byte)(key.Oddity | (KeyPreambleLength3OrLess << KeyPreambleLengthShift));
+            preamble = (byte)(key.Odd | (KeyPreambleLength3OrLess << KeyPreambleLengthShift));
 
             ref var b = ref key.UnsafeSpan;
 
             ushort hash = 0;
 
-            switch ((length << 1) + key.Oddity)
+            switch ((length << 1) + key.Odd)
             {
                 case 0:
                 case 1:
@@ -1593,8 +1593,8 @@ public readonly ref struct SlottedArray /*: IClearable */
 
                 // beyond 4
                 default:
-                    preamble = (byte)(KeyPreambleWithBytes | key.Oddity);
-                    trimmed = key.Slice(KeySlice + key.Oddity, length - KeyPreambleMaxEncodedLength);
+                    preamble = (byte)(KeyPreambleWithBytes | key.Odd);
+                    trimmed = key.Slice(KeySlice + key.Odd, length - KeyPreambleMaxEncodedLength);
 
                     Debug.Assert(trimmed.IsOdd == false, "Trimmed should be always even");
 

--- a/src/Paprika/Merkle/Node.cs
+++ b/src/Paprika/Merkle/Node.cs
@@ -202,7 +202,7 @@ public static partial class Node
         {
             Assert(path.Length >= MinimalLeafPathLength,
                 "Leaves that have empty path should not be persisted. They should be stored only in the branch");
-            Assert((path.Oddity + path.Length) % 2 == 0,
+            Assert((path.Odd + path.Length) % 2 == 0,
                 "If path is odd, length should be odd as well. If even, even");
 
             var metadata = path.IsOdd ? (byte)(OddPathMetadata | path.Nibble0) : 0;


### PR DESCRIPTION
As pointed out by @benaadams , length and oddity could benefit from not having them encoded as bytes. Byte addressing could result in CPU stalls so maybe by coalescing them into a single field, we could benefit from it.

After applying the changes, `Equals` got smaller, lost one branch and seems to be a bit faster.

### Benchmarks

#### Before

| Method                  | slice | length | fullKeccak | oddEnd | Mean     | Error     | StdDev    | Code Size |
|------------------------ |------ |------- |----------- |------- |---------:|----------:|----------:|----------:|
| Equals_not_equal_sliced | ?     | ?      | ?          | ?      | 2.550 ns | 0.0306 ns | 0.0286 ns |     434 B |
| Equals                  | 0     | 1      | ?          | ?      | 3.933 ns | 0.0520 ns | 0.0434 ns |     438 B |
| Equals                  | 0     | 16     | ?          | ?      | 3.932 ns | 0.0320 ns | 0.0299 ns |     438 B |
| Equals                  | 0     | 32     | ?          | ?      | 3.717 ns | 0.0421 ns | 0.0373 ns |     437 B |
| Equals                  | 0     | 48     | ?          | ?      | 3.944 ns | 0.0573 ns | 0.0536 ns |     438 B |
| Equals                  | 0     | 64     | ?          | ?      | 3.644 ns | 0.0553 ns | 0.0490 ns |     437 B |
| Equals                  | 1     | 1      | ?          | ?      | 3.648 ns | 0.0419 ns | 0.0392 ns |     437 B |
| Equals                  | 1     | 16     | ?          | ?      | 4.014 ns | 0.0757 ns | 0.0708 ns |     438 B |
| Equals                  | 1     | 32     | ?          | ?      | 3.677 ns | 0.0723 ns | 0.0676 ns |     437 B |
| Equals                  | 1     | 48     | ?          | ?      | 3.938 ns | 0.0396 ns | 0.0371 ns |     438 B |
| Hash                    | 0     | ?      | False      | ?      | 2.000 ns | 0.0122 ns | 0.0109 ns |   1,213 B |
| Hash                    | 1     | ?      | False      | ?      | 2.148 ns | 0.0153 ns | 0.0143 ns |   1,195 B |
| Hash                    | 2     | ?      | False      | ?      | 1.784 ns | 0.0300 ns | 0.0281 ns |   1,208 B |
| Append_byte_aligned     | ?     | ?      | ?          | False  | 5.614 ns | 0.0338 ns | 0.0300 ns |   1,352 B |
| Hash                    | 0     | ?      | True       | ?      | 3.603 ns | 0.0643 ns | 0.0601 ns |   1,185 B |
| Hash                    | 1     | ?      | True       | ?      | 3.012 ns | 0.0540 ns | 0.0505 ns |   1,176 B |
| Hash                    | 2     | ?      | True       | ?      | 3.603 ns | 0.0356 ns | 0.0278 ns |   1,185 B |
| Append_byte_aligned     | ?     | ?      | ?          | True   | 5.639 ns | 0.0364 ns | 0.0341 ns |   1,360 B |

#### After

| Method                  | slice | length | fullKeccak | oddEnd | Mean     | Error     | StdDev    | Code Size |
|------------------------ |------ |------- |----------- |------- |---------:|----------:|----------:|----------:|
| Equals_not_equal_sliced | ?     | ?      | ?          | ?      | 2.149 ns | 0.0457 ns | 0.0427 ns |     402 B |
| Equals                  | 0     | 1      | ?          | ?      | 3.875 ns | 0.0801 ns | 0.0750 ns |     406 B |
| Equals                  | 0     | 16     | ?          | ?      | 3.875 ns | 0.0780 ns | 0.0729 ns |     406 B |
| Equals                  | 0     | 32     | ?          | ?      | 3.952 ns | 0.0632 ns | 0.0591 ns |     407 B |
| Equals                  | 0     | 48     | ?          | ?      | 3.884 ns | 0.0819 ns | 0.0766 ns |     406 B |
| Equals                  | 0     | 64     | ?          | ?      | 3.860 ns | 0.0563 ns | 0.0527 ns |     407 B |
| Equals                  | 1     | 1      | ?          | ?      | 3.939 ns | 0.0450 ns | 0.0421 ns |     407 B |
| Equals                  | 1     | 16     | ?          | ?      | 3.910 ns | 0.0440 ns | 0.0411 ns |     407 B |
| Equals                  | 1     | 32     | ?          | ?      | 3.907 ns | 0.0460 ns | 0.0407 ns |     407 B |
| Equals                  | 1     | 48     | ?          | ?      | 3.775 ns | 0.0623 ns | 0.0553 ns |     406 B |
| Hash                    | 0     | ?      | False      | ?      | 2.069 ns | 0.0248 ns | 0.0220 ns |   1,233 B |
| Hash                    | 1     | ?      | False      | ?      | 2.191 ns | 0.0282 ns | 0.0313 ns |   1,215 B |
| Hash                    | 2     | ?      | False      | ?      | 1.777 ns | 0.0129 ns | 0.0107 ns |   1,228 B |
| Append_byte_aligned     | ?     | ?      | ?          | False  | 5.628 ns | 0.0462 ns | 0.0432 ns |   1,397 B |
| Hash                    | 0     | ?      | True       | ?      | 3.502 ns | 0.0543 ns | 0.0508 ns |   1,206 B |
| Hash                    | 1     | ?      | True       | ?      | 2.955 ns | 0.0245 ns | 0.0229 ns |   1,197 B |
| Hash                    | 2     | ?      | True       | ?      | 3.485 ns | 0.0774 ns | 0.0724 ns |   1,206 B |
| Append_byte_aligned     | ?     | ?      | ?          | True   | 5.722 ns | 0.0404 ns | 0.0378 ns |   1,397 B |